### PR TITLE
Use resident pool deeper into Merkle trees

### DIFF
--- a/autoresearch/submissions/2026-07-20-deeper-merkle-pool-parallelism/delta.json
+++ b/autoresearch/submissions/2026-07-20-deeper-merkle-pool-parallelism/delta.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "b343b866a9f4",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/prover/vcs_lifted/parameters.zig": "sha256:20f3e1dd6854030c71336f3c5ff51ed44c3eae6eed0bf7bc26483fbb117e486e"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "ef3943334dc463849e925bd9b811eb4b115146f324eac998f56eb7d7cc879c46",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-20-deeper-merkle-pool-parallelism/note.md
+++ b/autoresearch/submissions/2026-07-20-deeper-merkle-pool-parallelism/note.md
@@ -1,0 +1,23 @@
+# Use the resident pool deeper into Merkle trees
+
+## Model and harness
+
+Model: GPT-5 Codex. Harness: repo-resident `stwo-perf` updated at the start of the session, ReleaseFast on arm64 macOS, paired S3 small/time against current promoted `main`. The reasoning-first submitter transcript is attached as `transcripts/session-01.md`.
+
+## Hypothesis
+
+Current Merkle scheduling leaves most of the installed 16-worker prover pool idle below the largest tree layer: it requires 4,096 parent hashes per worker and stops parallel hashing below 8,192 parents. Full-proof sampling showed four-way BLAKE2s compression as the hottest executable frame while worker threads waited. Reducing task granularity should reuse the already-resident pool deeper into each tree, cutting repeated Merkle fixed cost without changing hash order or proof bytes.
+
+## Changes
+
+Lowered the lifted Merkle parallel threshold from 8,192 to 2,048 parent nodes and the minimum chunk from 4,096 to 1,024 parents per worker. No hashing, field arithmetic, transcript, or protocol logic changed; only the number of independent parent ranges scheduled onto the existing pool changed.
+
+## Results
+
+S3 `wf_log10x8` small/time: ratio 0.8710, 95% CI [0.8625, 0.8780], 15 paired rounds. The predecessor median was 2.723 ms and the candidate median was 2.379 ms. Every timed proof verified and remained byte-identical.
+
+Unpaired warmed diagnostics also preserved the existing proof hashes and measured 13.70 ms for the wide workload and 9.78 ms for the deep workload, indicating that the scheduling mechanism is not small-only. These are diagnostics, not claimed promotion scores.
+
+## Caveats
+
+This is a local claimed verdict; the locked judge rerun is authoritative. The anchor is not frozen, so drift budgets and judged promotion remain inactive. The threshold is tuned from profiling and full-proof evidence on the current 18-CPU arm64 host; other CPU topologies may select fewer workers through the existing capacity and CPU-count caps, but cross-host efficiency still belongs to judge and holdout validation.

--- a/autoresearch/submissions/2026-07-20-deeper-merkle-pool-parallelism/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-20-deeper-merkle-pool-parallelism/transcripts/session-01.md
@@ -1,0 +1,50 @@
+# Autoresearch session transcript
+
+- Captured by: submitter
+- Model: GPT-5 Codex
+- Date: 2026-07-20
+- Redaction policy: preserve reasoning and evidence; omit credentials, environment values, system instructions, broad local paths, and raw bulk tool output.
+
+## User request
+
+The user asked the agent to update the repository's autoresearch CLI first, learn from existing notes, transcripts, and researcher ideas, drive the largest CPU-prover optimization possible under the repository contract, and submit as soon as a significant solution is available.
+
+## Initial repository findings
+
+The repo-resident `stwo-perf update` reported current at commit `b343b866a9f4`. The task fixes a three-workload CPU proving suite and requires byte-identical proofs accepted by the pinned Rust oracle. Candidate edits are confined to `MANIFEST.json` editable paths, and submission requires an S3 paired verdict plus a reasoning-first sanitized transcript.
+
+The current frontier contains one claimed promotion. Its optimization packs direct quotient accumulation across four native M31 row lanes and reuses the resident Merkle work pool. The prior S1 quotient kernel improved by about 49%, but end-to-end wide proving improved by 2.64% (ratio 0.9736). This Amdahl gap suggests that further work should begin with current-main attribution rather than another speculative quotient rewrite.
+
+## Search strategy
+
+1. Preserve current `main` as the paired predecessor and work in this fresh candidate worktree.
+2. Inspect unmerged research branches and their histories for profiling evidence, rejected variants, and unfinished high-leverage ideas.
+3. Run the repository profiler on current `main` before source edits. Prefer a stage whose measured share can support an end-to-end improvement above the 1% significance floor.
+4. For constant-factor implementation changes, use counter and code-generation evidence. If the candidate becomes an algorithm replacement, stop and produce the repository's canonical problem-match brief before editing.
+5. Validate with focused correctness tests, ReleaseFast closure, and the exact S3 paired harness. Package and submit immediately once the confidence interval is wholly below 0.99 and all gates pass.
+
+## Alternatives already rejected
+
+- Repeating the predecessor's packed direct-column change: already merged and limited by end-to-end stage share.
+- Optimizing Metal: out of scope for the immediate `core_cpu` objective.
+- Editing harness or benchmark files to obtain better measurements: forbidden locked paths and invalid scientifically.
+
+## Current-main profiling and first experiment
+
+S2 profiles on the three scored workloads showed lazy FRI quotient construction plus commitment at about 6.85 ms / 41% of wide proving, 6.7 ms / 55% of deep proving, and roughly half of the small proof after warmup. The already-packed quotient provider measured 25.12 ns/row, 3,733 instructions/row, 1,003 cycles/row, and IPC 3.72 in `stwo-prof`, so repeating arithmetic SIMD work would attack only a minority of the remaining stage.
+
+A live stack sample of the full wide proof instead identified four-way BLAKE2s compression, Merkle leaf construction, and internal-layer hashing as the dominant executable frames inside FRI commit. A zero-diff worker sweep from 4 through 16 workers found that 16 was fastest (about 16.13 ms median versus 19.43 ms at 4), rejecting the hypothesis that whole-prover oversubscription was the cause.
+
+The more specific scheduling mismatch is that a 32K-leaf Merkle tree hashes its first 16K-parent layer with only four workers, the next layer with two, and every smaller layer serially. The resident pool has 16 workers and sampling showed idle worker waits while BLAKE2s remained hot. The first candidate therefore lowers Merkle parallel granularity from 4,096 to 1,024 parent nodes per worker and permits parallel execution from 2,048 parent nodes. Prediction: 15–30% less Merkle time and 3–6% less end-to-end wide/deep prove time. Falsifier: paired or direct proof medians are neutral/regressed after warmup, indicating spawn/wait overhead exceeds recovered parallelism.
+
+## First-experiment result and submission decision
+
+Warmed direct diagnostics preserved the existing proof hashes and measured 13.70 ms for wide, 9.78 ms for deep, and 2.37 ms for small. These were intentionally treated as mechanism diagnostics rather than promotion evidence because they were not paired against the predecessor.
+
+The exact S3 small/time ABBA run against unchanged current `main` produced ratio 0.8710 with 95% CI [0.8625, 0.8780] over 15 paired rounds. The predecessor median was 2.723 ms and the candidate median was 2.379 ms. All timed samples verified and were byte-identical. This clears the 0.99 significance threshold by a wide margin.
+
+The measured improvement was larger than predicted because small proofs repeat several Merkle commitments whose previously serial lower layers are a substantial fixed cost. The result falsifies the concern that resident-pool task overhead would outweigh the smaller chunks on this host. In accordance with the user's instruction to submit as soon as a significant solution exists, the search stops here for the first submission; wider batching and additional threshold sweeps remain future work rather than being mixed into this evidence-backed diff.
+
+## Submission-policy drift reconciliation
+
+Packaging reported that `origin/main` had advanced by one harness-only commit adding the post-merge record workflow. The canonical checkout was fast-forwarded to the new tip. A tree comparison confirmed that the performance source frontier and editable paths were unchanged, so the measured predecessor remains valid. The submission branch is rebased onto the new harness tip before push, and local absolute evidence prefixes are removed from the public claimed verdict.

--- a/autoresearch/submissions/2026-07-20-deeper-merkle-pool-parallelism/verdict.json
+++ b/autoresearch/submissions/2026-07-20-deeper-merkle-pool-parallelism/verdict.json
@@ -1,0 +1,114 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "a48a97b2cc2e",
+  "repo_commit": "b343b866a9f4",
+  "predecessor_commit": "b343b866a9f4",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": false,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 1.16
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; byte-identity enforced per round"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "anchor not frozen; budgets inactive (G5 blocks judged)"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log10x8": {
+        "r": 0.870962,
+        "ci": [
+          0.862475,
+          0.877999
+        ],
+        "rounds": 15,
+        "a_median_ms": 2.723125,
+        "b_median_ms": 2.378542
+      }
+    },
+    "R_geomean": 0.870962,
+    "theta": 0.01,
+    "aa_dispersion": null,
+    "significant": true,
+    "neutral": false
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "reports": [
+      "autoresearch/.runs/latest/wf_log10x8.a1.json",
+      "autoresearch/.runs/latest/wf_log10x8.b1.json",
+      "autoresearch/.runs/latest/wf_log10x8.a2.json",
+      "autoresearch/.runs/latest/wf_log10x8.b2.json",
+      "autoresearch/.runs/latest/wf_log10x8.a3.json",
+      "autoresearch/.runs/latest/wf_log10x8.b3.json",
+      "autoresearch/.runs/latest/wf_log10x8.a4.json",
+      "autoresearch/.runs/latest/wf_log10x8.b4.json",
+      "autoresearch/.runs/latest/wf_log10x8.a5.json",
+      "autoresearch/.runs/latest/wf_log10x8.b5.json",
+      "autoresearch/.runs/latest/wf_log10x8.a6.json",
+      "autoresearch/.runs/latest/wf_log10x8.b6.json",
+      "autoresearch/.runs/latest/wf_log10x8.a7.json",
+      "autoresearch/.runs/latest/wf_log10x8.b7.json",
+      "autoresearch/.runs/latest/wf_log10x8.a8.json",
+      "autoresearch/.runs/latest/wf_log10x8.b8.json",
+      "autoresearch/.runs/latest/wf_log10x8.a9.json",
+      "autoresearch/.runs/latest/wf_log10x8.b9.json",
+      "autoresearch/.runs/latest/wf_log10x8.a10.json",
+      "autoresearch/.runs/latest/wf_log10x8.b10.json",
+      "autoresearch/.runs/latest/wf_log10x8.a11.json",
+      "autoresearch/.runs/latest/wf_log10x8.b11.json",
+      "autoresearch/.runs/latest/wf_log10x8.a12.json",
+      "autoresearch/.runs/latest/wf_log10x8.b12.json",
+      "autoresearch/.runs/latest/wf_log10x8.a13.json",
+      "autoresearch/.runs/latest/wf_log10x8.b13.json",
+      "autoresearch/.runs/latest/wf_log10x8.a14.json",
+      "autoresearch/.runs/latest/wf_log10x8.b14.json",
+      "autoresearch/.runs/latest/wf_log10x8.a15.json",
+      "autoresearch/.runs/latest/wf_log10x8.b15.json"
+    ],
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)"
+  }
+}

--- a/src/prover/vcs_lifted/parameters.zig
+++ b/src/prover/vcs_lifted/parameters.zig
@@ -4,8 +4,8 @@ const std = @import("std");
 const builtin = @import("builtin");
 const mmap_alloc = @import("../mmap_alloc.zig");
 
-pub const parallel_min_nodes: usize = 1 << 13;
-pub const parallel_min_nodes_per_worker: usize = 1 << 12;
+pub const parallel_min_nodes: usize = 1 << 11;
+pub const parallel_min_nodes_per_worker: usize = 1 << 10;
 pub const max_parallel_workers: usize = 16;
 pub const merkle_worker_stack_size: usize = 1 << 20;
 pub const leaf_tile_len: usize = 256;


### PR DESCRIPTION
# Use the resident pool deeper into Merkle trees

## Model and harness

Model: GPT-5 Codex. Harness: repo-resident `stwo-perf` updated at the start of the session, ReleaseFast on arm64 macOS, paired S3 small/time against current promoted `main`. The reasoning-first submitter transcript is attached as `transcripts/session-01.md`.

## Hypothesis

Current Merkle scheduling leaves most of the installed 16-worker prover pool idle below the largest tree layer: it requires 4,096 parent hashes per worker and stops parallel hashing below 8,192 parents. Full-proof sampling showed four-way BLAKE2s compression as the hottest executable frame while worker threads waited. Reducing task granularity should reuse the already-resident pool deeper into each tree, cutting repeated Merkle fixed cost without changing hash order or proof bytes.

## Changes

Lowered the lifted Merkle parallel threshold from 8,192 to 2,048 parent nodes and the minimum chunk from 4,096 to 1,024 parents per worker. No hashing, field arithmetic, transcript, or protocol logic changed; only the number of independent parent ranges scheduled onto the existing pool changed.

## Results

S3 `wf_log10x8` small/time: ratio 0.8710, 95% CI [0.8625, 0.8780], 15 paired rounds. The predecessor median was 2.723 ms and the candidate median was 2.379 ms. Every timed proof verified and remained byte-identical.

Unpaired warmed diagnostics also preserved the existing proof hashes and measured 13.70 ms for the wide workload and 9.78 ms for the deep workload, indicating that the scheduling mechanism is not small-only. These are diagnostics, not claimed promotion scores.

## Caveats

This is a local claimed verdict; the locked judge rerun is authoritative. The anchor is not frozen, so drift budgets and judged promotion remain inactive. The threshold is tuned from profiling and full-proof evidence on the current 18-CPU arm64 host; other CPU topologies may select fewer workers through the existing capacity and CPU-count caps, but cross-host efficiency still belongs to judge and holdout validation.
