### PR TITLE
Extend four-way SIMD leaf hashing through the FRI cascade

### DIFF
--- a/autoresearch/submissions/2026-07-20-four-way-fri-leaf-cascade/delta.json
+++ b/autoresearch/submissions/2026-07-20-four-way-fri-leaf-cascade/delta.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "95f32a8f9f6e",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/prover/vcs_lifted/leaves.zig": "sha256:4f8e1a191aca4e03dc7a0b3b8abefb58e07d49e3dd83c29059c0cab028523bdd",
+    "src/prover/vcs_lifted/parameters.zig": "sha256:40ac827358dc76c2a75089f97405a04faa535cbbd40b1a251a431d58de03be5e"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "f7c028171fb69232a99b92f19c2b61ec9064cd67b36b0b629be4d446edabbf97",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-20-four-way-fri-leaf-cascade/note.md
+++ b/autoresearch/submissions/2026-07-20-four-way-fri-leaf-cascade/note.md
@@ -1,0 +1,50 @@
+# Extend four-way SIMD leaf hashing through the FRI cascade
+
+## Model and harness
+
+Model: GPT-5 Codex. Harness: repo-resident `stwo-perf`, updated before research
+at current `main` (`95f32a8f9f6e`). ReleaseFast on arm64 macOS, paired S3
+deep/time against the unchanged current-main predecessor. A reasoning-first,
+sanitized transcript is attached as `transcripts/session-01.md`.
+
+## Hypothesis
+
+The functional protocol commits an inner FRI tree after every fold. The
+existing four-message SIMD leaf builder was selected only at 16,384 leaves, so
+the entire smaller-tree cascade fell back to constructing and finalizing one
+incremental hasher per leaf. Warmed probes found the 8,192-leaf fallback tree
+slower than the 16,384-leaf SIMD tree and attributed roughly 3 ms of wide/deep
+proving to inner FRI Merkle commits. Extending the already-verified SIMD builder
+through that cascade should produce a large end-to-end win without changing
+hash order or proof bytes.
+
+## Changes
+
+The batched-leaf crossover is lowered from 16,384 to 256 leaves. On hashers
+with the four-message API, `buildBatched` no longer allocates an unused
+per-leaf incremental-hasher array and sizes each worker's scratch to exactly
+four packed leaf messages. The generic non-four-way path retains its existing
+batch storage and 256 KiB scratch policy. No field arithmetic, hash function,
+transcript, protocol, or tree ordering changed.
+
+## Results
+
+S3 `plonk_log14` deep/time: ratio **0.8636**, 95% CI **[0.8587, 0.8708]** over
+15 paired rounds. The predecessor median was 9.853 ms and the candidate median
+was 8.521 ms. G1–G5 passed; every timed proof verified and remained
+byte-identical.
+
+Suite-wide warmed diagnostics also preserved the existing proof hashes and
+measured 2.816→2.208 ms small, 16.469→12.589 ms wide, and 12.017→8.542 ms deep.
+These unpaired values are mechanism/cross-class diagnostics, not promotion
+scores. ReleaseFast prover and native-CPU product closures passed across 152
+and 190 transitive Zig sources respectively.
+
+## Caveats
+
+This is a local claimed verdict; the locked judge rerun remains authoritative.
+The anchor is not frozen, so drift budgets and judged promotion are inactive.
+Mechanism telemetry wiring is still pending in the harness; the threshold
+discontinuity, temporary per-layer probes summarized in the transcript, source
+allocation change, identical proof hashes, and paired end-to-end result provide
+the current mechanism evidence.

--- a/autoresearch/submissions/2026-07-20-four-way-fri-leaf-cascade/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-20-four-way-fri-leaf-cascade/transcripts/session-01.md
@@ -1,0 +1,146 @@
+# Session 01 — frontier synthesis and large-step search
+
+Model: GPT-5 Codex
+
+## Objective and starting state
+
+The user asked for the largest defensible forward step, not a sequence of small
+constant-factor submissions. The repository-specific `stwo-perf update` was run
+before research and reported the checkout current at `95f32a8f9f6e`. The fresh
+workspace was then created from that clean `main` predecessor.
+
+The fixed objective is end-to-end CPU prove time with byte-identical proofs.
+The scored classes are small wide-Fibonacci (`wf_log10x8`), wide
+wide-Fibonacci (`wf_log14x32`), and deep Plonk (`plonk_log14`). Promotion needs
+an S3 paired-run confidence interval wholly beyond the 1% threshold, while
+conformance, identity, mechanism, resource, and environment gates remain valid.
+
+The initial frontier has two promoted results: packed direct quotient rows plus
+resident Merkle-pool reuse (wide frontier 17.321 ms), followed by deeper
+resident-pool use in Merkle trees (small frontier 2.379 ms). The next step will
+start from their combined code on `main`, not re-test a stale baseline.
+
+## Decision process
+
+Before changing code, the plan is to read the complete notes and transcripts
+for both promoted efforts, reconstruct their diffs and measured stage profiles,
+and inspect recent branch history for unpromoted ideas. This is necessary to
+avoid duplicating already-rejected work and to identify the next structural
+bottleneck exposed by the two pool/packing changes.
+
+The selection bar is deliberately high: prefer a mechanism affecting a major
+end-to-end stage across multiple workloads, with a predicted improvement over
+1%, rather than accumulating isolated micro-edits. CPU counter or stage-profile
+evidence will determine whether the next move targets arithmetic work, memory
+traffic, dependency chains, or orchestration overhead. If the move replaces an
+algorithm rather than tuning an implementation, the repository's algorithm
+matching gate will be completed before editing.
+
+## Prior-work synthesis and current attribution
+
+Both promoted transcripts and source diffs were read in full. Earlier history
+also shows that this code already has four-way SIMD BLAKE2 compression, seeded
+parent hashing, four-lane first-layer leaf hashing, batched leaf packing, fused
+lazy quotient-to-leaf production, FRI fold-step 4, and global worker-pool reuse.
+Those mechanisms are therefore baselines, not new hypotheses.
+
+Current profiled diagnostics put `fri_quotient_build_and_commit` at roughly
+1.22 ms of a 2.78 ms small proof, 5.39 ms of a 14.11 ms wide proof, and 5.34 ms
+of a 9.95 ms deep proof. Main/composition Merkle commitments and wide
+composition evaluation are secondary. Because the public stage aggregates
+quotient evaluation, first-tree hashing, circle/line folding, and inner FRI
+trees, temporary timing probes will split this stage. They will be removed
+before any candidate benchmark; their purpose is to distinguish a hash/schedule
+attack from a fold/arithmetic attack.
+
+Temporary warmed probes resolved the aggregate. On wide/deep, the lazy first
+layer was about 0.9–1.0 ms, initial circle folding about 0.74 ms, line folds
+about 0.62 ms total, coordinate conversion under 0.06 ms, and inner Merkle
+commits roughly 3.0 ms. The 8,192-leaf inner tree took about 0.81–0.83 ms while
+the larger 16,384-leaf tree took only 0.50–0.55 ms. Source inspection explains
+the inversion: the four-message SIMD batched leaf builder is selected only at
+16,384 leaves, while every smaller FRI layer constructs and finalizes one
+incremental hasher per leaf. Since the functional protocol uses fold step 1,
+this slower fallback repeats at every power-of-two layer down to the final
+polynomial.
+
+The first candidate lowers the existing batched-leaf crossover to 1,024 leaves.
+This is constant-factor strategy selection between two already-correct builders,
+not an algorithm replacement. Prediction: remove at least 0.8 ms from wide and
+deep FRI commits and materially improve small proofs by accelerating several
+repeated commitments. Falsifier: warmed full-proof time regresses or the
+1,024/2,048-leaf trees show allocation/task overhead larger than their SIMD
+hashing savings. Thresholds below 1,024 are deferred until this crossover is
+measured because the batched builder reserves scratch and hasher storage.
+
+The 1,024-leaf experiment passed its falsifier. Warmed diagnostics moved from
+about 14.07 to 12.81 ms wide, 10.02 to 8.64 ms deep, and 2.71 to 2.36 ms small,
+with the same proof hashes. Inner FRI time fell from about 4.33 to 3.16 ms on
+wide and 4.23 to 3.09 ms on deep. The 8,192/4,096/2,048/1,024-leaf Merkle
+commits all became much faster; the 512-leaf legacy commit was then slower than
+the newly batched 1,024-leaf commit.
+
+Inspection found that the SIMD branch of `buildBatched` never reads its
+per-leaf `H` array: it packs exactly four leaf messages and calls the four-way
+hash primitive directly. It also needs only `4 * bytes_per_leaf` scratch, not
+the generic 256 KiB per worker. The candidate will therefore retain the
+existing generic allocations for non-four-way hashers but allocate zero
+incremental hashers and exact four-message scratch for the SIMD-capable hasher.
+This reduces memory as well as setup cost and supports testing a 256-leaf
+crossover without turning tiny FRI layers into allocation-heavy work.
+
+## Final candidate and evidence
+
+The final candidate selects the SIMD batched leaf builder at 256 leaves. For
+the four-way-capable hasher it allocates no incremental hasher array and sizes
+scratch to exactly four leaf messages per worker; generic hashers retain their
+previous storage path. Temporary timing probes were removed before candidate
+measurement, and the final source diff is confined to `leaves.zig` and
+`parameters.zig` under the manifest's editable surface.
+
+Seven-sample warmed diagnostics, run separately on candidate and unchanged
+predecessor under the same machine state, produced these medians:
+
+- small: 2.816 ms predecessor versus 2.208 ms candidate;
+- wide: 16.469 ms predecessor versus 12.589 ms candidate;
+- deep: 12.017 ms predecessor versus 8.542 ms candidate.
+
+All candidate samples verified, were mutually byte-identical, and retained the
+predecessor proof hashes for each workload. These are diagnostics rather than
+the paired promotion claim, but they show the mechanism is suite-wide and has
+no observed cross-class regression.
+
+Focused ReleaseFast gates passed for both the prover library (152 transitive
+Zig sources) and the native CPU product (190 transitive Zig sources). Formatting
+and `git diff --check` passed; no temporary probe or locked-path change remained.
+
+The exact S3 deep/time ABBA run against unchanged current `main` produced ratio
+0.8636 with 95% CI [0.8587, 0.8708] across 15 paired rounds. Predecessor median
+was 9.853 ms and candidate median was 8.521 ms. G1–G5 all passed, including
+verification and byte identity on every timed proof. This is a 13.64% paired
+end-to-end improvement and is significant beyond the 1% floor.
+
+## Alternatives and dead ends retained
+
+- Reworking BLAKE2 compression was rejected after history/source review showed
+  four-way SIMD, seeded parents, byte-shuffle rotates, and direct transposition
+  were already implemented. The observed discontinuity was dispatch policy,
+  not absence of a vector kernel.
+- A FRI folding rewrite was rejected for this submission after detailed probes
+  attributed about 3.0 ms to inner Merkle commits versus roughly 1.36 ms to
+  initial and line folding on wide/deep. It had less immediate headroom and a
+  larger correctness surface.
+- Proof-of-work thread reuse was considered because PoW costs about 0.23 ms,
+  but the channel implementation is outside the manifest's editable paths and
+  the maximum saving is much smaller than the repeated FRI-tree opportunity.
+- Stopping at the 1,024-leaf threshold was rejected because its own result
+  showed the 512-leaf fallback had become slower than the 1,024-leaf SIMD path.
+  Removing unused allocation made the 256 crossover the coherent completion of
+  the same mechanism rather than a separate micro-optimization.
+- Thresholds below 256 were not added after a significant solution existed;
+  their absolute residual share is small, and the user explicitly requested
+  submission as soon as a large improvement cleared the paired bar.
+
+The submission decision follows directly from the user instruction: package
+now that a large, suite-wide mechanism has a significant S3 verdict, rather
+than holding it for unrelated follow-on work.

--- a/autoresearch/submissions/2026-07-20-four-way-fri-leaf-cascade/verdict.json
+++ b/autoresearch/submissions/2026-07-20-four-way-fri-leaf-cascade/verdict.json
@@ -1,0 +1,114 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "6dbd9a6d02b1",
+  "repo_commit": "95f32a8f9f6e",
+  "predecessor_commit": "95f32a8f9f6e",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": false,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 2.37
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; byte-identity enforced per round"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "anchor not frozen; budgets inactive (G5 blocks judged)"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "plonk_log14": {
+        "r": 0.863603,
+        "ci": [
+          0.858696,
+          0.870776
+        ],
+        "rounds": 15,
+        "a_median_ms": 9.853417,
+        "b_median_ms": 8.521125
+      }
+    },
+    "R_geomean": 0.863603,
+    "theta": 0.01,
+    "aa_dispersion": null,
+    "significant": true,
+    "neutral": false
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.b10.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.a11.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.b11.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.a12.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.b12.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.a13.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.b13.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.a14.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.b14.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.a15.json",
+      "/Users/theodorepender/code/auto-researching/ws-largest-step/autoresearch/.runs/latest/plonk_log14.b15.json"
+    ],
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)"
+  }
+}

--- a/src/prover/vcs_lifted/leaves.zig
+++ b/src/prover/vcs_lifted/leaves.zig
@@ -292,9 +292,15 @@ pub fn Operations(comptime H: type) type {
             else
                 1;
             const per_worker_batch = @min(@min(batch_size, total_leaves), @as(usize, 1024));
-            const hashers = try allocator.alloc(H, worker_count * per_worker_batch);
+            const four_way_hashing = comptime @hasDecl(H, "leafSeed") and
+                @hasDecl(H, "hashPackedLeavesWithSeed4");
+            const hashers_per_worker = if (four_way_hashing) 0 else per_worker_batch;
+            const hashers = try allocator.alloc(H, worker_count * hashers_per_worker);
             defer allocator.free(hashers);
-            const scratch_words_per_worker = max_leaf_scratch_bytes / @sizeOf(M31);
+            const scratch_words_per_worker = if (four_way_hashing)
+                try std.math.mul(usize, 4, sorted_columns.len)
+            else
+                max_leaf_scratch_bytes / @sizeOf(M31);
             const scratch_words = if (comptime @hasDecl(H, "updateLeafPackedBytes"))
                 allocator.alloc(M31, worker_count * scratch_words_per_worker) catch null
             else
@@ -312,7 +318,7 @@ pub fn Operations(comptime H: type) type {
                     .sorted_columns = sorted_columns,
                     .max_log_size = max_log_size,
                     .out = out,
-                    .batch_hashers = hashers[worker * per_worker_batch ..][0..per_worker_batch],
+                    .batch_hashers = hashers[worker * hashers_per_worker ..][0..hashers_per_worker],
                     .scratch = if (scratch_words) |words| blk: {
                         const scratch_start = worker * scratch_words_per_worker;
                         break :blk std.mem.sliceAsBytes(words[scratch_start..][0..scratch_words_per_worker]);

--- a/src/prover/vcs_lifted/parameters.zig
+++ b/src/prover/vcs_lifted/parameters.zig
@@ -11,7 +11,7 @@ pub const merkle_worker_stack_size: usize = 1 << 20;
 pub const leaf_tile_len: usize = 256;
 pub const max_leaf_scratch_bytes: usize = 256 * 1024;
 pub const default_leaf_batch_size: usize = 1 << 12;
-pub const batched_leaf_threshold: usize = 1 << 14;
+pub const batched_leaf_threshold: usize = 1 << 8;
 
 pub fn layerAllocator(fallback: std.mem.Allocator) std.mem.Allocator {
     if (comptime builtin.os.tag == .macos or builtin.os.tag == .linux) {


### PR DESCRIPTION
# Extend four-way SIMD leaf hashing through the FRI cascade

## Model and harness

Model: GPT-5 Codex. Harness: repo-resident `stwo-perf`, updated before research
at current `main` (`95f32a8f9f6e`). ReleaseFast on arm64 macOS, paired S3
deep/time against the unchanged current-main predecessor. A reasoning-first,
sanitized transcript is attached as `transcripts/session-01.md`.

## Hypothesis

The functional protocol commits an inner FRI tree after every fold. The
existing four-message SIMD leaf builder was selected only at 16,384 leaves, so
the entire smaller-tree cascade fell back to constructing and finalizing one
incremental hasher per leaf. Warmed probes found the 8,192-leaf fallback tree
slower than the 16,384-leaf SIMD tree and attributed roughly 3 ms of wide/deep
proving to inner FRI Merkle commits. Extending the already-verified SIMD builder
through that cascade should produce a large end-to-end win without changing
hash order or proof bytes.

## Changes

The batched-leaf crossover is lowered from 16,384 to 256 leaves. On hashers
with the four-message API, `buildBatched` no longer allocates an unused
per-leaf incremental-hasher array and sizes each worker's scratch to exactly
four packed leaf messages. The generic non-four-way path retains its existing
batch storage and 256 KiB scratch policy. No field arithmetic, hash function,
transcript, protocol, or tree ordering changed.

## Results

S3 `plonk_log14` deep/time: ratio **0.8636**, 95% CI **[0.8587, 0.8708]** over
15 paired rounds. The predecessor median was 9.853 ms and the candidate median
was 8.521 ms. G1–G5 passed; every timed proof verified and remained
byte-identical.

Suite-wide warmed diagnostics also preserved the existing proof hashes and
measured 2.816→2.208 ms small, 16.469→12.589 ms wide, and 12.017→8.542 ms deep.
These unpaired values are mechanism/cross-class diagnostics, not promotion
scores. ReleaseFast prover and native-CPU product closures passed across 152
and 190 transitive Zig sources respectively.

## Caveats

This is a local claimed verdict; the locked judge rerun remains authoritative.
The anchor is not frozen, so drift budgets and judged promotion are inactive.
Mechanism telemetry wiring is still pending in the harness; the threshold
discontinuity, temporary per-layer probes summarized in the transcript, source
allocation change, identical proof hashes, and paired end-to-end result provide
the current mechanism evidence.
