### PR TITLE
Pack sampled-value polynomial evaluation across SIMD lanes

### DIFF
--- a/autoresearch/submissions/2026-07-20-packed-sampled-value-evaluation/delta.json
+++ b/autoresearch/submissions/2026-07-20-packed-sampled-value-evaluation/delta.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "4dc26f00d743",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/prover/poly/circle/point_evaluation.zig": "sha256:ea8fc7ea974a990caceefd024b2e80a57d525fb40c5c79e87591a2b8cb6e5d97",
+    "src/prover/poly/circle/poly.zig": "sha256:b62d6b8110ade63324d5ecc93298d0efa4107451ef71aa1d7ae2e46d3c6b50fc"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "7412e3d1f33b7fc8d8a83ab7624d7b8994c5a0b0952acd382b5378b99354bc54",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-20-packed-sampled-value-evaluation/note.md
+++ b/autoresearch/submissions/2026-07-20-packed-sampled-value-evaluation/note.md
@@ -1,0 +1,60 @@
+# Evaluate sampled-value polynomials across native SIMD lanes
+
+## Model and harness
+
+Model: GPT-5 Codex. Harness: repo-resident `stwo-perf`, updated before research
+to current `main` (`4dc26f00d743`). ReleaseFast on arm64 macOS, paired S3
+time evaluations against the unchanged current-main predecessor for every
+affected class. A reasoning-first sanitized transcript is attached as
+`transcripts/session-01.md`.
+
+## Hypothesis
+
+PCS sampled-value evaluation applies the same secure-field point factors to
+many independent circle-basis coefficient polynomials. The existing batched
+helper shares factors but reduces one polynomial at a time, leaving native SIMD
+lanes unused inside each worker. Packing independent polynomials into M31 lanes
+should preserve each polynomial's exact carry-style merge order while removing
+most scalar secure-field instructions across all three workloads.
+
+## Changes
+
+Added a lane-wise packed QM31 reduction for one native-width batch of
+coefficient streams. `evalManyAtPointsWithFlatFactors` dispatches full batches
+through it and retains the existing scalar evaluator for incomplete tails and
+scalar targets. The existing batch-vs-scalar property test now covers one full
+native batch plus a tail. Tree scheduling, point factors, field semantics,
+coefficient order, transcript order, and protocol bytes are unchanged.
+
+## Results
+
+S1 on 32 degree-2^14 live-repo polynomials at one secure point: packed/scalar
+wall ratio **0.3730**, 95% CI **[0.3674, 0.3738]**; instruction ratio **0.3201**
+and cycle ratio **0.3730**. The packed kernel measured 72.52 versus 226.5
+instructions per coefficient. Live arm64 disassembly contains the predicted
+`umull/umull2.2d`, `uzp1.4s`, `add/sub/cmhi.4s`, and `st4.4s` operations.
+
+Profiled sampled-value medians fell from 0.158 to 0.087 ms small, 1.745 to
+0.711 ms wide, and 0.879 to 0.380 ms deep. Promotion-grade paired S3 results:
+
+- `wf_log10x8` small: ratio **0.9612**, 95% CI **[0.9441, 1.0006]**, 15 rounds,
+  1.645 to 1.582 ms; favorable but correctly recorded as not significant.
+- `wf_log14x32` wide: ratio **0.9181**, 95% CI **[0.9099, 0.9246]**, 15 rounds,
+  12.573 to 11.524 ms; significant improvement.
+- `plonk_log14` deep: ratio **0.9430**, 95% CI **[0.9345, 0.9498]**, 15 rounds,
+  8.608 to 8.131 ms; significant improvement.
+
+Every timed proof verified and remained byte-identical. Fresh seven-sample
+suite diagnostics retained proof SHA-256 values `91741aec...bea5700` small,
+`57a7d291...0f3374` wide, and `d63a2c92...69dbaf` deep. The ReleaseFast prover
+and native CPU product closures passed across 152 and 190 transitive Zig
+sources respectively.
+
+## Caveats
+
+These are local claimed verdicts; the locked judge rerun remains authoritative.
+The anchor is not frozen, so budgets and judged promotion remain inactive.
+Mechanism telemetry is still pending in the harness; differential tests,
+counter ratios, stage attribution, and live codegen provide the current
+mechanism evidence. Small's measured stage improvement did not clear the
+end-to-end confidence threshold, so no significance is claimed for that class.

--- a/autoresearch/submissions/2026-07-20-packed-sampled-value-evaluation/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-20-packed-sampled-value-evaluation/transcripts/session-01.md
@@ -1,0 +1,187 @@
+# Session 01 — post-Merkle architecture search
+
+Model: GPT-5 Codex
+
+## Objective and contract
+
+The user requested the largest defensible CPU-prover improvement, explicitly
+requiring the repository CLI to be updated first, prior notes/transcripts to be
+used as research input, profilers and visualizations to guide architecture, and
+submission as soon as a significant solution is verified.
+
+The repo-resident updater fast-forwarded the clean primary checkout from
+`95f32a8` to current `main` at `4dc26f0` before a candidate workspace was
+created. The fixed suite is small wide-Fibonacci, wide wide-Fibonacci, and deep
+Plonk. Acceptance requires paired S3 end-to-end evidence, byte-identical proof
+outputs, and edits confined to the manifest's editable prover paths.
+
+## Prior-research synthesis
+
+All three promoted notes and reasoning-first transcripts were read before new
+profiling. The combined frontier already includes:
+
+- packed direct quotient accumulation using native four-row lanes;
+- reuse of the resident prover work pool for Merkle construction;
+- deeper pool scheduling with smaller Merkle layer tasks;
+- four-way BLAKE2s leaf hashing throughout the FRI cascade;
+- exact scratch sizing and removal of unused incremental hashers in that path.
+
+Their reported current-frontier medians are 2.379 ms small, 17.321 ms wide,
+and 8.521 ms deep, although the source improvements are combined on current
+`main` and a fresh baseline must be measured. Earlier temporary attribution
+split the formerly dominant FRI stage into approximately 0.9–1.0 ms lazy first
+layer, 1.36 ms circle/line folds, and roughly 3 ms inner Merkle commitments on
+wide/deep *before* the latest SIMD cascade optimization. Therefore the old
+stage percentages cannot be reused as the new map.
+
+## Architecture visualization and selection rule
+
+```text
+trace columns
+    |
+    +--> main/composition commitments ----+
+    |                                     |
+    +--> quotient tiles -> first FRI tree -+-> fold -> inner tree -> fold ...
+                    packed/fused             ^         ^
+                    frontier work             |         |
+                                         candidate   frontier SIMD/pool work
+                                         residual
+```
+
+The next candidate will be chosen from fresh current-main evidence. The
+preferred target must (1) retain at least about 1% end-to-end headroom, (2)
+affect more than one class if possible, (3) preserve exact transcript/hash
+ordering, and (4) admit a clear mechanism check through counters, samples,
+operation counts, or code generation. Repeating the now-optimized Merkle
+threshold work, optimizing Metal, or editing benchmark/harness files is
+rejected up front.
+
+If profiling recommends an algorithm or data-layout replacement rather than a
+mechanical constant-factor change, a complete canonical problem-match brief
+will be written before editing.
+
+## Fresh baseline and residual attribution
+
+The current combined frontier was built and the complete fixed suite was run
+locally with ten warmups and seven verified, unprofiled samples per workload.
+Median prove times were 1.984 ms small, 12.509 ms wide, and 8.445 ms deep. All
+seven proofs in each workload verified and were byte-identical; their SHA-256
+identities matched the promoted research record.
+
+Seven-sample diagnostic stage profiles produced this residual map:
+
+```text
+stage (median ms)             small   wide   deep
+FRI quotient build + commit   0.815  3.858  3.816
+composition evaluation        0.040  2.729  0.398
+sampled-value evaluation      0.158  1.745  0.879
+main-trace commit              0.279  1.898  1.119
+proof of work                 0.267  0.242  0.260
+```
+
+FRI remains the largest common aggregate, but its already-optimized hash path
+contains several mechanisms. Wide composition evaluation is large but belongs
+to one example's single-component row/constraint traversal, whose source is
+outside the editable submission surface. Sampled-value evaluation is both
+suite-wide and editable.
+
+## Packed direct-product sampled-value design
+
+Source inspection showed that a sampled-value plan applies identical secure
+point factors to many independent circle-basis coefficient polynomials. The
+current batched helper changes loop order and shares factors, but invokes the
+full scalar coefficient reduction for each polynomial. Existing thread
+parallelism uses one worker per eight columns, leaving lane-level parallelism
+inside each worker unused.
+
+The selected transfer is a direct-product SIMD evaluation: keep every
+polynomial's carry-style merge tree and arithmetic order unchanged, but place
+independent polynomials in native M31 vector lanes. This is a constant-factor
+representation transfer, not a replacement algorithm, so the algorithm-match
+gate does not require an external canonical-algorithm brief. Correctness is
+lane-wise equivalence to the existing scalar evaluator; batches with a partial
+tail retain the scalar path.
+
+```text
+factor[level] ───────────────┬─────────────── shared
+poly 0 coeff stream ── lane 0│
+poly 1 coeff stream ── lane 1├─ packed QM31 merge tree ── four exact outputs
+poly 2 coeff stream ── lane 2│
+poly 3 coeff stream ── lane 3│
+```
+
+A scratch S1 harness wired to live current-repo modules evaluated 32 degree-
+2^14 polynomials at one secure point. It included four deterministic
+differential checks against the scalar helper before timing. Results:
+
+- scalar: 11.67 ns/coefficient, 226.5 instructions, 53.62 cycles, IPC 4.225;
+- packed: 4.342 ns/coefficient, 72.52 instructions, 19.96 cycles, IPC 3.633;
+- ABBA packed/scalar wall ratio 0.3730, 95% CI [0.3674, 0.3738];
+- instruction ratio 0.3201 and cycle ratio 0.3730.
+
+The 2.68x kernel speedup supports an end-to-end prediction of roughly 0.5–1.2
+ms on wide and 0.2–0.6 ms on deep, depending on plan overhead and concurrent
+tree scheduling. The falsifier is a neutral/regressed sampled-value stage or
+failure of the existing scalar-vs-batch property test. A threshold-only worker
+granularity change is deferred because it cannot remove the measured scalar
+instruction burden and may oversubscribe trees already running concurrently.
+
+## Integration, codegen, and end-to-end outcome
+
+The packed secure-field helpers were integrated privately at the point-
+evaluation boundary, and `evalManyAtPointsWithFlatFactors` now groups complete
+native-width polynomial batches while preserving its scalar tail. No protocol,
+hashing, point-factor, or scheduler code changed. The existing batch-vs-scalar
+test was changed from a fixed five polynomials to `native width + 1`, explicitly
+covering both a full packed group and the tail on each target.
+
+The ReleaseFast prover closure passed across 152 transitive Zig sources. Fresh
+profiled stage medians confirmed the predicted mechanism:
+
+```text
+sampled-value stage (ms)      predecessor  candidate
+small                              0.158      0.087
+wide                               1.745      0.711
+deep                               0.879      0.380
+```
+
+Every seven-sample unpaired candidate workload verified and preserved the
+predecessor proof SHA-256. Live integrated arm64 disassembly showed packed
+widening multiplies (`umull/umull2.2d`), lane recombination (`uzp1.4s`), vector
+field reductions (`add/sub/cmhi.4s`), and a four-coordinate vector store
+(`st4.4s`). This closes the codegen requirement rather than inferring SIMD from
+source syntax.
+
+The exact paired S3 results against unchanged current `main` were:
+
+- small: ratio 0.9612, 95% CI [0.9441, 1.0006], 1.645 to 1.582 ms;
+- wide: ratio 0.9181, 95% CI [0.9099, 0.9246], 12.573 to 11.524 ms;
+- deep: ratio 0.9430, 95% CI [0.9345, 0.9498], 8.608 to 8.131 ms.
+
+All runs used 15 paired rounds and passed G1–G5. Wide and deep are significant
+beyond the 1% floor. Small's mechanism moved in the expected direction but its
+end-to-end CI reaches 1.0, so it is attached as neutral evidence rather than
+rounded into a win. The ReleaseFast native CPU product closure also passed
+across 190 transitive sources.
+
+## Rejected alternatives and stopping decision
+
+- A pure worker-threshold sweep was rejected as the primary design because the
+  S1 counters attributed most cost to scalar instructions, not idle dispatch,
+  and existing sampled-value evaluation already overlaps trees and partitions
+  the largest coefficient plan.
+- Wide composition evaluation has more single-workload time, but its concrete
+  recurrence traversal belongs to an example source outside the manifest's
+  editable paths. Attempting to route around that boundary would invalidate the
+  submission.
+- Another Merkle threshold or BLAKE2 rewrite was rejected because the three
+  promoted sessions already optimized that architecture and fresh attribution
+  exposed sampled-value evaluation as the larger unclaimed common residual.
+- A new global packed-QM31 public type was unnecessary. Keeping the lane type
+  private to point evaluation minimizes API and correctness surface while still
+  reusing the repository's tested packed M31 primitives.
+
+The user required submission as soon as a significant solution existed. With
+two class CIs clearing the threshold, all affected classes measured, exact
+proof identity preserved, profiler/codegen mechanism evidence collected, and
+both product closures green, the search stops here to package this checkpoint.

--- a/autoresearch/submissions/2026-07-20-packed-sampled-value-evaluation/verdict-deep.json
+++ b/autoresearch/submissions/2026-07-20-packed-sampled-value-evaluation/verdict-deep.json
@@ -1,0 +1,114 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "1b0be568ace8",
+  "repo_commit": "4dc26f00d743",
+  "predecessor_commit": "4dc26f00d743",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": false,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 3.05
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; byte-identity enforced per round"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "anchor not frozen; budgets inactive (G5 blocks judged)"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "plonk_log14": {
+        "r": 0.942963,
+        "ci": [
+          0.934532,
+          0.949791
+        ],
+        "rounds": 15,
+        "a_median_ms": 8.608167,
+        "b_median_ms": 8.131
+      }
+    },
+    "R_geomean": 0.942963,
+    "theta": 0.01,
+    "aa_dispersion": null,
+    "significant": true,
+    "neutral": false
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.b10.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.a11.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.b11.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.a12.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.b12.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.a13.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.b13.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.a14.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.b14.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.a15.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/plonk_log14.b15.json"
+    ],
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)"
+  }
+}

--- a/autoresearch/submissions/2026-07-20-packed-sampled-value-evaluation/verdict-wide.json
+++ b/autoresearch/submissions/2026-07-20-packed-sampled-value-evaluation/verdict-wide.json
@@ -1,0 +1,114 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "1b0be568ace8",
+  "repo_commit": "4dc26f00d743",
+  "predecessor_commit": "4dc26f00d743",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "wide",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": false,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 3.26
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; byte-identity enforced per round"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "anchor not frozen; budgets inactive (G5 blocks judged)"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log14x32": {
+        "r": 0.918108,
+        "ci": [
+          0.909853,
+          0.924581
+        ],
+        "rounds": 15,
+        "a_median_ms": 12.573166,
+        "b_median_ms": 11.524167
+      }
+    },
+    "R_geomean": 0.918108,
+    "theta": 0.01,
+    "aa_dispersion": null,
+    "significant": true,
+    "neutral": false
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.b10.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.a11.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.b11.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.a12.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.b12.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.a13.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.b13.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.a14.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.b14.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.a15.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log14x32.b15.json"
+    ],
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)"
+  }
+}

--- a/autoresearch/submissions/2026-07-20-packed-sampled-value-evaluation/verdict.json
+++ b/autoresearch/submissions/2026-07-20-packed-sampled-value-evaluation/verdict.json
@@ -1,0 +1,114 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "1b0be568ace8",
+  "repo_commit": "4dc26f00d743",
+  "predecessor_commit": "4dc26f00d743",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": false,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 3.58
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; byte-identity enforced per round"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "anchor not frozen; budgets inactive (G5 blocks judged)"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log10x8": {
+        "r": 0.961205,
+        "ci": [
+          0.944054,
+          1.000586
+        ],
+        "rounds": 15,
+        "a_median_ms": 1.64475,
+        "b_median_ms": 1.582125
+      }
+    },
+    "R_geomean": 0.961205,
+    "theta": 0.01,
+    "aa_dispersion": null,
+    "significant": false,
+    "neutral": false
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.b10.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.a11.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.b11.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.a12.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.b12.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.a13.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.b13.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.a14.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.b14.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.a15.json",
+      "/Users/theodorepender/code/auto-researching/ws-architecture-next/autoresearch/.runs/latest/wf_log10x8.b15.json"
+    ],
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)"
+  }
+}

--- a/src/prover/poly/circle/point_evaluation.zig
+++ b/src/prover/poly/circle/point_evaluation.zig
@@ -37,6 +37,163 @@ pub inline fn evalAtPointIterative(
     return pending[log_size];
 }
 
+const PackedM31 = m31.PackedM31;
+
+const PackedCM31 = struct {
+    a: PackedM31,
+    b: PackedM31,
+};
+
+const PackedQM31 = struct {
+    c0: PackedCM31,
+    c1: PackedCM31,
+};
+
+inline fn addPackedCM31(lhs: PackedCM31, rhs: PackedCM31) PackedCM31 {
+    return .{
+        .a = m31.addPacked(lhs.a, rhs.a),
+        .b = m31.addPacked(lhs.b, rhs.b),
+    };
+}
+
+inline fn subPackedCM31(lhs: PackedCM31, rhs: PackedCM31) PackedCM31 {
+    return .{
+        .a = m31.subPacked(lhs.a, rhs.a),
+        .b = m31.subPacked(lhs.b, rhs.b),
+    };
+}
+
+inline fn mulPackedCM31(lhs: PackedCM31, rhs: PackedCM31) PackedCM31 {
+    const ac = m31.mulPacked(lhs.a, rhs.a);
+    const bd = m31.mulPacked(lhs.b, rhs.b);
+    const cross = m31.mulPacked(
+        m31.addPacked(lhs.a, lhs.b),
+        m31.addPacked(rhs.a, rhs.b),
+    );
+    return .{
+        .a = m31.subPacked(ac, bd),
+        .b = m31.subPacked(m31.subPacked(cross, ac), bd),
+    };
+}
+
+inline fn mulPackedCM31ByR(value: PackedCM31) PackedCM31 {
+    // (a + bi) * (2 + i) = (2a - b) + (a + 2b)i.
+    return .{
+        .a = m31.subPacked(m31.addPacked(value.a, value.a), value.b),
+        .b = m31.addPacked(value.a, m31.addPacked(value.b, value.b)),
+    };
+}
+
+inline fn addPackedQM31(lhs: PackedQM31, rhs: PackedQM31) PackedQM31 {
+    return .{
+        .c0 = addPackedCM31(lhs.c0, rhs.c0),
+        .c1 = addPackedCM31(lhs.c1, rhs.c1),
+    };
+}
+
+inline fn mulPackedQM31(lhs: PackedQM31, rhs: PackedQM31) PackedQM31 {
+    const ac = mulPackedCM31(lhs.c0, rhs.c0);
+    const bd = mulPackedCM31(lhs.c1, rhs.c1);
+    const cross = subPackedCM31(
+        subPackedCM31(
+            mulPackedCM31(
+                addPackedCM31(lhs.c0, lhs.c1),
+                addPackedCM31(rhs.c0, rhs.c1),
+            ),
+            ac,
+        ),
+        bd,
+    );
+    return .{
+        .c0 = addPackedCM31(ac, mulPackedCM31ByR(bd)),
+        .c1 = cross,
+    };
+}
+
+inline fn packedQM31FromBase(values: PackedM31) PackedQM31 {
+    const zero: PackedM31 = @splat(0);
+    return .{
+        .c0 = .{ .a = values, .b = zero },
+        .c1 = .{ .a = zero, .b = zero },
+    };
+}
+
+inline fn splatQM31(value: QM31) PackedQM31 {
+    const limbs = value.toM31Array();
+    return .{
+        .c0 = .{
+            .a = m31.splatPacked(limbs[0]),
+            .b = m31.splatPacked(limbs[1]),
+        },
+        .c1 = .{
+            .a = m31.splatPacked(limbs[2]),
+            .b = m31.splatPacked(limbs[3]),
+        },
+    };
+}
+
+/// Evaluates one native-width batch of independent coefficient polynomials at
+/// the same secure-field point. Each polynomial occupies one packed M31 lane;
+/// its carry-style reduction and field-operation order match
+/// `evalAtPointIterative` exactly.
+pub inline fn evalBatchAtPointIterative(
+    coefficient_batches: [m31.PACK_WIDTH][]const M31,
+    factors: []const QM31,
+    log_size: u32,
+) [m31.PACK_WIDTH]QM31 {
+    const expected_len = @as(usize, 1) << @intCast(log_size);
+    for (coefficient_batches) |coefficients| {
+        std.debug.assert(coefficients.len == expected_len);
+    }
+    std.debug.assert(factors.len == log_size);
+
+    if (log_size == 0) {
+        var constants: [m31.PACK_WIDTH]QM31 = undefined;
+        for (coefficient_batches, 0..) |coefficients, lane| {
+            constants[lane] = QM31.fromBase(coefficients[0]);
+        }
+        return constants;
+    }
+
+    var packed_factors: [circle.M31_CIRCLE_LOG_ORDER]PackedQM31 = undefined;
+    for (factors, 0..) |factor, factor_idx| {
+        packed_factors[factor_idx] = splatQM31(factor);
+    }
+
+    var pending: [circle.M31_CIRCLE_LOG_ORDER + 1]PackedQM31 = undefined;
+    for (coefficient_batches[0], 0..) |_, coeff_idx| {
+        var packed_coefficients: PackedM31 = undefined;
+        for (0..m31.PACK_WIDTH) |lane| {
+            packed_coefficients[lane] = coefficient_batches[lane][coeff_idx].v;
+        }
+        var value = packedQM31FromBase(packed_coefficients);
+        var level: usize = @as(usize, @intCast(@ctz(~coeff_idx)));
+        if (level > @as(usize, @intCast(log_size))) {
+            level = @as(usize, @intCast(log_size));
+        }
+        var merge_level: usize = 0;
+        while (merge_level < level) : (merge_level += 1) {
+            value = addPackedQM31(
+                pending[merge_level],
+                mulPackedQM31(value, packed_factors[merge_level]),
+            );
+        }
+        pending[level] = value;
+    }
+
+    const packed_result = pending[log_size];
+    var results: [m31.PACK_WIDTH]QM31 = undefined;
+    for (0..m31.PACK_WIDTH) |lane| {
+        results[lane] = QM31.fromU32Unchecked(
+            packed_result.c0.a[lane],
+            packed_result.c0.b[lane],
+            packed_result.c1.a[lane],
+            packed_result.c1.b[lane],
+        );
+    }
+    return results;
+}
+
 /// Fills the circle-basis factors for one secure-field point.
 pub fn fillEvalFactorsForPoint(
     point: CirclePointQM31,

--- a/src/prover/poly/circle/poly.zig
+++ b/src/prover/poly/circle/poly.zig
@@ -171,7 +171,24 @@ pub const CircleCoefficients = struct {
         var factor_at: usize = 0;
         for (0..point_count) |point_idx| {
             const point_factors = flat_factors[factor_at .. factor_at + log_size];
-            for (polys, out_batch) |poly, out| {
+            var poly_idx: usize = 0;
+            if (comptime m31.PACK_WIDTH > 1) {
+                while (poly_idx + m31.PACK_WIDTH <= polys.len) : (poly_idx += m31.PACK_WIDTH) {
+                    var coefficient_batches: [m31.PACK_WIDTH][]const M31 = undefined;
+                    for (0..m31.PACK_WIDTH) |lane| {
+                        coefficient_batches[lane] = polys[poly_idx + lane].coeffs;
+                    }
+                    const values = point_evaluation.evalBatchAtPointIterative(
+                        coefficient_batches,
+                        point_factors,
+                        log_size,
+                    );
+                    for (values, 0..) |value, lane| {
+                        out_batch[poly_idx + lane][point_idx] = value;
+                    }
+                }
+            }
+            for (polys[poly_idx..], out_batch[poly_idx..]) |poly, out| {
                 out[point_idx] = point_evaluation.evalAtPointIterative(
                     poly.coeffs,
                     point_factors,
@@ -523,7 +540,7 @@ test "prover poly circle poly: precomputed folded factors match scalar oracle" {
 test "prover poly circle poly: batched point evaluation matches scalar helper" {
     const alloc = std.testing.allocator;
     const log_size: u32 = 6;
-    const poly_count: usize = 5;
+    const poly_count: usize = m31.PACK_WIDTH + 1;
     const point_count: usize = 7;
 
     var prng = std.Random.DefaultPrng.init(0xd1a5_4e7b_11c2_39af);


### PR DESCRIPTION
# Evaluate sampled-value polynomials across native SIMD lanes

## Model and harness

Model: GPT-5 Codex. Harness: repo-resident `stwo-perf`, updated before research
to current `main` (`4dc26f00d743`). ReleaseFast on arm64 macOS, paired S3
time evaluations against the unchanged current-main predecessor for every
affected class. A reasoning-first sanitized transcript is attached as
`transcripts/session-01.md`.

## Hypothesis

PCS sampled-value evaluation applies the same secure-field point factors to
many independent circle-basis coefficient polynomials. The existing batched
helper shares factors but reduces one polynomial at a time, leaving native SIMD
lanes unused inside each worker. Packing independent polynomials into M31 lanes
should preserve each polynomial's exact carry-style merge order while removing
most scalar secure-field instructions across all three workloads.

## Changes

Added a lane-wise packed QM31 reduction for one native-width batch of
coefficient streams. `evalManyAtPointsWithFlatFactors` dispatches full batches
through it and retains the existing scalar evaluator for incomplete tails and
scalar targets. The existing batch-vs-scalar property test now covers one full
native batch plus a tail. Tree scheduling, point factors, field semantics,
coefficient order, transcript order, and protocol bytes are unchanged.

## Results

S1 on 32 degree-2^14 live-repo polynomials at one secure point: packed/scalar
wall ratio **0.3730**, 95% CI **[0.3674, 0.3738]**; instruction ratio **0.3201**
and cycle ratio **0.3730**. The packed kernel measured 72.52 versus 226.5
instructions per coefficient. Live arm64 disassembly contains the predicted
`umull/umull2.2d`, `uzp1.4s`, `add/sub/cmhi.4s`, and `st4.4s` operations.

Profiled sampled-value medians fell from 0.158 to 0.087 ms small, 1.745 to
0.711 ms wide, and 0.879 to 0.380 ms deep. Promotion-grade paired S3 results:

- `wf_log10x8` small: ratio **0.9612**, 95% CI **[0.9441, 1.0006]**, 15 rounds,
  1.645 to 1.582 ms; favorable but correctly recorded as not significant.
- `wf_log14x32` wide: ratio **0.9181**, 95% CI **[0.9099, 0.9246]**, 15 rounds,
  12.573 to 11.524 ms; significant improvement.
- `plonk_log14` deep: ratio **0.9430**, 95% CI **[0.9345, 0.9498]**, 15 rounds,
  8.608 to 8.131 ms; significant improvement.

Every timed proof verified and remained byte-identical. Fresh seven-sample
suite diagnostics retained proof SHA-256 values `91741aec...bea5700` small,
`57a7d291...0f3374` wide, and `d63a2c92...69dbaf` deep. The ReleaseFast prover
and native CPU product closures passed across 152 and 190 transitive Zig
sources respectively.

## Caveats

These are local claimed verdicts; the locked judge rerun remains authoritative.
The anchor is not frozen, so budgets and judged promotion remain inactive.
Mechanism telemetry is still pending in the harness; differential tests,
counter ratios, stage attribution, and live codegen provide the current
mechanism evidence. Small's measured stage improvement did not clear the
end-to-end confidence threshold, so no significance is claimed for that class.
