### PR TITLE
Enumerate bit-reversed FRI cosets linearly

### DIFF
--- a/autoresearch/submissions/2026-07-20-linear-fri-coset-walk/delta.json
+++ b/autoresearch/submissions/2026-07-20-linear-fri-coset-walk/delta.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "b275053b9c42",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/core/fri/folding.zig": "sha256:606882a5c48cde80df12e211518d0bfd1264690fe525530988a7035c634b3a9c"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "ab8fda201722ab95626cbbc2a84731524e41730cf16a71a7205bcb127b75ced0",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-20-linear-fri-coset-walk/note.md
+++ b/autoresearch/submissions/2026-07-20-linear-fri-coset-walk/note.md
@@ -1,0 +1,87 @@
+# Enumerate bit-reversed FRI cosets in linear group work
+
+## Model and harness
+
+Model: GPT-5 Codex. Harness: repo-resident `stwo-perf`, updated before research
+to current `main` at `b275053b9c42`. The change was measured in ReleaseFast on
+arm64 macOS with paired S3/time runs against the unchanged updated-main
+predecessor. A reasoning-first sanitized session transcript is attached.
+
+All four prior promoted notes, transcripts, and diffs were read before new
+profiling. Their packed quotient rows, resident/deeper Merkle scheduling,
+four-way FRI leaf cascade, and packed sampled-value evaluation are retained and
+treated as the starting frontier.
+
+## Hypothesis
+
+Both circle-to-line and line-to-line FRI folds filled inverse-coordinate
+workspaces by calling `domain.at(bitReverseIndex(i << 1, log_size))` for every
+output. Each indexed lookup reconstructed a circle-group point from the set
+bits of its index, repeating roughly logarithmic group work per coordinate.
+
+For `w = log_size - 1`, `bitrev_log_size(2*i) = bitrev_w(i)`, and bit reversal
+is self-inverse. A coset is already an arithmetic progression with a fixed
+group step. Walking it once in natural order and scattering point `j` to
+destination `bitrev_w(j)` must therefore produce the identical coordinate
+array with linear rather than `N log N` group work.
+
+The pinned upstream Rust CPU fold calls the same indexed lookup and explicitly
+labels it inefficient pending stored domain twiddles. The selected traversal
+uses only this repository's existing coset iterator and bit-reversal helper; no
+external implementation is copied.
+
+## Changes
+
+Added one private coordinate-filling helper in `src/core/fri/folding.zig`. It
+walks a circle coset through repeated addition of its fixed step and scatters
+either x or y coordinates through the existing bit-reversal permutation. Four
+duplicated indexed-generation loops now use it:
+
+- allocating and in-place line folds;
+- secure-slice and coordinate-column circle folds.
+
+The batch inversion inputs are byte-for-byte equivalent and remain in the same
+order. Inversion, butterfly arithmetic, alpha powers, evaluation ownership,
+Merkle hashing, transcript order, and protocol output are unchanged. A new
+differential test checks the traversal against independent indexed lookup for
+shifted line and circle cosets at every log size from the minimum through 15.
+
+## Results
+
+An S1 live-core ABBA profile at log size 14 measured the coset-walk candidate
+at 3.823 ns per coordinate versus 28.177 ns for indexed reconstruction. The
+baseline/candidate wall ratio was 7.3005 with 95% CI [7.1535, 7.4194]; the
+candidate used about 12.7% of the instructions and 13.6% of the cycles.
+
+Seven-sample profiled diagnostics showed the intended FRI stage moving from
+3.870 to 3.229 ms on wide and 3.804 to 3.177 ms on deep, about a 16.5% stage
+reduction. All fresh proofs retained the frontier digests and were mutually
+byte-identical.
+
+Paired S3 results, 15 rounds each, all with G1–G5 passing:
+
+- small `wf_log10x8`: ratio **0.9690**, 95% CI **[0.9507, 0.9824]**,
+  1.590 to 1.540 ms;
+- wide `wf_log14x32`: ratio **0.9408**, 95% CI **[0.9284, 0.9539]**,
+  11.412 to 10.752 ms;
+- deep `plonk_log14`: ratio **0.9189**, 95% CI **[0.9091, 0.9610]**,
+  8.108 to 7.456 ms.
+
+The three-class geometric ratio is approximately **0.9427**, a **5.73%** suite
+improvement before judge rerun. ReleaseFast core, prover, and native CPU product
+closures passed across 70, 152, and 190 transitive Zig sources respectively.
+
+## Caveats
+
+These are local claimed verdicts; the locked judge rerun is authoritative. The
+anchor remains unfrozen, so judged promotion and drift budgets are inactive.
+Native mechanism telemetry is still pending in the harness; the live counter
+ratio, exact stage reduction, source complexity change, shifted-domain
+differential test, and byte-identical proofs provide the current mechanism
+evidence.
+
+Metal was measured for applicability as requested, but the scored binary is
+compile-time CPU-only and rejects Metal options, so no Metal change can move
+this board. Full Metal System Trace was unavailable because the host has
+Command Line Tools rather than full Xcode; this did not affect CPU profiling or
+the paired verdicts.

--- a/autoresearch/submissions/2026-07-20-linear-fri-coset-walk/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-20-linear-fri-coset-walk/transcripts/session-01.md
@@ -1,0 +1,258 @@
+# Session 01 — frontier baseline and architecture search
+
+Date: 2026-07-20
+Model: GPT-5 Codex
+
+## Objective supplied by the researcher
+
+Drive the largest CPU or Metal optimization allowed by the autoresearch
+contract, starting with a local benchmark, learning from prior notes and
+transcripts, profiling hot paths, using architectural visualization and
+critical analysis, and submitting as soon as a significant verified solution
+exists.
+
+## Contract and initial decisions
+
+- Updated the repo-resident `stwo-perf` CLI/frontier before benchmarking. The
+  clean base advanced seven commits and now includes the promoted packed
+  sampled-value evaluation.
+- Read every unique in-repo skill guide. The scored task is specifically the
+  `core_cpu` end-to-end prover suite; Metal remains worth measuring for
+  applicability, but a Metal-only change cannot move the CPU board unless the
+  production CPU benchmark actually invokes it.
+- Kept updated `main` untouched as the paired predecessor and created this
+  worktree from it. Existing researcher worktrees and their untracked notes
+  were not modified.
+- The initial frontier reports approximately 2.379 ms small, 11.524 ms wide,
+  and 8.131 ms deep. These are ledger values, not trusted as this host's local
+  baseline; a fresh local full-suite run comes first.
+
+## Search policy
+
+The first design choice will be driven by end-to-end stage attribution and
+live-code counter/sample evidence. Existing submission notes, transcripts, and
+diffs will then be treated as prior experiments: reusable mechanisms will be
+combined only when their invariants compose, and rejected ideas will not be
+repeated without new evidence. Any algorithm replacement gets a formal
+problem-match brief before source edits. Constant-factor changes remain under
+the Zig/Metal profiling loop.
+
+## Fresh local suite baseline
+
+Ran the production `ReleaseFast` CPU proof binary on all three fixed workloads
+with ten warmups and three timed, verified samples per workload. Median prove
+times were:
+
+| class | workload | median prove time | proof digest stable |
+| --- | --- | ---: | --- |
+| small | wide Fibonacci 2^10 x 8 | 1.929 ms | yes |
+| wide | wide Fibonacci 2^14 x 32 | 11.582 ms | yes |
+| deep | Plonk 2^14 | 8.050 ms | yes |
+
+The worktree is intentionally dirty only because transcript capture began
+before timing, so the reports correctly label these as diagnostic rather than
+headline-eligible. The byte-identical proofs and local medians are still valid
+grounding evidence. Wide exposes the largest absolute time budget; deep is
+close enough that a shared prover-stage optimization would earn much more suite
+score than another workload-specific shortcut.
+
+## Prior-work synthesis and fresh attribution
+
+Read all four promoted notes and attached transcripts, then inspected their
+source diffs. The combined frontier already packs direct quotient rows, reuses
+the resident Merkle pool deeper into trees, extends four-way BLAKE2s leaf
+hashing down the FRI cascade, and evaluates batches of sampled polynomials in
+native lanes. Those mechanisms are the baseline rather than candidates to
+repeat.
+
+Seven-sample current-frontier stage profiles gave this residual map:
+
+```text
+stage median (ms)               small   wide   deep
+FRI quotient build + commit     0.807   3.870  3.804
+main trace commit               0.241   1.913  1.164
+composition evaluation          0.037   2.729  0.393
+sampled-value evaluation        0.080   0.712  0.369
+proof of work                   0.251   0.250  0.264
+```
+
+Wide composition evaluation is large but its workload recurrence is outside
+the editable surface. FRI is the largest editable common stage. A live stack
+sample also retained BLAKE2s, quotient execution, folding transforms, and
+worker waits as residuals; no single prior mechanism had disappeared, so the
+next target must remove work shared by the circle and line folds.
+
+## Metal applicability/design brief
+
+The Metal skill classified the alternative as compute-only. Device capability
+capture reported Apple M5 Max, 32 KiB maximum threadgroup memory, 1,024 maximum
+threads per threadgroup, and a roughly 55.7 GB recommended working set. The
+generic device runner measured a 1,048,576-element add at 0.0393 ms and about
+321 GB/s with a 256-thread group; a sweep peaked at 1,024 threads, 0.0378 ms
+and about 333 GB/s. This is a bandwidth-ceiling calibration, not prover
+evidence. Its sub-0.05 ms dispatch time also means submission economics matter
+for small kernels.
+
+The scored `native-proof-bench-cpu` is compiled against `CpuBackend` and rejects
+Metal options; neither the production Metal engine nor command queue is linked
+into this board. Therefore a Metal-only edit cannot affect the score, while
+adding an offload boundary would require locked build/product changes and a
+new backend identity. Whole-command Metal System Trace was attempted but is
+unavailable because the host has Command Line Tools rather than full Xcode.
+The selected architecture remains CPU, with no resource-lifetime or CPU/GPU
+ownership transition to prove.
+
+## Architecture visualization
+
+```text
+                         current FRI fold setup
+
+logical output i
+      |
+      +-- bit_reverse(i << 1)
+      |          |
+      |          +-- reconstruct circle point from index bits
+      |                     O(log N) group additions per point
+      v
+coordinate workspace --> batch inverse --> butterfly fold --> next evaluation
+
+                         selected traversal
+
+coset initial --(+ fixed step)--> P0, P1, P2, ...       O(1) each
+                                  |   |   |
+                                  +---+---+-- scatter at bit_reverse(j)
+                                               |
+                                               v
+coordinate workspace --> identical batch inverse --> identical butterfly fold
+```
+
+Only coordinate enumeration changes. Inversion order, field arithmetic,
+butterfly order, alpha powers, evaluation storage, transcript roots, and proof
+serialization remain unchanged.
+
+## Problem-match brief — bit-reversed coset enumeration
+
+Task and required semantics:
+Generate the x (line fold) or y (circle fold) coordinate corresponding to each
+bit-reversed even domain index. Output is the exact same M31 array in the exact
+same order; no approximation, randomness, or protocol change is allowed.
+
+Inputs, measured scale/provenance, encoding, and computational model:
+Power-of-two circle/line domains from the fixed FRI suite, primarily log sizes
+10–15, represented by an initial circle-group point and fixed step. Cost model
+is arm64 word-RAM plus M31 group arithmetic. The current live implementation
+calls `domain.at(bitReverseIndex(i << 1, log_size))` once per output.
+
+Constraints, promises, invariants, and exploitable structure:
+For `w = log_size - 1`, `bitrev_log_size(2*i) = bitrev_w(i)`. Bit reversal is
+self-inverse. A coset is an arithmetic progression in the circle group, so its
+natural sequence obeys `P[j+1] = P[j] + step`. The destination workspace is
+already writable scratch and can accept permutation scatters.
+
+Candidate matches, relationship, and evidence status:
+
+| candidate | relationship | guarantee/complexity | measured fit | risk |
+| --- | --- | --- | --- | --- |
+| independent indexed reconstruction | current exact baseline | derived `Theta(N log N)` group work | 28.177 ns/coordinate | none, slow |
+| natural coset walk + bit-reversal scatter | exact reformulation | sourced/derived `Theta(N)` group work | 3.823 ns/coordinate | cache scatter |
+| direct bit-reversed Gray/delta walk | exact specialized generator | `Theta(N)` and sequential writes | unmeasured | harder delta proof |
+| session-cached inverse/twiddle tables | preprocessing tradeoff | `Theta(N)` once, reuse later | potentially strong at S4 | lifecycle/RSS and min-rung expansion |
+
+Chosen canonical problem and exact variant:
+Linear-time generation of a power-of-two bit-reversal permutation while
+evaluating a group arithmetic progression. Bit reversal is the canonical FFT
+permutation; prior work establishes linear-time generation on a random-access
+machine. This instance additionally exploits an existing O(1)-step coset
+iterator.
+
+Project -> canonical mapping and solution recovery:
+Let `P(j) = initial + j*step`. The current output is
+`out[i] = coord(P(bitrev_w(i)))`. Natural iteration produces `P(j)` for
+`j=0..N-1`; writing it to `out[bitrev_w(j)]` recovers the current array because
+`bitrev_w(bitrev_w(i)) = i`.
+
+Complexity/limits, named parameters, and citations:
+Current `CirclePointIndex.toPoint` sums generator doubles for every set index
+bit, yielding `Theta(N*w)` group additions in the measured loop. The selected
+transfer uses `Theta(N)` group additions, `N` word bit reversals, and unchanged
+`Theta(N)` storage traffic. The pinned upstream Rust implementation labels the
+same indexed fold lookup inefficient and calls for stored domain twiddles:
+<https://github.com/starkware-libs/stwo/blob/a8fcf4bdde3778ae72f1e6cfe61a38e2911648d2/crates/stwo/src/prover/backend/cpu/fri.rs>.
+Hinze describes bit reversal as an FFT permutation with a linear-time
+random-access implementation: <https://doi.org/10.1017/S0956796800003701>.
+
+Prior algorithms, solvers, and implementations:
+The upstream pinned CPU fold is the same indexed baseline. Linear sequential,
+inductive/XOR, cache-oblivious, and table-based bit reversal are established
+families. The local code already supplies the natural-order coset iterator, so
+no external implementation or license-bearing code is copied.
+
+Selected transfer, integration boundary, and rejected alternatives:
+Use the local coset iterator and existing `bitReverseIndex` to fill only the two
+fold coordinate workspaces. Reject a direct Gray/delta bit-reversed iterator
+for this checkpoint because it adds a more delicate signed group-step proof for
+little measured upside over the already 7.3x candidate. Defer session caching
+because it touches S4 lifecycle ownership and increases retained memory.
+
+End-to-end prediction, crossover, and falsifier:
+S1 ABBA measured candidate/baseline wall ratio 0.1370 (the tool displayed the
+inverse baseline/candidate ratio 7.3005 with CI [7.1535, 7.4194]), instruction
+ratio 0.1266, and cycle ratio 0.1362. Per-coordinate savings are about 24.35 ns;
+a log-14 half-domain pass should save about 0.20 ms. Across the initial circle
+fold and geometric line-fold cascade, predict 0.3–0.8 ms or roughly 3–8%
+end-to-end on wide/deep. Falsifier: stage profiles fail to reduce FRI time or
+paired S3 confidence spans the 0.99 threshold.
+
+Correctness and benchmark plan:
+Property-test the iterator/scatter helper against indexed reconstruction for
+multiple log sizes, shifted cosets, and both x/y coordinates. Run the full
+ReleaseFast closure, byte-identical three-workload diagnostics, then paired S3
+for every class whose stage moves.
+
+Open uncertainty:
+Bit-reversal scatter locality may shrink the microbenchmark gain once batch
+inversion and fold arithmetic dominate. The exact share of coordinate
+enumeration inside the aggregate FRI stage remains to be measured after
+integration.
+
+## Implementation and outcome
+
+Implemented one private helper in `src/core/fri/folding.zig` and routed all four
+production coordinate-generation loops through it: allocating/in-place line
+folds and secure-slice/coordinate-column circle folds. The helper changes only
+how the exact coordinate array is generated. A property test compares x and y
+arrays with independent indexed reconstruction over shifted cosets for every
+supported test log size through 15.
+
+The first focused build passed the ReleaseFast core closure across 70
+transitive sources. Fresh candidate diagnostics kept the existing proof hashes
+for all three workloads. The target FRI stage moved as predicted:
+
+```text
+class   predecessor FRI ms   candidate FRI ms   reduction
+small          0.807                0.792          1.9%
+wide           3.870                3.229         16.6%
+deep           3.804                3.177         16.5%
+```
+
+The small stage share was much lower than wide/deep, but repository policy
+requires paired evidence for every moved class. All three official S3 ABBA
+runs cleared the 1% significance threshold over 15 rounds:
+
+```text
+class  ratio    95% CI              predecessor -> candidate median
+small  0.9690   [0.9507, 0.9824]     1.590 -> 1.540 ms
+wide   0.9408   [0.9284, 0.9539]    11.412 -> 10.752 ms
+deep   0.9189   [0.9091, 0.9610]     8.108 -> 7.456 ms
+```
+
+Every timed proof verified and remained byte-identical. The compounded
+three-class ratio is about 0.9427, or a 5.73% suite improvement. ReleaseFast
+prover and native CPU product closures then passed across 152 and 190
+transitive sources. Formatting and `git diff --check` also passed.
+
+No further optimization was mixed into this checkpoint. A direct delta/Gray
+bit-reversed iterator, retained session twiddles, AoS FRI layer ownership, and
+eight-message BLAKE interleaving remain distinct future experiments. The user
+requested submission as soon as a significant solution existed; with all
+three class CIs clear and the correctness closures green, packaging begins now.

--- a/autoresearch/submissions/2026-07-20-linear-fri-coset-walk/verdict-deep.json
+++ b/autoresearch/submissions/2026-07-20-linear-fri-coset-walk/verdict-deep.json
@@ -1,0 +1,114 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "24a1c5bf7b2b",
+  "repo_commit": "b275053b9c42",
+  "predecessor_commit": "b275053b9c42",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": false,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 1.58
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; byte-identity enforced per round"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "anchor not frozen; budgets inactive (G5 blocks judged)"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "plonk_log14": {
+        "r": 0.918897,
+        "ci": [
+          0.909088,
+          0.960975
+        ],
+        "rounds": 15,
+        "a_median_ms": 8.107667,
+        "b_median_ms": 7.456167
+      }
+    },
+    "R_geomean": 0.918897,
+    "theta": 0.01,
+    "aa_dispersion": null,
+    "significant": true,
+    "neutral": false
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.b10.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.a11.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.b11.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.a12.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.b12.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.a13.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.b13.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.a14.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.b14.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.a15.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/plonk_log14.b15.json"
+    ],
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)"
+  }
+}

--- a/autoresearch/submissions/2026-07-20-linear-fri-coset-walk/verdict-wide.json
+++ b/autoresearch/submissions/2026-07-20-linear-fri-coset-walk/verdict-wide.json
@@ -1,0 +1,114 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "24a1c5bf7b2b",
+  "repo_commit": "b275053b9c42",
+  "predecessor_commit": "b275053b9c42",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "wide",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": false,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 1.53
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; byte-identity enforced per round"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "anchor not frozen; budgets inactive (G5 blocks judged)"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log14x32": {
+        "r": 0.940832,
+        "ci": [
+          0.928361,
+          0.953856
+        ],
+        "rounds": 15,
+        "a_median_ms": 11.412042,
+        "b_median_ms": 10.752041
+      }
+    },
+    "R_geomean": 0.940832,
+    "theta": 0.01,
+    "aa_dispersion": null,
+    "significant": true,
+    "neutral": false
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.b10.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.a11.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.b11.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.a12.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.b12.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.a13.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.b13.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.a14.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.b14.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.a15.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log14x32.b15.json"
+    ],
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)"
+  }
+}

--- a/autoresearch/submissions/2026-07-20-linear-fri-coset-walk/verdict.json
+++ b/autoresearch/submissions/2026-07-20-linear-fri-coset-walk/verdict.json
@@ -1,0 +1,114 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "24a1c5bf7b2b",
+  "repo_commit": "b275053b9c42",
+  "predecessor_commit": "b275053b9c42",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": false,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 2.42
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; byte-identity enforced per round"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "anchor not frozen; budgets inactive (G5 blocks judged)"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log10x8": {
+        "r": 0.969013,
+        "ci": [
+          0.950699,
+          0.982411
+        ],
+        "rounds": 15,
+        "a_median_ms": 1.589833,
+        "b_median_ms": 1.539584
+      }
+    },
+    "R_geomean": 0.969013,
+    "theta": 0.01,
+    "aa_dispersion": null,
+    "significant": true,
+    "neutral": false
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.b10.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.a11.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.b11.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.a12.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.b12.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.a13.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.b13.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.a14.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.b14.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.a15.json",
+      "/Users/theodorepender/code/auto-researching/ws-gpt5-architecture/autoresearch/.runs/latest/wf_log10x8.b15.json"
+    ],
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)"
+  }
+}

--- a/src/core/fri/folding.zig
+++ b/src/core/fri/folding.zig
@@ -302,6 +302,38 @@ pub const FoldCircleWorkspace = struct {
     }
 };
 
+const CosetCoordinate = enum { x, y };
+
+/// Fills one coordinate of the first `out.len` coset points in bit-reversed
+/// order. FRI consumes even natural-domain indices in bit-reversed order, and
+/// for a `log_size`-bit index `bitReverse(i << 1)` is exactly the
+/// `(log_size - 1)`-bit reversal of `i`.
+///
+/// Walking the arithmetic-progression coset once avoids reconstructing every
+/// point independently from the set bits of its index. Bit reversal is an
+/// involution, so scattering natural point `j` to `bitReverse(j)` produces the
+/// same output order as gathering point `bitReverse(i)` for each output `i`.
+fn fillBitReversedCosetCoordinate(
+    out: []M31,
+    coset: circle.Coset,
+    comptime coordinate: CosetCoordinate,
+) void {
+    std.debug.assert(out.len != 0 and std.math.isPowerOfTwo(out.len));
+    std.debug.assert(out.len <= coset.size());
+
+    const log_len: u32 = @intCast(std.math.log2_int(usize, out.len));
+    var points = coset.iter();
+    var natural_index: usize = 0;
+    while (natural_index < out.len) : (natural_index += 1) {
+        const point = points.next() orelse unreachable;
+        const output_index = core_utils.bitReverseIndex(natural_index, log_len);
+        out[output_index] = switch (coordinate) {
+            .x => point.x,
+            .y => point.y,
+        };
+    }
+}
+
 pub fn foldLine(
     allocator: std.mem.Allocator,
     eval: []const QM31,
@@ -331,15 +363,10 @@ pub fn foldLineSingleStep(
     const x_values = workspace.x_values[0..folded_values.len];
     const inv_x_values = workspace.inv_x_values[0..folded_values.len];
 
-    const domain_log_size = domain.logSize();
-    var i: usize = 0;
-    while (i < folded_values.len) : (i += 1) {
-        // fold_shift=1 for single-step: each pair occupies 2 consecutive positions.
-        x_values[i] = domain.at(core_utils.bitReverseIndex(i << 1, domain_log_size));
-    }
+    fillBitReversedCosetCoordinate(x_values, domain.coset(), .x);
     try fields.batchInverseInPlace(M31, x_values, inv_x_values);
 
-    i = 0;
+    var i: usize = 0;
     while (i < folded_values.len) : (i += 1) {
         const inv_x = inv_x_values[i];
         var f0 = eval[i * 2];
@@ -411,14 +438,10 @@ fn foldLineInPlaceSingleStep(
     const x_values = workspace.x_values[0..folded_len];
     const inv_x_values = workspace.inv_x_values[0..folded_len];
 
-    const domain_log_size = domain.logSize();
-    var i: usize = 0;
-    while (i < folded_len) : (i += 1) {
-        x_values[i] = domain.at(core_utils.bitReverseIndex(i << 1, domain_log_size));
-    }
+    fillBitReversedCosetCoordinate(x_values, domain.coset(), .x);
     try fields.batchInverseInPlace(M31, x_values, inv_x_values);
 
-    i = 0;
+    var i: usize = 0;
     while (i < folded_len) : (i += 1) {
         const inv_x = inv_x_values[i];
         var f0 = eval[i * 2];
@@ -514,20 +537,14 @@ pub fn foldCircleIntoLineWithWorkspace(
     }
 
     const alpha_sq = alpha.square();
-    const fold_shift: std.math.Log2Int(usize) = @intCast(CIRCLE_TO_LINE_FOLD_STEP);
-    const domain_log_size = src_domain.logSize();
     try workspace.ensureCapacity(allocator, dst.len);
     const py_values = workspace.py_values[0..dst.len];
     const inv_py_values = workspace.inv_py_values[0..dst.len];
 
-    var i: usize = 0;
-    while (i < dst.len) : (i += 1) {
-        const p = src_domain.at(core_utils.bitReverseIndex(i << fold_shift, domain_log_size));
-        py_values[i] = p.y;
-    }
+    fillBitReversedCosetCoordinate(py_values, src_domain.half_coset, .y);
     try fields.batchInverseInPlace(M31, py_values, inv_py_values);
 
-    i = 0;
+    var i: usize = 0;
     while (i < dst.len) : (i += 1) {
         const inv_py = inv_py_values[i];
         var f0_px = src[i * 2];
@@ -554,20 +571,14 @@ pub fn foldCircleColumnsIntoLineWithWorkspace(
     }
 
     const alpha_sq = alpha.square();
-    const fold_shift: std.math.Log2Int(usize) = @intCast(CIRCLE_TO_LINE_FOLD_STEP);
-    const domain_log_size = src_domain.logSize();
     try workspace.ensureCapacity(allocator, dst.len);
     const py_values = workspace.py_values[0..dst.len];
     const inv_py_values = workspace.inv_py_values[0..dst.len];
 
-    var i: usize = 0;
-    while (i < dst.len) : (i += 1) {
-        const p = src_domain.at(core_utils.bitReverseIndex(i << fold_shift, domain_log_size));
-        py_values[i] = p.y;
-    }
+    fillBitReversedCosetCoordinate(py_values, src_domain.half_coset, .y);
     try fields.batchInverseInPlace(M31, py_values, inv_py_values);
 
-    i = 0;
+    var i: usize = 0;
     while (i < dst.len) : (i += 1) {
         const inv_py = inv_py_values[i];
         const left_idx = i * 2;
@@ -595,5 +606,40 @@ pub fn accumulateLine(layer_query_evals: []QM31, column_query_evals: []const QM3
     const alpha_sq = folding_alpha.square();
     for (layer_query_evals, 0..) |*curr, i| {
         curr.* = curr.*.mul(alpha_sq).add(column_query_evals[i]);
+    }
+}
+
+test "fri folding: coset walk matches indexed bit-reversed coordinates" {
+    const allocator = std.testing.allocator;
+
+    var line_log_size: u32 = 1;
+    while (line_log_size <= 15) : (line_log_size += 1) {
+        const base_coset = circle.Coset.halfOdds(line_log_size);
+        const shifted_coset = base_coset.shift(base_coset.step_size.mul(3));
+        const domain = try line.LineDomain.init(shifted_coset);
+        const output_len = domain.size() / 2;
+        const actual = try allocator.alloc(M31, output_len);
+        defer allocator.free(actual);
+
+        fillBitReversedCosetCoordinate(actual, domain.coset(), .x);
+        for (actual, 0..) |coordinate, i| {
+            const expected = domain.at(core_utils.bitReverseIndex(i << 1, line_log_size));
+            try std.testing.expect(coordinate.eql(expected));
+        }
+    }
+
+    var circle_log_size: u32 = 2;
+    while (circle_log_size <= 15) : (circle_log_size += 1) {
+        const base_half_coset = circle.Coset.halfOdds(circle_log_size - 1);
+        const shifted_half_coset = base_half_coset.shift(base_half_coset.step_size.mul(5));
+        const domain = circle_domain.CircleDomain.new(shifted_half_coset);
+        const actual = try allocator.alloc(M31, domain.size() / 2);
+        defer allocator.free(actual);
+
+        fillBitReversedCosetCoordinate(actual, domain.half_coset, .y);
+        for (actual, 0..) |coordinate, i| {
+            const expected = domain.at(core_utils.bitReverseIndex(i << 1, circle_log_size)).y;
+            try std.testing.expect(coordinate.eql(expected));
+        }
     }
 }


### PR DESCRIPTION
# Enumerate bit-reversed FRI cosets in linear group work

## Model and harness

Model: GPT-5 Codex. Harness: repo-resident `stwo-perf`, updated before research
to current `main` at `b275053b9c42`. The change was measured in ReleaseFast on
arm64 macOS with paired S3/time runs against the unchanged updated-main
predecessor. A reasoning-first sanitized session transcript is attached.

All four prior promoted notes, transcripts, and diffs were read before new
profiling. Their packed quotient rows, resident/deeper Merkle scheduling,
four-way FRI leaf cascade, and packed sampled-value evaluation are retained and
treated as the starting frontier.

## Hypothesis

Both circle-to-line and line-to-line FRI folds filled inverse-coordinate
workspaces by calling `domain.at(bitReverseIndex(i << 1, log_size))` for every
output. Each indexed lookup reconstructed a circle-group point from the set
bits of its index, repeating roughly logarithmic group work per coordinate.

For `w = log_size - 1`, `bitrev_log_size(2*i) = bitrev_w(i)`, and bit reversal
is self-inverse. A coset is already an arithmetic progression with a fixed
group step. Walking it once in natural order and scattering point `j` to
destination `bitrev_w(j)` must therefore produce the identical coordinate
array with linear rather than `N log N` group work.

The pinned upstream Rust CPU fold calls the same indexed lookup and explicitly
labels it inefficient pending stored domain twiddles. The selected traversal
uses only this repository's existing coset iterator and bit-reversal helper; no
external implementation is copied.

## Changes

Added one private coordinate-filling helper in `src/core/fri/folding.zig`. It
walks a circle coset through repeated addition of its fixed step and scatters
either x or y coordinates through the existing bit-reversal permutation. Four
duplicated indexed-generation loops now use it:

- allocating and in-place line folds;
- secure-slice and coordinate-column circle folds.

The batch inversion inputs are byte-for-byte equivalent and remain in the same
order. Inversion, butterfly arithmetic, alpha powers, evaluation ownership,
Merkle hashing, transcript order, and protocol output are unchanged. A new
differential test checks the traversal against independent indexed lookup for
shifted line and circle cosets at every log size from the minimum through 15.

## Results

An S1 live-core ABBA profile at log size 14 measured the coset-walk candidate
at 3.823 ns per coordinate versus 28.177 ns for indexed reconstruction. The
baseline/candidate wall ratio was 7.3005 with 95% CI [7.1535, 7.4194]; the
candidate used about 12.7% of the instructions and 13.6% of the cycles.

Seven-sample profiled diagnostics showed the intended FRI stage moving from
3.870 to 3.229 ms on wide and 3.804 to 3.177 ms on deep, about a 16.5% stage
reduction. All fresh proofs retained the frontier digests and were mutually
byte-identical.

Paired S3 results, 15 rounds each, all with G1–G5 passing:

- small `wf_log10x8`: ratio **0.9690**, 95% CI **[0.9507, 0.9824]**,
  1.590 to 1.540 ms;
- wide `wf_log14x32`: ratio **0.9408**, 95% CI **[0.9284, 0.9539]**,
  11.412 to 10.752 ms;
- deep `plonk_log14`: ratio **0.9189**, 95% CI **[0.9091, 0.9610]**,
  8.108 to 7.456 ms.

The three-class geometric ratio is approximately **0.9427**, a **5.73%** suite
improvement before judge rerun. ReleaseFast core, prover, and native CPU product
closures passed across 70, 152, and 190 transitive Zig sources respectively.

## Caveats

These are local claimed verdicts; the locked judge rerun is authoritative. The
anchor remains unfrozen, so judged promotion and drift budgets are inactive.
Native mechanism telemetry is still pending in the harness; the live counter
ratio, exact stage reduction, source complexity change, shifted-domain
differential test, and byte-identical proofs provide the current mechanism
evidence.

Metal was measured for applicability as requested, but the scored binary is
compile-time CPU-only and rejects Metal options, so no Metal change can move
this board. Full Metal System Trace was unavailable because the host has
Command Line Tools rather than full Xcode; this did not affect CPU profiling or
the paired verdicts.
