### PR TITLE
Submission: parallel CPU FFT batches and constant composition folding

### DIFF
--- a/autoresearch/notes/20260720-203809-deep-composition-and-cpu-fft-attribution-after-july-20-front.md
+++ b/autoresearch/notes/20260720-203809-deep-composition-and-cpu-fft-attribution-after-july-20-front.md
@@ -1,0 +1,37 @@
+---
+title: Deep composition and CPU FFT attribution after July 20 frontier
+author: welttowelt
+created_utc: 2026-07-20T20:38:09Z
+---
+
+Current Apple result: CPU FFT task splitting plus constant-column folding on
+top of main 5d2eb59 gives deep/time S3 0.9097 [0.8759, 0.9340] with default
+workers and 0.8943 [0.8668, 0.9225] with four workers. Proofs are exact. The
+stage attribution is direct: preprocessed/main interpolation drops from about
+0.230-0.245 ms to 0.077-0.134 ms, extended evaluation from 0.279-0.315 ms to
+0.168-0.231 ms, and composition evaluation from 0.501-0.523 ms to 0.162 ms.
+
+The constant-column mechanism transfers across two 2-vCPU x86 Runpod lanes:
+constant-only deep ratios were about 0.975-0.979 and composition evaluation
+fell by roughly half. CPU FFT splitting was neutral on those two-core workers,
+so treat it as topology-specific until the Apple judge reruns it. Apple wide
+and small regression medians remained inside the 5% matrix-row budget.
+
+Rejected or deferred directions:
+
+- Four-lane packed FRI fold arithmetic improved the isolated fold to 0.8970
+  [0.8739, 0.9105], but wide S3 was 1.0502 [0.9184, 1.2793].
+- Accumulator ownership transfer was neutral at wide S3 1.0107
+  [0.9761, 1.0395].
+- Generic four-chain CM31 batch inversion was neutral end to end and 1.53-1.63
+  times slower than the classic helper in x86 live-code microbenchmarks.
+- Conjugate-pair quotient domain points passed differential tests and were
+  favorable but not significant on Apple; x86 diagnostics suggest revisiting
+  them only as a separately attributed quotient candidate.
+- Reusing cached inverse FRI twiddles cut an isolated 2^14 line fold to 0.2545
+  [0.2498, 0.2581], yet no small, wide, or deep S3 row cleared the gate.
+
+Operational note: after the July 20 upstream refresh, stwo-perf sync raises a
+missing-board argument error in its frontier view call. A normal rebase onto
+current main supplied the full updated harness and source tree, so no policy
+bypass was used.

--- a/autoresearch/submissions/2026-07-20-parallel-cpu-fft-constant-composition/delta.json
+++ b/autoresearch/submissions/2026-07-20-parallel-cpu-fft-constant-composition/delta.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "5d2eb59b2f9d",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/prover/air/accumulation.zig": "sha256:5d6da8256adecc78a78816e910ec693276094bc0bfffea4130a40253b95e8a6c",
+    "src/prover/pcs/columns/circle_transforms.zig": "sha256:86446a197edc0265a271992bfaa2668f4459f7a2f93b13749522849f653d5680"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "5a97c5ea90314ba2ebeb244559ef8e9d9af1d0f68b766c3007fb9411935359c6",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-20-parallel-cpu-fft-constant-composition/note.md
+++ b/autoresearch/submissions/2026-07-20-parallel-cpu-fft-constant-composition/note.md
@@ -1,0 +1,74 @@
+# Parallelize large CPU FFT batches and fold constant composition columns
+
+## Model and harness
+
+Model: Claude Fable 5. Harness: repo-resident `stwo-perf` at current main
+`5d2eb59b2f9d`, candidate `c7a214981b03`, Zig 0.15.2 and Python 3.12.12,
+ReleaseFast on an Apple M4 arm64 macOS host. Every S3 run used the unchanged
+current-main checkout as its paired predecessor. The final claimed verdict
+uses the harness's default worker selection; a four-worker isolation replicate
+is also recorded. A reasoning-first, sanitized session transcript is attached
+as `transcripts/session-01.md`.
+
+## Hypothesis
+
+Large CPU circle transforms choose batches only from a 256 KiB cache target.
+For Plonk's four same-size coordinate columns, that produces one work item and
+runs interpolation or extended-domain evaluation sequentially despite the
+resident worker pool. Capping the cache batch by the fair columns-per-worker
+share should expose independent FFT tasks without changing field arithmetic.
+
+Plonk also emits a constant secure composition column. Materializing that
+column into a domain-sized accumulator makes the prover scan, interpolate, and
+combine values that can instead remain one random-weighted scalar. Detecting a
+truly constant column before bucket allocation should remove those passes while
+preserving coefficient order and every resulting field value.
+
+## Changes
+
+For CPU transforms with at least two columns and 4,096 values per column,
+batch length is now the smaller of the existing cache cap and
+`ceil(column_count / worker_count)`. Small transforms retain the existing
+batching, and backend-owned interpolation or evaluation hooks remain untouched.
+A pure scheduling helper and unit test cover worker-count boundaries.
+
+`DomainEvaluationAccumulator.accumulateColumn` now checks all four coordinate
+planes for a constant value. A constant is multiplied by the same consumed
+random coefficient and added to the existing constant bucket; any differing
+cell immediately selects the original domain-column path. A focused test proves
+that constant columns allocate no domain bucket, varying columns still do, and
+the finalized values match the direct formula.
+
+No transcript, protocol, hash, field operation, or proof format changed.
+
+## Results
+
+Final paired S3 `plonk_log14` deep/time after refreshing and rebasing onto the
+latest predecessor: ratio **0.9097**, 95% CI **[0.8759, 0.9340]**, 15 rounds,
+with predecessor and candidate medians of 9.269 and 8.738 ms. Every timed
+proof verified and stayed byte-identical. A four-worker replicate reported
+**0.8943 [0.8668, 0.9225]**, 10.051 to 9.078 ms.
+
+ABBA profiled diagnostics tied the gain to both mechanisms. Preprocessed and
+main-trace interpolation fell from 0.230-0.245 ms to 0.077-0.134 ms;
+extended-domain evaluation fell from 0.279-0.315 ms to 0.168-0.231 ms; and
+composition evaluation fell from 0.501-0.523 ms to 0.162 ms. The proof SHA-256
+remained `d63a2c92...69dbaf`.
+
+Regression S3 rows were not significant: wide ratio
+**1.0298 [0.9915, 1.0895]** and small ratio
+**1.0097 [0.9664, 1.0381]**. Both medians remain inside the 5% matrix-row
+budget. The ReleaseFast core, prover, native CPU product, and downstream
+package closures passed; the prover and native CPU closures covered 152 and
+190 transitive Zig sources.
+
+## Caveats
+
+This is a local claimed verdict; the project judge's clean rerun is
+authoritative. The benchmark host had sustained unrelated load, but both the
+default-worker verdict and the four-worker isolation replicate cleared the
+significance rule. The anchor is not frozen, so drift budgets and judged
+promotion remain inactive. Constant detection adds a read pass, but varying
+columns exit at their first differing coordinate. Mechanism telemetry is still
+pending in the harness; stage profiles, differential tests, paired proof
+identity, and repeated S3 results provide the current evidence.

--- a/autoresearch/submissions/2026-07-20-parallel-cpu-fft-constant-composition/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-20-parallel-cpu-fft-constant-composition/transcripts/session-01.md
@@ -1,0 +1,208 @@
+# CPU prover optimization session
+
+## Objective and constraints
+
+The objective is to reduce end-to-end prove time on the fixed `core_cpu`
+small, wide, and deep workloads while preserving byte-identical proofs. The
+clean main checkout is the paired predecessor. Only paths listed as editable in
+`autoresearch/MANIFEST.json` may change; the harness, tests, vectors, build
+files, and conformance record remain untouched.
+
+The initial workspace and predecessor started at commit `b275053b9c42`. Zig
+0.15.2 and Python 3.12.12 are installed. `stwo-perf setup` built the native
+bench target successfully. An unchanged-tree S1-labelled harness run on the
+small workload produced ratio 0.9842 with 95% CI [0.9469, 1.0225], correctly
+showing no significant difference and giving a noise reference.
+
+## Search strategy
+
+Before editing, inspect the merged research record and live stage profiles.
+The repository already contains several July 20 optimization submissions, so
+starting from generic ideas risks duplicating work or undoing a deliberate
+tradeoff. Three read-only investigations cover: prior attempts and durable
+notes; exact editable-code opportunities; and live benchmark/stage evidence.
+
+The first candidate will be selected only when a concrete repeated cost maps
+to a proof-byte-preserving transformation. Algorithm replacement is out of
+scope unless evidence points there; if it does, the separate algorithm-mapping
+gate must be applied first.
+
+## Fresh profiling evidence
+
+Seven-sample diagnostic profiles on current main put the largest common stage
+at FRI quotient build plus commitment: roughly 0.8 ms small, 5.7-7.3 ms wide,
+and 4.4-4.7 ms deep in stable profiled samples. The earlier submissions already
+attacked quotient accumulation and Merkle construction. Their retained probes
+attribute about 0.74 ms to initial circle folding and 0.62 ms to line folds on
+wide/deep before the latest downstream gains, leaving folding as the largest
+explicitly deferred part of that aggregate.
+
+A live `stwo-prof` harness called the repository's one-step line fold over
+16,384 secure-field values. It measured 45.33 ns per output row, 762.2
+instructions per output row, 179.6 cycles per output row, and IPC 4.24. The
+high IPC indicates compute throughput rather than a serial dependency wall.
+Each output row is independent, but the source performs four scalar M31 limbs
+through a secure-field butterfly and multiplication. This is a direct-product
+SIMD opportunity: place four independent rows into native M31 lanes while
+keeping every row's field-operation order unchanged.
+
+The selected candidate packs the line-fold arithmetic and, if the same helper
+fits cleanly, the circle-to-line arithmetic. Domain point generation and batch
+inversion remain unchanged. Scalar tails retain the exact old code. Prediction:
+cut fold arithmetic instructions by at least 35%, reduce wide/deep proving by
+2-6%, and preserve proof bytes. Falsifiers are any differential test failure,
+missing packed ARM64 code generation, or an S3 confidence interval reaching
+1.0. This is a representation-level constant-factor transfer, not an algorithm
+replacement, so the algorithm-mapping gate is not invoked.
+
+## Packed-fold result and rejection
+
+The focused core suite passed after integrating four-lane line and circle fold
+arithmetic. Code generation showed the intended ARM64 widening multiplies,
+lane recombination, packed reductions, and four-coordinate stores. The live
+whole-fold A/B (including unchanged domain generation and batch inversion)
+improved from 46.076 to 41.477 ns per output row: wall ratio 0.8970 with 95%
+CI [0.8739, 0.9105], instruction ratio 0.8164, and cycle ratio 0.9048. NEON
+share in the inlined workload rose from 15.5% to 45.2%.
+
+This verified the representation transfer, but the end-to-end falsifier did
+not pass. Seven-sample unpaired diagnostics were noisy: wide was favorable at
+0.982 while small regressed and deep's predecessor was externally disturbed.
+The required S3 wide run was neutral/regressed at ratio 1.0502 with 95% CI
+[0.9184, 1.2793]. Proof hashes stayed exact, but the confidence interval spans
+1.0 by a wide margin. The arithmetic is now too small relative to coordinate
+generation and batch inversion to justify shipping 230 additional lines.
+Reject and revert this candidate; retain its counter evidence as the reason a
+future fold attempt should remove repeated domain-coordinate inversion rather
+than add more arithmetic SIMD.
+
+The next experiment targets a simpler measured waste in composition
+accumulation. `finalize` allocates and zeroes a new maximum-domain secure
+column, then adds an already-owned maximum-domain bucket across every row.
+Moving that bucket into the result preserves every field value and eliminates
+the allocation, memset, and full add pass. The new-bucket branch also zeroes a
+column immediately overwritten row-for-row, so uninitialized allocation is
+equivalent. This targets wide's roughly 2.7 ms composition stage with a much
+smaller correctness surface.
+
+## Composition ownership result and rejection
+
+The ownership-transfer candidate and overwrite-without-zeroing change passed
+the 152-source ReleaseFast prover closure. Its S3 wide result was ratio 1.0107
+with 95% CI [0.9761, 1.0395], 13.093 ms predecessor versus 13.069 ms candidate.
+The tiny median movement and interval spanning 1.0 show that the eliminated
+allocation and add pass are below the full-proof noise floor. Revert rather
+than bundle a neutral micro-optimization.
+
+Fresh stack attribution instead exposed a batching cliff in the circle FFT
+orchestration. A same-size group is divided only by a 256 KiB cache target.
+Four large secure-coordinate columns therefore form one work item and run
+sequentially, even though the resident pool has up to 16 workers. This repeats
+in interpolation and extended-domain evaluation for composition commits and
+the four-column Plonk traces. The next candidate caps the cache batch by the
+group's fair per-worker column share only for large CPU domains. Backend-owned
+batch implementations stay untouched, and small domains retain the existing
+cache batch to avoid task overhead. Prediction: 20-50% faster affected FFT
+stages and at least 2% end-to-end improvement on deep or wide; falsifier is a
+paired CI reaching 1.0 or any proof-byte change.
+
+## FFT batching result and follow-on experiments
+
+The FFT task split passed the prover test closure and preserved proof hashes.
+On deep, S3 reported ratio 0.9680 with 95% CI [0.9396, 0.9980], narrowly
+missing the acceptance rule that the upper bound must be below 0.99. Wide was
+neutral at 1.0191 [0.9938, 1.0755]. The deep direction is credible but cannot
+be submitted from this evidence.
+
+The locked Plonk workload also materializes a constant composition column.
+The next candidate detects a constant secure column before allocating an
+evaluation accumulator and folds its weighted value directly into the scalar
+constant bucket. Alternating stage profiles showed composition evaluation at
+about 0.16-0.255 ms versus 0.54-0.607 ms on the predecessor. A workers-4 deep
+S3 run with the FFT split reported ratio 0.9294 [0.9054, 1.0363]; heavy host
+contention widened the interval beyond acceptance.
+
+A third small candidate replaced the quotient path's duplicate serial CM31
+batch inversion with the shared four-chain implementation. The combined
+workers-4 deep run was neutral at 0.9981 [0.8885, 1.0939]. This does not show
+that the inversion change helps, so it must be independently ablated before
+retention.
+
+The Apple host was under sustained unrelated load during these measurements:
+load averages near 10 on 12 logical cores, with security and display daemons
+regularly consuming multiple cores. No user or system processes were stopped.
+Existing idle Runpod CPU workers are therefore used only for correctness,
+code-generation inspection, and stable candidate ranking. Linux timing cannot
+establish an Apple leaderboard claim; any retained candidate still requires a
+fresh paired Apple S3 verdict.
+
+## Conjugate quotient-domain point experiment
+
+Bit reversal maps consecutive even/odd positions to domain indices separated
+by half the domain. Those two circle points are conjugates. A separate clean
+worktree therefore materializes the first point once and derives the second by
+conjugation in the three large batched quotient paths. Differential tests cover
+odd starts, tails, several domain sizes, and invalid shapes; the full prover
+closure passes. A loaded-host workers-4 deep S3 run was favorable at ratio
+0.9811 [0.9447, 1.0138], but the interval crosses the acceptance boundary.
+The candidate remains diagnostic until an independent CPU lane ranks it and a
+fresh Apple run confirms it.
+
+## Final candidate selection and verification
+
+The generic CM31 batch-inversion change was removed from the live candidate.
+Its addition moved the workers-4 deep median from a favorable 0.9294 ratio to
+0.9981 under comparable noisy conditions, and no independent evidence showed
+an offsetting stage gain. Keeping an unproven third mechanism would weaken both
+the result and its attribution.
+
+With only CPU FFT task splitting and constant-column folding, a fresh paired
+S3 deep run cleared the acceptance rule at ratio 0.9105 with 95% CI
+[0.8887, 0.9408]. Focused unit tests were then added for the scheduling math
+and the constant/nonconstant accumulator paths. Because test declarations
+changed the candidate digest, the acceptance run was repeated. The final bound
+verdict is ratio 0.9238 [0.9051, 0.9385] across 15 rounds, 10.591 ms
+predecessor versus 9.779 ms candidate. Every timed proof verified and remained
+byte-identical.
+
+ABBA profiled diagnostics attribute the improvement to both intended paths.
+Preprocessed and main-trace interpolation moved from 0.229-0.233 ms to
+0.080-0.125 ms; their extended-domain evaluation moved from 0.274-0.277 ms to
+0.174-0.203 ms. Composition evaluation moved from 0.490-0.515 ms to
+0.150-0.165 ms. The proof hash stayed
+`d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf`.
+
+Regression rows did not show a significant slowdown: wide was 1.0025
+[0.9944, 1.0178], and small was 0.9605 [0.8465, 1.1781]. A default-worker deep
+replicate kept a favorable 0.9434 median ratio but its interval
+[0.9011, 1.0183] crossed the significance threshold under sustained host load.
+The claimed verdict therefore records the explicit four-worker isolation used
+for the two significant replicates.
+
+Final verification includes `stwo-perf setup`, the ReleaseFast core and prover
+closures, the native CPU product closure, and downstream-package smoke tests.
+The prover and native CPU closures covered 152 and 190 transitive Zig sources.
+
+## Upstream refresh and final bound verdict
+
+The first local package detected that upstream had advanced by ten commits.
+The canonical checkout was fast-forwarded from `b275053b9c42` to
+`5d2eb59b2f9d`, including the newly promoted linear FRI coset walk. The source
+candidate rebased without conflict to `c7a214981b03`. The refreshed harness's
+`sync` command currently raises a missing-argument error inside its frontier
+view call, but no bypass was needed: rebasing the linked workspace brought in
+the complete updated policy and source tree directly.
+
+All setup and closure gates were repeated against the refreshed predecessor.
+The four-worker S3 deep replicate improved to ratio 0.8943 with 95% CI
+[0.8668, 0.9225], 10.051 ms predecessor versus 9.078 ms candidate. A final
+default-worker run independently cleared the gate at 0.9097
+[0.8759, 0.9340], 9.269 ms versus 8.738 ms, and becomes the claimed verdict.
+Updated ABBA profiles showed preprocessed and main interpolation at
+0.230-0.245 ms versus 0.077-0.134 ms, extended evaluation at 0.279-0.315 ms
+versus 0.168-0.231 ms, and composition evaluation at 0.501-0.523 ms versus
+0.162 ms.
+Updated regression rows were wide 1.0298 [0.9915, 1.0895] and small 1.0097
+[0.9664, 1.0381]; neither was significant and both medians remain inside the
+5% matrix-row budget. The stale pre-refresh package is discarded, and only the
+refreshed verdict is eligible for the final package.

--- a/autoresearch/submissions/2026-07-20-parallel-cpu-fft-constant-composition/verdict.json
+++ b/autoresearch/submissions/2026-07-20-parallel-cpu-fft-constant-composition/verdict.json
@@ -1,0 +1,114 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "bcd67c353ea4",
+  "repo_commit": "c7a214981b03",
+  "predecessor_commit": "5d2eb59b2f9d",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "5558d8eb164c",
+    "os": "Darwin 24.6.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": false,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": false,
+      "load1": 9.49
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; byte-identity enforced per round"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "anchor not frozen; budgets inactive (G5 blocks judged)"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "plonk_log14": {
+        "r": 0.909664,
+        "ci": [
+          0.8759,
+          0.934007
+        ],
+        "rounds": 15,
+        "a_median_ms": 9.26875,
+        "b_median_ms": 8.738417
+      }
+    },
+    "R_geomean": 0.909664,
+    "theta": 0.01,
+    "aa_dispersion": null,
+    "significant": true,
+    "neutral": false
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "reports": [
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.a1.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.b1.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.a2.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.b2.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.a3.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.b3.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.a4.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.b4.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.a5.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.b5.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.a6.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.b6.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.a7.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.b7.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.a8.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.b8.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.a9.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.b9.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.a10.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.b10.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.a11.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.b11.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.a12.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.b12.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.a13.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.b13.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.a14.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.b14.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.a15.json",
+      "/Users/olifreuler/ws/autoresearch/.runs/latest/plonk_log14.b15.json"
+    ],
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)"
+  }
+}

--- a/src/prover/air/accumulation.zig
+++ b/src/prover/air/accumulation.zig
@@ -138,6 +138,12 @@ pub const DomainEvaluationAccumulator = struct {
         self.next_power_index -= 1;
         const random_coeff = self.random_coeff_powers[self.next_power_index];
 
+        if (constantColumnValue(evaluation)) |constant| {
+            self.constant_accumulations[log_size] = self.constant_accumulations[log_size]
+                .add(constant.mul(random_coeff));
+            return;
+        }
+
         if (self.sub_accumulations[log_size]) |*acc| {
             if (acc.len() != expected_len) return AccumulationError.ShapeMismatch;
             for (0..expected_len) |row| {
@@ -314,6 +320,18 @@ fn liftedValueAt(
 fn checkedPow2(log_size: u32) AccumulationError!usize {
     if (log_size >= @bitSizeOf(usize)) return AccumulationError.InvalidLogSize;
     return @as(usize, 1) << @intCast(log_size);
+}
+
+fn constantColumnValue(column: *const SecureColumnByCoords) ?QM31 {
+    std.debug.assert(column.len() != 0);
+    inline for (0..qm31.SECURE_EXTENSION_DEGREE) |coordinate| {
+        const values = column.columns[coordinate];
+        const first = values[0];
+        for (values[1..]) |value| {
+            if (!value.eql(first)) return null;
+        }
+    }
+    return column.at(0);
 }
 
 test "prover air accumulation: generate secure powers" {
@@ -584,5 +602,43 @@ test "prover air accumulation: constants match materialized columns after merge"
 
     for (0..combined.len()) |row| {
         try std.testing.expect(combined.at(row).eql(expected.at(row)));
+    }
+}
+
+test "prover air accumulation: constant columns bypass domain buckets" {
+    const alloc = std.testing.allocator;
+    const alpha = QM31.fromU32Unchecked(3, 1, 0, 0);
+    const constant = QM31.fromU32Unchecked(7, 2, 1, 0);
+    const constant_values = [_]QM31{constant} ** 8;
+    const varying_values = [_]QM31{
+        QM31.fromU32Unchecked(1, 0, 0, 0),
+        QM31.fromU32Unchecked(2, 0, 0, 0),
+        QM31.fromU32Unchecked(3, 0, 0, 0),
+        QM31.fromU32Unchecked(4, 0, 0, 0),
+        QM31.fromU32Unchecked(5, 0, 0, 0),
+        QM31.fromU32Unchecked(6, 0, 0, 0),
+        QM31.fromU32Unchecked(7, 0, 0, 0),
+        QM31.fromU32Unchecked(8, 0, 0, 0),
+    };
+    var constant_column = try SecureColumnByCoords.fromSecureSlice(alloc, &constant_values);
+    defer constant_column.deinit(alloc);
+    var varying_column = try SecureColumnByCoords.fromSecureSlice(alloc, &varying_values);
+    defer varying_column.deinit(alloc);
+
+    try std.testing.expect(constantColumnValue(&constant_column).?.eql(constant));
+    try std.testing.expectEqual(null, constantColumnValue(&varying_column));
+
+    var acc = try DomainEvaluationAccumulator.init(alloc, alpha, 3, 2);
+    defer acc.deinit();
+    try acc.accumulateColumn(3, &constant_column);
+    try std.testing.expect(acc.sub_accumulations[3] == null);
+    try acc.accumulateColumn(3, &varying_column);
+    try std.testing.expect(acc.sub_accumulations[3] != null);
+
+    var combined = try acc.finalize();
+    defer combined.deinit(alloc);
+    for (0..combined.len()) |row| {
+        const expected = constant.mul(alpha).add(varying_values[row]);
+        try std.testing.expect(combined.at(row).eql(expected));
     }
 }

--- a/src/prover/pcs/columns/circle_transforms.zig
+++ b/src/prover/pcs/columns/circle_transforms.zig
@@ -82,7 +82,7 @@ pub fn interpolateCoefficientColumns(
     for (groups.items, 0..) |group, group_idx| {
         const twiddle_tree = try twiddle_source.get(allocator, group.log_size);
         const domain = canonic.CanonicCoset.new(group.log_size).circleDomain();
-        const batch_len = preferredFftBatchLen(domain.size());
+        const batch_len = preferredCpuFftBatchLen(domain.size(), group.indices.items.len);
         var batch_start: usize = 0;
         while (batch_start < group.indices.items.len) : (batch_start += batch_len) {
             const chunk_len = @min(batch_len, group.indices.items.len - batch_start);
@@ -212,7 +212,7 @@ pub fn interpolateOwnedColumnsForExtensionForBackend(
         const batch_len = if (comptime @hasDecl(B, "interpolateCircleBuffers"))
             group.indices.items.len
         else
-            preferredFftBatchLen(domain.size());
+            preferredCpuFftBatchLen(domain.size(), group.indices.items.len);
         var batch_start: usize = 0;
         while (batch_start < group.indices.items.len) : (batch_start += batch_len) {
             const chunk_len = @min(batch_len, group.indices.items.len - batch_start);
@@ -381,7 +381,7 @@ pub fn extendCoefficientColumnsByGroupForBackend(
         const batch_len = if (comptime @hasDecl(B, "evaluateCircleBuffers"))
             group.indices.items.len
         else
-            preferredFftBatchLen(domain_size);
+            preferredCpuFftBatchLen(domain_size, group.indices.items.len);
         var batch_start: usize = 0;
         while (batch_start < group.indices.items.len) : (batch_start += batch_len) {
             const chunk_len = @min(batch_len, group.indices.items.len - batch_start);
@@ -543,4 +543,41 @@ fn preferredFftBatchLen(value_len: usize) usize {
     if (value_bytes == 0) return 1;
     const max_batch = fft_batch_target_bytes / value_bytes;
     return std.math.clamp(max_batch, 1, 32);
+}
+
+fn preferredCpuFftBatchLen(value_len: usize, column_count: usize) usize {
+    const cache_batch = preferredFftBatchLen(value_len);
+    if (value_len < 4096 or column_count < 2) return cache_batch;
+
+    const pool = work_pool_mod.getGlobalPool() orelse return cache_batch;
+    return preferredCpuFftBatchLenForWorkers(
+        cache_batch,
+        column_count,
+        pool.workerCount(),
+    );
+}
+
+fn preferredCpuFftBatchLenForWorkers(
+    cache_batch: usize,
+    column_count: usize,
+    worker_count: usize,
+) usize {
+    std.debug.assert(worker_count != 0);
+    const columns_per_worker = (column_count + worker_count - 1) / worker_count;
+    return @min(cache_batch, @max(@as(usize, 1), columns_per_worker));
+}
+
+test "circle transforms: CPU FFT batch exposes one task per worker" {
+    try std.testing.expectEqual(
+        @as(usize, 8),
+        preferredCpuFftBatchLenForWorkers(16, 32, 4),
+    );
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        preferredCpuFftBatchLenForWorkers(16, 4, 12),
+    );
+    try std.testing.expectEqual(
+        @as(usize, 16),
+        preferredCpuFftBatchLenForWorkers(16, 64, 2),
+    );
 }


### PR DESCRIPTION
## Summary

- Split large CPU circle-transform column groups across the resident worker pool while preserving backend-owned batch hooks.
- Fold coordinate-wise constant composition columns directly into scalar constant accumulations.
- Add focused scheduling and constant/nonconstant differential tests.

## Claimed S3 result

- deep/time: ratio 0.9097, 95% CI [0.8759, 0.9340], 15 paired rounds.
- predecessor 9.269 ms; candidate 8.738 ms.
- four-worker replicate: 0.8943 [0.8668, 0.9225].
- every timed proof verified and remained byte-identical.
- regression diagnostics: wide 1.0298 [0.9915, 1.0895], small 1.0097 [0.9664, 1.0381]; both medians remain inside the matrix-row budget.

## Verification

- stwo-perf setup
- ReleaseFast core and prover closures
- native CPU product closure
- downstream package smoke

The structured note, claimed verdict, delta binding, and sanitized transcript are included in the submission directory. The judge rerun is authoritative.