### PR TITLE
metal: batch sampled-value trees in one command epoch

### DIFF
--- a/autoresearch/notes/20260720-233710-one-metal-epoch-for-all-sampled-value-trees.md
+++ b/autoresearch/notes/20260720-233710-one-metal-epoch-for-all-sampled-value-trees.md
@@ -1,0 +1,124 @@
+---
+title: One Metal epoch for all sampled-value trees
+author: Teddy Pender
+created_utc: 2026-07-20T23:37:10Z
+---
+
+# Batch all sampled-value trees into one Metal command epoch
+
+## Model and harness
+
+GPT-5 Codex optimized clean candidate `f58bab07f67c` from current predecessor
+`bbb8c8823cca` on an Apple M5 Max running macOS 26.5.2. The production evidence
+uses the real ReleaseFast `native-proof-bench-metal` product, functional
+protocol, proof verification, and the source-JIT runtime. Zig embeds the MSL and
+macOS compiles it through `newLibraryWithSource`; initialization is excluded
+from timed samples. This change does not modify MSL, the Objective-C runtime,
+the C/shader ABI, pipeline identities, or the authenticated AOT path.
+
+The manifest still has no enabled `core_metal` scoring workload. The attached
+S3 verdicts are honest CPU no-regression controls; the Metal claim comes from
+the production-compatible Native Metal binary and is not mislabeled as a CPU
+speedup.
+
+## Hypothesis
+
+Fresh stage profiles found sampled-value evaluation at 1.355 ms on wide and
+2.111 ms on deep. Source and mechanism telemetry showed that one logical ragged
+result was evaluated as one synchronous Metal transaction per commitment tree:
+two command buffers/waits on small and wide, three on deep. Each call repacked
+descriptors, allocated six Metal buffers, dispatched basis construction and
+polynomial evaluation, waited, and copied a small result.
+
+The numerical tasks are independent after the CPU builds their point-factor
+plans. The canonical match is segmented/CSR-style flattening: translate every
+tree-local coefficient and output index through prefix offsets, concatenate all
+plans, execute the existing arbitrary-task kernels once, then scatter through
+the saved offsets. The prediction was one physical epoch, unchanged arithmetic
+and proof bytes, a 0.3--0.8 ms stage reduction, and a measurable end-to-end win.
+
+Apple recommends submitting the fewest command buffers that keep the GPU busy,
+because frequent submissions can introduce CPU/GPU synchronization stalls:
+https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/MTLBestPracticesGuide/CommandBuffers.html
+
+## Changes
+
+The generic PCS evaluator now exposes an optional backend batch hook after
+building the exact existing per-tree coefficient plans. The Metal runtime:
+
+- counts aggregate coefficient, factor, basis-task, evaluation-task, and output
+  storage;
+- assigns global coefficient and output prefixes while preserving tree-local
+  plan order;
+- calls the unchanged polynomial-evaluation FFI once; and
+- scatters exact QM31 outputs only after the existing terminal completion wait.
+
+The former single-tree runtime API remains as a one-element wrapper. All
+non-Metal backends retain the reference path. No asynchronous ownership, new
+feature requirement, numerical reassociation, or fallback was introduced. A
+two-tree device test gives both trees local column index zero and compares every
+batched output with scalar circle-polynomial evaluation, directly testing the
+prefix mapping that could otherwise alias trees.
+
+## Results
+
+Seven clean paired rounds per class alternated A-B / B-A process order. Every
+process used ten warmups and seven timed verified proofs. Statistics are the
+repository's round-median Hodges--Lehmann estimator with deterministic
+100,000-resample bootstrap intervals.
+
+| class | predecessor | candidate | B/A (95% CI) | latency reduction |
+| --- | ---: | ---: | ---: | ---: |
+| small `wf_log10x8` | 3.078 ms | 2.874 ms | 0.9187 [0.6642, 0.9289] | 8.13% |
+| wide `wf_log14x32` | 12.563 ms | 11.894 ms | 0.9517 [0.9357, 0.9678] | 4.83% |
+| deep `plonk_log14` | 8.668 ms | 7.603 ms | 0.8767 [0.8742, 0.8789] | 12.33% |
+
+The suite geometric-mean ratio is 0.9152: 8.48% less latency / 1.093x
+throughput. A separate symmetrically preconditioned seven-round small run
+measured 3.042 -> 2.825 ms, ratio 0.9225 [0.8290, 0.9442], confirming that the
+small win is about 7.8% after removing favorable baseline-first frequency-ramp
+outliers.
+
+The profiled sampled stage moved exactly as intended:
+
+| class | stage before -> after | physical sampled epochs |
+| --- | ---: | ---: |
+| wide | 1.355 -> 0.800 ms | 2 -> 1 |
+| deep | 2.111 -> 0.661 ms | 3 -> 1 |
+| small | candidate 0.377 ms | 2 -> 1 |
+
+Across the primary paired suite, all 294 timed proofs independently verified,
+were byte-identical, and matched across arms. Every report was audited for the
+fixed digest, verification count, mechanism count, and fallback count. CPU
+sampled-value fallbacks remained zero. Fixed proof hashes are:
+
+- small: `91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700`
+- wide: `57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374`
+- deep: `d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf`
+
+## Official controls and validation
+
+Fresh CPU S3 controls for all moved classes passed G1--G5, the pinned Rust
+oracle, all proof-digest checks, and all 12 regression guards. They were neutral
+as expected for a compile-time Metal-only hook: small 0.9896
+`[0.9724, 1.0009]`, wide 0.9924 `[0.9783, 1.0028]`, and deep 1.0009
+`[0.9901, 1.0083]`.
+
+Validation passes the full Zig tests, Native Metal product test, Metal compile
+gate, both authenticated-AOT tooling/probe suites, source conformance,
+formatting, diff checks, exact fixed proofs, and the new multi-tree device
+parity test. The broad Metal runtime suite is 80/83 with two expected skips and
+the same single resident-FRI parity failure documented on the untouched
+predecessor.
+
+## Caveats
+
+- No enabled Metal judge workload exists, so this cannot receive Metal board
+  credit until the harness exposes one.
+- Full Metal System Trace is unavailable because this host has Command Line
+  Tools rather than full Xcode. Real source-JIT execution, stage timers,
+  per-operation GPU timestamps, source wait topology, and mechanism telemetry
+  support the attribution.
+- The batch temporarily holds the sum rather than the maximum of two or three
+  trees' GPU-visible evaluator buffers. At the fixed log-14 shapes this is only
+  low-single-digit MiB against the device's 55.66 GB recommended working set.

--- a/autoresearch/submissions/2026-07-20-metal-batched-sampled-value-epoch/delta.json
+++ b/autoresearch/submissions/2026-07-20-metal-batched-sampled-value-epoch/delta.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "bbb8c8823cca",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/backends/metal/commit_backend.zig": "sha256:f6c91e087f542cf02d40b07256f8d938a33616da6980063168832e9e0a110a36",
+    "src/backends/metal/runtime.zig": "sha256:4486dcf0f819e79cfb50a83192db414ad61f6d9f57bd55d28afd4032aa4b31e5",
+    "src/backends/metal/runtime/polynomial_operations.zig": "sha256:72b64105a1dd94d5342be42fb01921b272f222265e76ef2b21c66415ca1a6d0f",
+    "src/backends/metal/tests/polynomial_eval.zig": "sha256:51d14a90448c100c0331069d95f352d6ced9f0f5fd7204845a1efcbce71c9f8c",
+    "src/prover/pcs/sampled_values.zig": "sha256:5feb07903a7078e48d79736c3edd31a93b23a1ea308aa68bbf24e2d96e135350"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "a78b84410b5863c5b7094df82e4dca413a7f62e8f748811caac9e603933032f4",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-20-metal-batched-sampled-value-epoch/note.md
+++ b/autoresearch/submissions/2026-07-20-metal-batched-sampled-value-epoch/note.md
@@ -1,0 +1,118 @@
+# Batch all sampled-value trees into one Metal command epoch
+
+## Model and harness
+
+GPT-5 Codex optimized clean candidate `f58bab07f67c` from current predecessor
+`bbb8c8823cca` on an Apple M5 Max running macOS 26.5.2. The production evidence
+uses the real ReleaseFast `native-proof-bench-metal` product, functional
+protocol, proof verification, and the source-JIT runtime. Zig embeds the MSL and
+macOS compiles it through `newLibraryWithSource`; initialization is excluded
+from timed samples. This change does not modify MSL, the Objective-C runtime,
+the C/shader ABI, pipeline identities, or the authenticated AOT path.
+
+The manifest still has no enabled `core_metal` scoring workload. The attached
+S3 verdicts are honest CPU no-regression controls; the Metal claim comes from
+the production-compatible Native Metal binary and is not mislabeled as a CPU
+speedup.
+
+## Hypothesis
+
+Fresh stage profiles found sampled-value evaluation at 1.355 ms on wide and
+2.111 ms on deep. Source and mechanism telemetry showed that one logical ragged
+result was evaluated as one synchronous Metal transaction per commitment tree:
+two command buffers/waits on small and wide, three on deep. Each call repacked
+descriptors, allocated six Metal buffers, dispatched basis construction and
+polynomial evaluation, waited, and copied a small result.
+
+The numerical tasks are independent after the CPU builds their point-factor
+plans. The canonical match is segmented/CSR-style flattening: translate every
+tree-local coefficient and output index through prefix offsets, concatenate all
+plans, execute the existing arbitrary-task kernels once, then scatter through
+the saved offsets. The prediction was one physical epoch, unchanged arithmetic
+and proof bytes, a 0.3--0.8 ms stage reduction, and a measurable end-to-end win.
+
+Apple recommends submitting the fewest command buffers that keep the GPU busy,
+because frequent submissions can introduce CPU/GPU synchronization stalls:
+https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/MTLBestPracticesGuide/CommandBuffers.html
+
+## Changes
+
+The generic PCS evaluator now exposes an optional backend batch hook after
+building the exact existing per-tree coefficient plans. The Metal runtime:
+
+- counts aggregate coefficient, factor, basis-task, evaluation-task, and output
+  storage;
+- assigns global coefficient and output prefixes while preserving tree-local
+  plan order;
+- calls the unchanged polynomial-evaluation FFI once; and
+- scatters exact QM31 outputs only after the existing terminal completion wait.
+
+The former single-tree runtime API remains as a one-element wrapper. All
+non-Metal backends retain the reference path. No asynchronous ownership, new
+feature requirement, numerical reassociation, or fallback was introduced. A
+two-tree device test gives both trees local column index zero and compares every
+batched output with scalar circle-polynomial evaluation, directly testing the
+prefix mapping that could otherwise alias trees.
+
+## Results
+
+Seven clean paired rounds per class alternated A-B / B-A process order. Every
+process used ten warmups and seven timed verified proofs. Statistics are the
+repository's round-median Hodges--Lehmann estimator with deterministic
+100,000-resample bootstrap intervals.
+
+| class | predecessor | candidate | B/A (95% CI) | latency reduction |
+| --- | ---: | ---: | ---: | ---: |
+| small `wf_log10x8` | 3.078 ms | 2.874 ms | 0.9187 [0.6642, 0.9289] | 8.13% |
+| wide `wf_log14x32` | 12.563 ms | 11.894 ms | 0.9517 [0.9357, 0.9678] | 4.83% |
+| deep `plonk_log14` | 8.668 ms | 7.603 ms | 0.8767 [0.8742, 0.8789] | 12.33% |
+
+The suite geometric-mean ratio is 0.9152: 8.48% less latency / 1.093x
+throughput. A separate symmetrically preconditioned seven-round small run
+measured 3.042 -> 2.825 ms, ratio 0.9225 [0.8290, 0.9442], confirming that the
+small win is about 7.8% after removing favorable baseline-first frequency-ramp
+outliers.
+
+The profiled sampled stage moved exactly as intended:
+
+| class | stage before -> after | physical sampled epochs |
+| --- | ---: | ---: |
+| wide | 1.355 -> 0.800 ms | 2 -> 1 |
+| deep | 2.111 -> 0.661 ms | 3 -> 1 |
+| small | candidate 0.377 ms | 2 -> 1 |
+
+Across the primary paired suite, all 294 timed proofs independently verified,
+were byte-identical, and matched across arms. Every report was audited for the
+fixed digest, verification count, mechanism count, and fallback count. CPU
+sampled-value fallbacks remained zero. Fixed proof hashes are:
+
+- small: `91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700`
+- wide: `57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374`
+- deep: `d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf`
+
+## Official controls and validation
+
+Fresh CPU S3 controls for all moved classes passed G1--G5, the pinned Rust
+oracle, all proof-digest checks, and all 12 regression guards. They were neutral
+as expected for a compile-time Metal-only hook: small 0.9896
+`[0.9724, 1.0009]`, wide 0.9924 `[0.9783, 1.0028]`, and deep 1.0009
+`[0.9901, 1.0083]`.
+
+Validation passes the full Zig tests, Native Metal product test, Metal compile
+gate, both authenticated-AOT tooling/probe suites, source conformance,
+formatting, diff checks, exact fixed proofs, and the new multi-tree device
+parity test. The broad Metal runtime suite is 80/83 with two expected skips and
+the same single resident-FRI parity failure documented on the untouched
+predecessor.
+
+## Caveats
+
+- No enabled Metal judge workload exists, so this cannot receive Metal board
+  credit until the harness exposes one.
+- Full Metal System Trace is unavailable because this host has Command Line
+  Tools rather than full Xcode. Real source-JIT execution, stage timers,
+  per-operation GPU timestamps, source wait topology, and mechanism telemetry
+  support the attribution.
+- The batch temporarily holds the sum rather than the maximum of two or three
+  trees' GPU-visible evaluator buffers. At the fixed log-14 shapes this is only
+  low-single-digit MiB against the device's 55.66 GB recommended working set.

--- a/autoresearch/submissions/2026-07-20-metal-batched-sampled-value-epoch/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-20-metal-batched-sampled-value-epoch/transcripts/session-01.md
@@ -1,0 +1,316 @@
+# Session 01 — continuing Metal autoresearch after the resident FRI cascade
+
+Date: 2026-07-21
+Model: GPT-5 Codex
+
+## Objective and process
+
+Continue the optimization loop for the requested multi-hour window: update the
+repo-resident CLI, benchmark the current merged frontier, profile and formalize
+the next bottleneck, implement an exact Metal architecture, gather paired
+evidence, package a transcript-bearing submission, open a PR, repair CI, merge
+only when green, and repeat.
+
+The canonical checkout and CLI were current at `bbb8c8823cca`, which contains
+the merged resident line-FRI cascade from PR #25. A fresh worktree and branch
+`autoresearch/metal-epoch2` were created from that exact recorded frontier and
+`stwo-perf setup` passed before source work.
+
+All five repository skills were read completely for this iteration. Algorithm
+matching will gate any changed algorithm; Metal profiling supplies device-time
+and submission evidence; Metal performance design supplies the resource,
+ownership, ABI, and synchronization proof; Zig profiling is retained for any
+host-side candidate; and this transcript is being captured before profiling or
+editing. The required compute common-pattern reference was also read in full.
+Render guidance is deliberately not loaded because the prover remains
+compute-only.
+
+## Untouched Native Metal baseline
+
+No production source had been edited when this baseline was captured. The real
+`native-proof-bench-metal` product was built in ReleaseFast and used the
+source-JIT runtime, functional protocol, ten warmups, seven timed proofs, and
+independent verification. Shader compilation and PSO initialization remain
+outside the sampled proof interval. All samples verified, stayed byte-identical
+within each run, reported `accelerated_without_fallbacks`, and used zero CPU
+fallbacks.
+
+| fixed class | median prove | median request | dispatches | FRI epochs | resident commits | proof SHA-256 |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| small, `wf_log10x8` | 6.351 ms | 6.555 ms | 19 | 1 | 12 | `91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700` |
+| wide, `wf_log14x32` | 12.614 ms | 13.588 ms | 23 | 1 | 16 | `57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374` |
+| deep, `plonk_log14` | 8.690 ms | 9.020 ms | 26 | 1 | 17 | `d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf` |
+
+The small samples drifted thermally from 7.48 to 4.51 ms, so its single-process
+median is grounding evidence only. Any verdict must use counterbalanced fresh
+processes. Wide and deep were substantially tighter.
+
+Three-sample profiled medians on the current frontier were:
+
+| stage | wide | deep |
+| --- | ---: | ---: |
+| main trace commit | 1.845 ms | 0.761 ms |
+| composition evaluation | 2.644 ms | 0.145 ms |
+| composition interpolate/split | 0.469 ms | 0.061 ms |
+| composition commit | 1.393 ms | 0.849 ms |
+| sampled-value evaluation | 1.355 ms | 2.111 ms |
+| FRI quotient/build/commit | 4.209 ms | 4.641 ms |
+| proof of work | 0.337 ms | 0.335 ms |
+| all decommit stages | 0.182 ms | 0.219 ms |
+
+FRI remains the largest common stage, but source inspection shows that the
+sampled-value stage contains an immediately removable synchronization defect:
+`evaluateCoefficientTreesWithBackend` calls the Metal runtime once per tree.
+Telemetry observes two physical sampled-value dispatch epochs on wide and three
+on deep, with no fallback. Each call independently packs descriptors, allocates
+six Metal buffers, creates a command buffer, dispatches basis construction and
+polynomial evaluation, waits for completion, and copies a small output.
+
+The device is an Apple M5 Max on macOS 26.5.2 with unified memory, 1,024 maximum
+threads per threadgroup, 32 KiB maximum threadgroup memory, and a 55.66 GB
+recommended working set. The product policy is portable Metal 3.1 with a macOS
+14 minimum. A Metal System Trace was attempted through `stwo-prof metal trace`
+and failed because this host has Command Line Tools rather than full Xcode;
+source-JIT execution remains valid through the macOS runtime compiler. A warmed
+Debug diagnostic exposed approximately 0.43 ms of device time per deep tree,
+while the three-call stage cost 3.78 ms in that diagnostic build. The absolute
+Debug timing is not a ReleaseFast verdict, but it confirms repeated host/device
+transaction overhead. A live-repo `stwo-prof zig` harness measured construction
+of sixteen log-14 point-factor sets at 4.912 microseconds, 62.7k instructions,
+14.95k cycles, and IPC 4.20, ruling factor math out as the millisecond-scale
+target.
+
+## Algorithmic problem match: segmented plan flattening
+
+**Task and required semantics.** Evaluate every retained coefficient
+polynomial at its tree-specific sampled points, then return the same ragged
+`tree -> column -> point` QM31 result. Polynomial coefficient order, point
+normalization, output order, exact M31/QM31 arithmetic, transcript absorption,
+proof bytes, and failure behavior are immutable.
+
+**Inputs and model.** The production fixed shapes contain two (wide) or three
+(deep) commitment trees. Each tree currently owns a homogeneous list of
+coefficient columns, cached point-factor plans, and output slices. GPU tasks are
+independent once those plans exist. The relevant model is a word-RAM host that
+constructs descriptors plus a bulk-synchronous accelerator: arithmetic work and
+bytes are important, but command-buffer submissions and blocking completion
+rounds are measured first-class costs.
+
+**Canonical match and mapping.** This is a ragged segmented-batch flattening
+problem, equivalently CSR-style local-to-global index translation over a static
+independent-task DAG. Tree-local coefficient and output indices become global
+indices by prefix offsets; the inverse mapping is retained for the final host
+scatter. The existing Metal basis/evaluation kernels already accept arbitrary
+task arrays, so no new numerical algorithm is needed.
+
+| candidate | relationship / guarantee | fit at measured scale | implementation and risk | decision |
+| --- | --- | --- | --- | --- |
+| Sequential per-tree calls | Exact baseline; O(T) submissions and waits | Measured T=2/3 | Existing, highest transaction cost | reject |
+| Asynchronous per-tree command buffers, one final wait | Exact if all buffers live; O(T) submissions, O(1) host waits | Removes waits but not allocations/submissions | More ownership/error plumbing and queue transactions | reject |
+| Persistent ICB or argument-buffer graph | Exact when fully prepared | Shapes repeat, but factors and coefficients change per proof | New feature gates and lifetime system; disproportionate for 2/3 trees | defer |
+| Global segmented descriptor batch | Exact; O(total tasks) work and O(1) submission/wait | Existing shader grid already models independent tasks | Prefix offsets plus one call through existing FFI | select |
+| Fuse sampling into later quotient shader | Potentially exact but transcript needs sampled values first | Could remove a larger boundary | Couples distinct kernels, output/readback and transcript ABI; much larger proof | defer |
+
+Apple's command-buffer guidance is **sourced**: submit the fewest command
+buffers possible without starving the GPU, because frequent submission can
+cause CPU/GPU synchronization stalls. `waitUntilCompleted` blocking the host is
+also **sourced** from the Metal API contract. The local-index prefix mapping,
+unchanged arithmetic count, and exact scatter are **derived** from this source
+tree. A 0.3--0.8 ms stage reduction and one physical sampling epoch are the
+**hypothesis**.
+
+Selected transfer: flatten all per-tree coefficient pointers, factor words,
+basis tasks, evaluation tasks, and output slots into one runtime call. Reject
+the change if any exact result differs, telemetry does not become one epoch,
+peak memory becomes material, or a counterbalanced ReleaseFast interval does
+not improve end-to-end proof time.
+
+Primary references:
+
+- Apple, *Metal Best Practices Guide: Command Buffers*:
+  https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/MTLBestPracticesGuide/CommandBuffers.html
+- Apple, `MTLCommandBuffer.waitUntilCompleted`:
+  https://developer.apple.com/documentation/metal/mtlcommandbuffer/waituntilcompleted%28%29
+- Apple, `MTLComputeCommandEncoder` (multiple compute commands per pass):
+  https://developer.apple.com/documentation/metal/mtlcomputecommandencoder
+
+## Metal architecture brief: one sampled-value epoch
+
+**Workload and target.** Compute-only Native Metal proving on the measured M5
+Max. The unit is all coefficient-polynomial samples in one proof. The oracle is
+the existing CPU evaluator plus independently verified, byte-identical fixed
+proof hashes.
+
+**Measurement boundary.** ReleaseFast, source-JIT initialization excluded, ten
+warmups, profiled diagnosis followed by uninstrumented counterbalanced A-B-B-A
+runs. Local source-JIT and authenticated AOT both consume the same unchanged MSL
+exports; this proposal changes neither shader source nor pipeline identity.
+
+**Measured bottleneck.** Wide spends 1.355 ms over two synchronous evaluator
+calls; deep spends 2.111 ms over three. Host factor planning is only
+microseconds. The existing runtime performs one basis and one evaluation
+dispatch per tree, and blocks after each command buffer.
+
+**Feature/fallback contract.** No new Metal feature is required. The existing
+device/runtime admission, shared/private choices, source-JIT/AOT paths, and CPU
+fallback policy remain unchanged. The generic PCS code uses the batched hook
+only when the backend declares it; all other backends keep the reference path.
+
+**Resource lifetime and storage.**
+
+| resource | producer -> consumer | storage | lifetime/change |
+| --- | --- | --- | --- |
+| coefficient columns | retained PCS trees -> eval kernel | existing host slices copied/no-copy wrapped into shared input | all trees held until terminal wait; bytes unchanged in aggregate |
+| point factors | CPU plan -> basis kernel | shared upload | concatenate all plans; aggregate bytes unchanged |
+| basis/eval task descriptors | CPU prefix flatten -> kernels | shared upload | one pair of buffers instead of T pairs |
+| basis values | basis -> eval | private | sum of per-tree basis counts in one buffer |
+| sampled outputs | eval -> CPU scatter/transcript | shared | sum of output counts; read only after terminal wait |
+
+Peak Metal transient bytes change from the largest tree's buffers to the sum of
+two or three trees' buffers during the call. At log 14 this is bounded by the
+already-live proof coefficients plus low-single-digit MiB of GPU-visible data,
+negligible against 55.66 GB. There is still only one proof in flight, so the
+in-flight multiplier is one.
+
+**Dependency and ownership graph.**
+
+```text
+current
+  CPU plan tree 0 -> allocate/copy -> GPU basis 0 -> GPU eval 0 -> WAIT -> scatter 0
+  CPU plan tree 1 -> allocate/copy -> GPU basis 1 -> GPU eval 1 -> WAIT -> scatter 1
+  CPU plan tree 2 -> allocate/copy -> GPU basis 2 -> GPU eval 2 -> WAIT -> scatter 2
+
+candidate
+  CPU build all plans -> prefix-map/pack once -> GPU basis(all)
+                                           -> GPU eval(all) -> one WAIT
+                                           -> exact segmented scatter
+```
+
+One command buffer owns every temporary Objective-C buffer through completion.
+Basis production precedes evaluation in command order; the existing separate
+compute encoders preserve that producer/consumer dependency. The host touches
+output only after successful completion. An allocation or Metal error returns
+through the existing error path; there is no partial result or silent fallback.
+
+**Binding, shader, and compilation plan.** Add one backend batch hook and a
+runtime host flattener. Reuse the existing C ABI and call it once; do not edit
+Objective-C, MSL, pipeline creation, threadgroup widths, math mode, or AOT
+manifests. Local tree indices are translated with checked prefix offsets while
+packing tasks. Final outputs are scattered with the retained offsets.
+
+**Budget and prediction.** Arithmetic work, task count, factor bytes,
+coefficient bytes, and output bytes are invariant. Sample-evaluator command
+buffers/waits and basis/eval dispatches should change 2 -> 1 on wide and 3 -> 1
+on deep. Metal buffer objects should fall from 12/18 to 6. Prediction: reduce
+the sampled stage by 0.3--0.8 ms and total wide/deep proof latency by roughly
+2--8%; small may be neutral because it has fewer columns and lower absolute
+work.
+
+**Correctness and validation.** Add a generic batching equivalence test with
+ragged tree shapes and duplicate point plans; run sampled-value/backend tests,
+the complete Metal suites and AOT contract probes, exact CPU-vs-Metal proof
+hashes, no-fallback telemetry, one-epoch mechanism telemetry, profiled stage
+medians, uninstrumented counterbalanced proof timings, and the official locked
+CPU S3 suite as a no-regression control.
+
+## Implementation and first falsification pass
+
+The selected architecture was implemented without changing Objective-C, MSL,
+the C ABI, shader exports, or compilation identity. The generic PCS evaluator
+builds every tree's existing cached plan and exposes one optional backend batch
+hook. The Metal runtime counts aggregate resources, assigns checked global
+coefficient/output prefixes, concatenates factors and basis/evaluation tasks,
+calls the existing evaluator FFI once, then scatters results through the saved
+prefixes. The old single-tree runtime entry point is retained as a one-element
+wrapper, and all non-Metal backends retain the sequential reference route.
+
+A two-tree device test gives both trees local column index zero, evaluates them
+in one epoch, and compares every result against scalar circle-polynomial
+evaluation. This specifically catches the dangerous mapping error where the
+second tree could otherwise read the first tree's coefficient or overwrite its
+output.
+
+The first ReleaseFast profiled candidate pass used ten warmups and three timed,
+verified proofs per class:
+
+| class | baseline sampled stage | candidate sampled stage | reduction | candidate proof | sampled epochs |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| small | not isolated in the initial profile | 0.377 ms | pending paired verdict | 6.639 ms | 1 |
+| wide | 1.355 ms | 0.800 ms | 41.0% | 12.162 ms | 2 -> 1 |
+| deep | 2.111 ms | 0.661 ms | 68.7% | 7.569 ms | 3 -> 1 |
+
+All nine candidate proofs independently verified, were byte-identical per
+class, matched the fixed hashes above, reported one physical sampled-value
+epoch, and used zero CPU fallback evaluations. This confirms the mechanism and
+exceeds the predeclared stage prediction. The single-process proof medians are
+still diagnostic: final performance evidence must compare fresh clean commits
+in counterbalanced process order.
+
+Validation at this freeze point passes `zig build test`, `test-native-metal`,
+`metal-check`, both authenticated-AOT tooling/probe suites, source conformance,
+formatting, and diff checks. The broad `metal-test` result is 80/83 with two
+expected skips and the same one resident-FRI parity failure documented on the
+untouched predecessor; the newly added batch test passes. Changed production
+owners remain below the 850-line ceiling (762 sampled-value scheduler, 823
+Metal backend, 619 polynomial runtime).
+
+## Counterbalanced end-to-end Metal verdict
+
+The source candidate was frozen, and clean `bbb8c8823cca` (A) and candidate
+`f58bab07f67c` (B) binaries were rebuilt in ReleaseFast. Seven round pairs per
+class alternated A-B / B-A process order. Every process performed ten warmups
+and seven timed verified proofs under the functional protocol. Ratios below
+use the repository's round-median Hodges--Lehmann estimator and a deterministic
+100,000-resample bootstrap interval.
+
+| Metal class | predecessor median | candidate median | B/A HL (95% CI) | latency reduction |
+| --- | ---: | ---: | ---: | ---: |
+| small, `wf_log10x8` | 3.078 ms | 2.874 ms | 0.9187 [0.6642, 0.9289] | 8.13% |
+| wide, `wf_log14x32` | 12.563 ms | 11.894 ms | 0.9517 [0.9357, 0.9678] | 4.83% |
+| deep, `plonk_log14` | 8.668 ms | 7.603 ms | 0.8767 [0.8742, 0.8789] | 12.33% |
+
+The three-class geometric-mean ratio is 0.9152: about 8.48% less latency and
+1.093x throughput. All seven per-round ratios favor the candidate in every
+class. Small's wide interval reflects two baseline-first low-frequency process
+outliers. A second seven-round experiment symmetrically ran an untimed
+ten-warmup process immediately before each measured arm; it independently
+measured small at 3.042 -> 2.825 ms, HL 0.9225 [0.8290, 0.9442], or 7.75% less
+latency. The claim therefore uses the more conservative interpretation: a
+repeatable roughly 7.8--8.1% small win, not the outlier-amplified tail.
+
+Across the primary paired suite, all 294 timed proofs independently verified,
+were byte-identical within each process, and matched across arms. A scripted
+audit checked every report's fixed hash, verification count, fallback counter,
+and mechanism counter. Sampled-value physical epochs were exactly 2 -> 1 on
+small/wide and 3 -> 1 on deep in every sample; CPU sampled-value fallbacks were
+zero throughout. The changed work is therefore the predicted transaction
+collapse, not reduced proof work or a backend escape.
+
+## Official harness controls and packaging correction
+
+The autoresearch manifest still enables only `core_cpu`, so the Metal result
+cannot honestly be recorded as a scored Metal board verdict. Fresh S3 CPU
+controls were run for all three moved classes against the current canonical
+frontier. Every verdict passed G1--G5, the pinned Rust oracle, cross-arm proof
+digest checks, request/RSS budgets, and all 12 impact-mapped regression guards:
+
+| CPU control | ratio (95% CI) | classification |
+| --- | ---: | --- |
+| small | 0.9896 [0.9724, 1.0009] | confirmed neutral |
+| wide | 0.9924 [0.9783, 1.0028] | confirmed neutral |
+| deep | 1.0009 [0.9901, 1.0083] | confirmed neutral |
+
+The first small control attempt correctly failed G2 because this working
+transcript had temporarily been committed at root-level `transcripts/`, which
+is outside the optimization allowlist. The transcript was removed from the
+source commit, preserved as an untracked sanitized attachment, and the control
+was rerun clean; G2 then passed. A second attempt stopped before verdict because
+the previous ignored Rust-oracle artifact already existed. Only that exact
+reproducible artifact was deleted, and the successful clean rerun followed.
+These packaging failures produced no claimed performance evidence.
+
+Immediately before packaging, the canonical updater confirmed that
+`bbb8c8823cca` remained current. The final source diff contains only the five
+allowed production/test files and does not include this root-level attachment;
+the submitter will copy the sanitized transcript into the schema-approved
+submission directory.

--- a/autoresearch/submissions/2026-07-20-metal-batched-sampled-value-epoch/verdict-deep.json
+++ b/autoresearch/submissions/2026-07-20-metal-batched-sampled-value-epoch/verdict-deep.json
@@ -1,0 +1,290 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "caef9f755204",
+  "repo_commit": "f58bab07f67c",
+  "predecessor_commit": "bbb8c8823cca",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 2.41
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.4676 vs targeted budget x1.02; regression guards 12/12 within budget; request ratio 1.0016 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "plonk_log14": {
+        "r": 1.00089,
+        "ci": [
+          0.990135,
+          1.008301
+        ],
+        "rounds": 11,
+        "a_median_ms": 6.741541,
+        "b_median_ms": 6.7405
+      }
+    },
+    "R_geomean": 1.00089,
+    "theta": 0.018278,
+    "aa_dispersion": 0.009139,
+    "significant": false,
+    "neutral": true
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {
+    "guard_blake_10x10": {
+      "r": 1.004655,
+      "ci": [
+        0.995737,
+        1.00765
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "4153acd6e32a98b9d240730062f7fa35e2e31eca915f01c179337f04d409cbd2"
+    },
+    "guard_blake_12x16": {
+      "r": 0.982272,
+      "ci": [
+        0.964807,
+        0.990514
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "70e516957d2d38ed78214bfda5b0b2bdfe41f1c93439fb68e124bfef096fbc9f"
+    },
+    "guard_plonk_14": {
+      "r": 0.996923,
+      "ci": [
+        0.989783,
+        1.006715
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf"
+    },
+    "guard_plonk_16": {
+      "r": 0.982572,
+      "ci": [
+        0.96951,
+        0.994688
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "cfb36bf17fb3526bf1bdd9401fb885fd91ca46b9982fee1ca5fad33a1d574b72"
+    },
+    "guard_poseidon_10": {
+      "r": 0.987741,
+      "ci": [
+        0.972597,
+        0.996219
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "af33240da8e7947362fdf7e78d306f2e11cb2e3df7e1b6f498a6e86ac3ae7b1b"
+    },
+    "guard_poseidon_13": {
+      "r": 0.998102,
+      "ci": [
+        0.996597,
+        0.999496
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "f196835da5d4a155c6311bafb44335c2863cc028879d69a7ae53b802321200f1"
+    },
+    "guard_sm_14": {
+      "r": 1.007574,
+      "ci": [
+        1.004064,
+        1.01479
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "488fadeeb4e5d76b6fc0a9c10ab258bab6673de8e912ae5de927561650920b37"
+    },
+    "guard_sm_16": {
+      "r": 1.010604,
+      "ci": [
+        0.997025,
+        1.034394
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "88ec35ee88a05ce0a5db4b6cb063f4cf7824ee65284db0908a62a9362879af73"
+    },
+    "guard_wf_14x32": {
+      "r": 0.989843,
+      "ci": [
+        0.97783,
+        1.013797
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374"
+    },
+    "guard_wf_16x64": {
+      "r": 1.019212,
+      "ci": [
+        0.998554,
+        1.031005
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "42086545b7a170c5868afcc390f83d964e06d528e2d1039420fc6bfd7a6aac74"
+    },
+    "guard_xor_14": {
+      "r": 0.996267,
+      "ci": [
+        0.984248,
+        1.00277
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "35bb35714e10888c786a71ccdfe31d2b9b4651c567fac5ba4c9543bc247cad80"
+    },
+    "guard_xor_16": {
+      "r": 1.010817,
+      "ci": [
+        1.006893,
+        1.015392
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "56163b8ea3d877b3b9bf15753b7c0175d4a6ead493640eef8210c59ba7e5215c"
+    }
+  },
+  "rust_oracle": [
+    {
+      "workload": "plonk_log14",
+      "verified": true,
+      "artifact_sha256": "ed64ff803f2e7ec8c5eeb81f520ee3cb228c6811795a53137092a8632f9e5e68"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "plonk_log14": {
+        "round_ratios": [
+          0.982954,
+          1.008301,
+          1.030314,
+          0.973024,
+          0.999846,
+          1.004148,
+          0.982335,
+          1.014609,
+          1.001546,
+          1.007245,
+          0.994925
+        ],
+        "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf",
+        "request_ratio": 1.001592,
+        "report_sha256s": [
+          "f44735ecffa9f4188f46998bee526ce7a0321e6b4e18a1727e8b94affc9b6b1c",
+          "8384ab866f96bbc293afe3307f8f25e39406128c4d74d65d08f26f40dd1a3662",
+          "b1d6f795cadd88d6227ffd86362750dfd7eaa1535bab83c74a795aca12c8f6b9",
+          "7347cdd16e07260305e1f9b14e48416e3a5f855125fb41cb4b4a70f4b285aa6c",
+          "6223e702f1d2708f06b9ed142040faf2170bc16c31c3dacfc0f40e3a465bbfcc",
+          "317cbb6637a1d8e286fd1babfd4efa75ac0ddaf1aac393414518febca0eb544c",
+          "35a3a481bbf05348ba0098d8b30f3ccb8867c1847bd7bccad6a1334c0bd20741",
+          "c1b4bb8c583ecefb63ad6bee64cc633dfe2d5bb4623a58728190284f9f08a391",
+          "b00bb3ebffba654fee2cb4d5ab243898281a0c83225d8f97db81c4ef7876cf19",
+          "649b6455c2cedff4b3ba399aaa276d1d76820257fa5925be5f1d7dae05425476",
+          "5c8b096a50ac9bbfa8b09f71672c6f83d2878d748f3beefa253162ce8c5e6034",
+          "93bc1638e8a62c320ca24ec5bf349d1f541e93c3d4e1acb93ffbf6352bfe563c",
+          "2dd785d5a8d00cf310c58953eb6a9b6b3412a7ab82dcac1f7a0a561870ca9281",
+          "71314899540970820861bd89edb37df53c9e172307062e8a80cd505fc3ca75fb",
+          "91cc9ddf7ef2afd54cc360f627c0b49f5290210437d5ea1cfb3f89c99c023bdf",
+          "376cb3fc2c0eccf9b33aa2e51e03d80f9b09c4f80a24369eb693531913f4e47f",
+          "e2985326e6d6cee8f4a9090a458033aeaac2a8c2779c73043083c9def9ad5574",
+          "01df1d2323e810773b67f35dff9d90e79a7930d7a709f12f0a778713e045c580",
+          "35df9c8033091ba762462da7aa89bbb5ed5930484740191cf426007c97facf7d",
+          "485f4eb445ecf85791c53e1e6c4db0cb9f9fcf1a5fac76401c2172b3d0637547",
+          "10ac8a482fd602979fd53e9151f2eaa8ca4b51902d016b51acd4d64db2b4b902",
+          "56d3e1220e62ce3e55cfb412ab8666296ce04e01c4aba2cd6aff239900bf3a91"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/plonk_log14.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/plonk_log14.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/plonk_log14.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/plonk_log14.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/plonk_log14.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/plonk_log14.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/plonk_log14.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/plonk_log14.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/plonk_log14.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/plonk_log14.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/plonk_log14.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/plonk_log14.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/plonk_log14.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/plonk_log14.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/plonk_log14.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/plonk_log14.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/plonk_log14.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/plonk_log14.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/plonk_log14.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/plonk_log14.b10.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/plonk_log14.a11.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/plonk_log14.b11.json"
+    ]
+  }
+}

--- a/autoresearch/submissions/2026-07-20-metal-batched-sampled-value-epoch/verdict-wide.json
+++ b/autoresearch/submissions/2026-07-20-metal-batched-sampled-value-epoch/verdict-wide.json
@@ -1,0 +1,270 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "caef9f755204",
+  "repo_commit": "f58bab07f67c",
+  "predecessor_commit": "bbb8c8823cca",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "wide",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 2.63
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.6116 vs targeted budget x1.02; regression guards 12/12 within budget; request ratio 0.9980 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log14x32": {
+        "r": 0.992418,
+        "ci": [
+          0.978301,
+          1.002816
+        ],
+        "rounds": 7,
+        "a_median_ms": 10.889625,
+        "b_median_ms": 10.798625
+      }
+    },
+    "R_geomean": 0.992418,
+    "theta": 0.02929,
+    "aa_dispersion": 0.014645,
+    "significant": false,
+    "neutral": true
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {
+    "guard_blake_10x10": {
+      "r": 0.998375,
+      "ci": [
+        0.994422,
+        1.003653
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "4153acd6e32a98b9d240730062f7fa35e2e31eca915f01c179337f04d409cbd2"
+    },
+    "guard_blake_12x16": {
+      "r": 0.997245,
+      "ci": [
+        0.986259,
+        1.016971
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "70e516957d2d38ed78214bfda5b0b2bdfe41f1c93439fb68e124bfef096fbc9f"
+    },
+    "guard_plonk_14": {
+      "r": 1.005411,
+      "ci": [
+        1.000815,
+        1.015371
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf"
+    },
+    "guard_plonk_16": {
+      "r": 1.002759,
+      "ci": [
+        0.967177,
+        1.014913
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "cfb36bf17fb3526bf1bdd9401fb885fd91ca46b9982fee1ca5fad33a1d574b72"
+    },
+    "guard_poseidon_10": {
+      "r": 1.002033,
+      "ci": [
+        0.996198,
+        1.006996
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "af33240da8e7947362fdf7e78d306f2e11cb2e3df7e1b6f498a6e86ac3ae7b1b"
+    },
+    "guard_poseidon_13": {
+      "r": 0.996445,
+      "ci": [
+        0.990833,
+        1.005838
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "f196835da5d4a155c6311bafb44335c2863cc028879d69a7ae53b802321200f1"
+    },
+    "guard_sm_14": {
+      "r": 1.001456,
+      "ci": [
+        0.999233,
+        1.007251
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "488fadeeb4e5d76b6fc0a9c10ab258bab6673de8e912ae5de927561650920b37"
+    },
+    "guard_sm_16": {
+      "r": 1.008349,
+      "ci": [
+        0.9959,
+        1.04124
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "88ec35ee88a05ce0a5db4b6cb063f4cf7824ee65284db0908a62a9362879af73"
+    },
+    "guard_wf_14x32": {
+      "r": 0.988032,
+      "ci": [
+        0.975922,
+        1.010411
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374"
+    },
+    "guard_wf_16x64": {
+      "r": 0.994878,
+      "ci": [
+        0.988495,
+        1.000284
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "42086545b7a170c5868afcc390f83d964e06d528e2d1039420fc6bfd7a6aac74"
+    },
+    "guard_xor_14": {
+      "r": 1.007928,
+      "ci": [
+        0.997619,
+        1.011703
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "35bb35714e10888c786a71ccdfe31d2b9b4651c567fac5ba4c9543bc247cad80"
+    },
+    "guard_xor_16": {
+      "r": 0.985454,
+      "ci": [
+        0.983069,
+        0.987333
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "56163b8ea3d877b3b9bf15753b7c0175d4a6ead493640eef8210c59ba7e5215c"
+    }
+  },
+  "rust_oracle": [
+    {
+      "workload": "wf_log14x32",
+      "verified": true,
+      "artifact_sha256": "d32393fe3b1f9abbc4795d87c3b3316e06111f014ec30f0635f13ec0ff0587f9"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "wf_log14x32": {
+        "round_ratios": [
+          0.964958,
+          0.990447,
+          1.002816,
+          1.010791,
+          0.982549,
+          0.991643,
+          1.001757
+        ],
+        "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374",
+        "request_ratio": 0.998011,
+        "report_sha256s": [
+          "9670f5e4ffcd38e0c8c17d7152f6971c0950b4e77b771eb9841465e4667eaf24",
+          "1e722c03e59003c05d691052c26bcab2a58bdd01a94d675681166096f656b39c",
+          "7841a5fdaba2dfeec20a4132ccb8fac2b87fb9b57c7087dcd3e874ae6498705b",
+          "7b1f1c6ad914d575b874de8128efd65f60e45797e78bc0ad011ce8ee1079c987",
+          "f5144d0a8c4c5430dc6b00ab3bc995aa61af068941954676ef6b08ed0970401d",
+          "8b13611c74a28f462f8e1184202abfb12781a0c1b1a007ca9cd87f0b81191611",
+          "2e2a590425c51cfa8d1a326a8811f1656c361bba87e8e0ee91bfc1384e1f8935",
+          "05b5176f1aa3d652202f6190ccd257a8206651275ebe5562ea36724504b577e3",
+          "1360f552a7e0d6beb349013aa9ac4893f8a525bf59e725a5ba09658382a86fc7",
+          "fb47be81b1c92c307a1dda586a23ba44514f5892d3a15f27889c6c6c3e00e708",
+          "cd693e35851eba2b443a53d33e584a8464d2d24844ba10e7677404d8f1d5c50b",
+          "9ec47d12e232b2fd0090caadbf0d90f50341880addaa9da61c77b0d07c38be48",
+          "410078844c65a5b0562ae53a2f7ba787709b57cee6fc432ea0ae7a766bbdbd95",
+          "deb02baad06780be5850e427f994b95363cae8758ca1fc4ba219bf0a91e1a6c3"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log14x32.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log14x32.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log14x32.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log14x32.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log14x32.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log14x32.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log14x32.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log14x32.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log14x32.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log14x32.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log14x32.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log14x32.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log14x32.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log14x32.b7.json"
+    ]
+  }
+}

--- a/autoresearch/submissions/2026-07-20-metal-batched-sampled-value-epoch/verdict.json
+++ b/autoresearch/submissions/2026-07-20-metal-batched-sampled-value-epoch/verdict.json
@@ -1,0 +1,270 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "caef9f755204",
+  "repo_commit": "f58bab07f67c",
+  "predecessor_commit": "bbb8c8823cca",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 2.18
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.5573 vs targeted budget x1.02; regression guards 12/12 within budget; request ratio 0.9902 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log10x8": {
+        "r": 0.989573,
+        "ci": [
+          0.972361,
+          1.000933
+        ],
+        "rounds": 7,
+        "a_median_ms": 1.571375,
+        "b_median_ms": 1.554416
+      }
+    },
+    "R_geomean": 0.989573,
+    "theta": 0.037308,
+    "aa_dispersion": 0.018654,
+    "significant": false,
+    "neutral": true
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {
+    "guard_blake_10x10": {
+      "r": 0.998126,
+      "ci": [
+        0.992175,
+        1.000732
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "4153acd6e32a98b9d240730062f7fa35e2e31eca915f01c179337f04d409cbd2"
+    },
+    "guard_blake_12x16": {
+      "r": 0.994693,
+      "ci": [
+        0.985393,
+        1.012071
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "70e516957d2d38ed78214bfda5b0b2bdfe41f1c93439fb68e124bfef096fbc9f"
+    },
+    "guard_plonk_14": {
+      "r": 0.995612,
+      "ci": [
+        0.979955,
+        1.004574
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf"
+    },
+    "guard_plonk_16": {
+      "r": 0.995484,
+      "ci": [
+        0.983117,
+        1.028734
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "cfb36bf17fb3526bf1bdd9401fb885fd91ca46b9982fee1ca5fad33a1d574b72"
+    },
+    "guard_poseidon_10": {
+      "r": 1.005792,
+      "ci": [
+        0.996304,
+        1.021357
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "af33240da8e7947362fdf7e78d306f2e11cb2e3df7e1b6f498a6e86ac3ae7b1b"
+    },
+    "guard_poseidon_13": {
+      "r": 0.99638,
+      "ci": [
+        0.992031,
+        1.002505
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "f196835da5d4a155c6311bafb44335c2863cc028879d69a7ae53b802321200f1"
+    },
+    "guard_sm_14": {
+      "r": 1.002131,
+      "ci": [
+        0.985472,
+        1.018073
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "488fadeeb4e5d76b6fc0a9c10ab258bab6673de8e912ae5de927561650920b37"
+    },
+    "guard_sm_16": {
+      "r": 0.997626,
+      "ci": [
+        0.991237,
+        1.014067
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "88ec35ee88a05ce0a5db4b6cb063f4cf7824ee65284db0908a62a9362879af73"
+    },
+    "guard_wf_14x32": {
+      "r": 1.027949,
+      "ci": [
+        1.00959,
+        1.039936
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374"
+    },
+    "guard_wf_16x64": {
+      "r": 1.005248,
+      "ci": [
+        0.977967,
+        1.021489
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "42086545b7a170c5868afcc390f83d964e06d528e2d1039420fc6bfd7a6aac74"
+    },
+    "guard_xor_14": {
+      "r": 1.011168,
+      "ci": [
+        0.993428,
+        1.037957
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "35bb35714e10888c786a71ccdfe31d2b9b4651c567fac5ba4c9543bc247cad80"
+    },
+    "guard_xor_16": {
+      "r": 1.002893,
+      "ci": [
+        0.993038,
+        1.014904
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "56163b8ea3d877b3b9bf15753b7c0175d4a6ead493640eef8210c59ba7e5215c"
+    }
+  },
+  "rust_oracle": [
+    {
+      "workload": "wf_log10x8",
+      "verified": true,
+      "artifact_sha256": "6a2250b56d5e10b6385e3a0f617ef4cee001b5279fd3bbef404a5ccb58ccd7ce"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "wf_log10x8": {
+        "round_ratios": [
+          0.972361,
+          0.994005,
+          0.981678,
+          0.993938,
+          0.971906,
+          1.014329,
+          1.000933
+        ],
+        "proof_digest": "91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700",
+        "request_ratio": 0.990239,
+        "report_sha256s": [
+          "ef3a22b31483d6401a1bb194e3c11ec2cde202681bababd93501c5f7e7b2a17c",
+          "eb0dbc7111ed07c31aaca76ce0e35a06d15df1f4bc4108ee0d98118e55122a6b",
+          "a1d011c50c037d031aea3b7b3a6deb9bfd41108386bb62be31a092121b4ef532",
+          "2cb76bc8549b9f4e5441b9efa93aae0eeecffd1538ab584b5b29be19abb9f415",
+          "479d6caa663f5d4471fbfeff33901a8e9644810ae18e49675d0c421f3a452f2f",
+          "da390cfa4d37955bba3e985262efeb44c3bf066e43cff00b7a9ed6cf57a15b06",
+          "05d143166525fa3d4b12ab6044eb03ba612c7e57a68fcf71ed55dc88b0ddf5ef",
+          "49cebbbc69a7a74b42f852051190f79823fc97e3854befa82c23644a9f8c46fa",
+          "37346b163ae4172823f1618e287c8bdccfc8ce4269c216633a1a2887e599b1a1",
+          "42d2dc12ee6be74cc86fc743be0ead00bfbee4f471943435531d313fa0a89c1b",
+          "364d2c9347cdd79e0ab19ed380e713a0a10631639598a56a269f114c0bdf10d8",
+          "7b1a2f1e8f9dd54133249f03a85c8c7378a8ed9ea663fb16faa35fb26ebc6466",
+          "8cd8e674435e2880362bb76a731eec8ea25d64ba59ce6e6e13c35b6ab943bd32",
+          "2d7ce2d840c17be1c1a9f8766f65f52bb255d1d016854a256d32977b23669353"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log10x8.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log10x8.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log10x8.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log10x8.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log10x8.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log10x8.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log10x8.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log10x8.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log10x8.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log10x8.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log10x8.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log10x8.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log10x8.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch2/autoresearch/.runs/latest/wf_log10x8.b7.json"
+    ]
+  }
+}

--- a/src/backends/metal/commit_backend.zig
+++ b/src/backends/metal/commit_backend.zig
@@ -291,6 +291,18 @@ pub const MetalCommitBackend = struct {
         std.log.debug("Metal sampled-value kernel: {d:.3}ms", .{gpu_ms});
     }
 
+    pub fn evaluateCoefficientTreePlans(
+        allocator: std.mem.Allocator,
+        tree_plans: anytype,
+    ) !void {
+        if (tree_plans.len == 0) return;
+        var lease = try shared_runtime.acquire();
+        defer lease.deinit();
+        const gpu_ms = try lease.runtime.evaluateCoefficientTreePlans(allocator, tree_plans);
+        telemetry.record(.metal_sampled_value_dispatch);
+        std.log.debug("Metal sampled-value batch epoch: {d:.3}ms", .{gpu_ms});
+    }
+
     pub fn interpolateCircleBuffers(
         allocator: std.mem.Allocator,
         values: []const []@import("stwo_core").fields.m31.M31,

--- a/src/backends/metal/runtime.zig
+++ b/src/backends/metal/runtime.zig
@@ -204,6 +204,7 @@ pub const Runtime = struct {
     pub const computeQuotients = polynomial_ops.computeQuotients;
     pub const computeQuotientsAndCommit = polynomial_ops.computeQuotientsAndCommit;
     pub const evaluateCoefficientPlans = polynomial_ops.evaluateCoefficientPlans;
+    pub const evaluateCoefficientTreePlans = polynomial_ops.evaluateCoefficientTreePlans;
     pub const transformCircle = polynomial_ops.transformCircle;
     pub const transformCircleResident = polynomial_ops.transformCircleResident;
     pub const transformCircleLde = polynomial_ops.transformCircleLde;

--- a/src/backends/metal/runtime/polynomial_operations.zig
+++ b/src/backends/metal/runtime/polynomial_operations.zig
@@ -296,31 +296,69 @@ pub fn evaluateCoefficientPlans(
     tree_values: anytype,
     plans: anytype,
 ) (MetalError || std.mem.Allocator.Error)!f64 {
-    const coefficient_offsets = try allocator.alloc(u32, coefficients.len);
-    defer allocator.free(coefficient_offsets);
-    const coefficient_ptrs = try allocator.alloc([*]const u32, coefficients.len);
-    defer allocator.free(coefficient_ptrs);
-    const coefficient_lengths = try allocator.alloc(usize, coefficients.len);
-    defer allocator.free(coefficient_lengths);
-    var coefficient_count: usize = 0;
-    for (coefficients, 0..) |coefficient, index| {
-        const words = std.mem.bytesAsSlice(u32, std.mem.sliceAsBytes(coefficient.coefficients()));
-        coefficient_offsets[index] = @intCast(coefficient_count);
-        coefficient_ptrs[index] = words.ptr;
-        coefficient_lengths[index] = words.len;
-        coefficient_count += words.len;
-    }
+    const TreePlan = struct {
+        coefficients: @TypeOf(coefficients),
+        tree_values: @TypeOf(tree_values),
+        plans: @TypeOf(plans),
+    };
+    const tree_plans = [_]TreePlan{.{
+        .coefficients = coefficients,
+        .tree_values = tree_values,
+        .plans = plans,
+    }};
+    return evaluateCoefficientTreePlans(self, allocator, &tree_plans);
+}
 
+pub fn evaluateCoefficientTreePlans(
+    self: *Runtime,
+    allocator: std.mem.Allocator,
+    tree_plans: anytype,
+) (MetalError || std.mem.Allocator.Error)!f64 {
+    var coefficient_column_count: usize = 0;
+    var coefficient_count: usize = 0;
     var factor_word_count: usize = 0;
     var task_count: usize = 0;
     var basis_task_count: usize = 0;
     var basis_count: usize = 0;
-    for (plans) |plan| {
-        factor_word_count += plan.flat_factors.len * 4;
-        task_count += plan.column_indices.items.len * plan.normalized_points.len;
-        basis_task_count += plan.normalized_points.len;
-        basis_count += plan.normalized_points.len * (@as(usize, 1) << @intCast(plan.coeff_log_size));
+    var output_count: usize = 0;
+    for (tree_plans) |tree_plan| {
+        if (tree_plan.coefficients.len != tree_plan.tree_values.len)
+            return MetalError.PolynomialEvaluationFailed;
+        coefficient_column_count += tree_plan.coefficients.len;
+        for (tree_plan.coefficients) |coefficient| {
+            coefficient_count += std.mem.sliceAsBytes(coefficient.coefficients()).len / @sizeOf(u32);
+        }
+        for (tree_plan.plans) |plan| {
+            factor_word_count += plan.flat_factors.len * 4;
+            task_count += plan.column_indices.items.len * plan.normalized_points.len;
+            basis_task_count += plan.normalized_points.len;
+            basis_count += plan.normalized_points.len * (@as(usize, 1) << @intCast(plan.coeff_log_size));
+        }
+        for (tree_plan.tree_values) |values| output_count += values.len;
     }
+    if (coefficient_column_count == 0 or task_count == 0) return 0;
+
+    const coefficient_offsets = try allocator.alloc(u32, coefficient_column_count);
+    defer allocator.free(coefficient_offsets);
+    const coefficient_ptrs = try allocator.alloc([*]const u32, coefficient_column_count);
+    defer allocator.free(coefficient_ptrs);
+    const coefficient_lengths = try allocator.alloc(usize, coefficient_column_count);
+    defer allocator.free(coefficient_lengths);
+    var coefficient_cursor: usize = 0;
+    var coefficient_word_cursor: usize = 0;
+    for (tree_plans) |tree_plan| {
+        for (tree_plan.coefficients) |coefficient| {
+            const words = std.mem.bytesAsSlice(u32, std.mem.sliceAsBytes(coefficient.coefficients()));
+            coefficient_offsets[coefficient_cursor] = @intCast(coefficient_word_cursor);
+            coefficient_ptrs[coefficient_cursor] = words.ptr;
+            coefficient_lengths[coefficient_cursor] = words.len;
+            coefficient_cursor += 1;
+            coefficient_word_cursor += words.len;
+        }
+    }
+    std.debug.assert(coefficient_cursor == coefficient_column_count);
+    std.debug.assert(coefficient_word_cursor == coefficient_count);
+
     const factor_words = try allocator.alloc(u32, factor_word_count);
     defer allocator.free(factor_words);
     const task_words = try allocator.alloc(u32, task_count * 5);
@@ -330,55 +368,73 @@ pub fn evaluateCoefficientPlans(
     const basis_task_words = try allocator.alloc(u32, basis_task_count * 4);
     defer allocator.free(basis_task_words);
 
-    const output_offsets = try allocator.alloc(u32, tree_values.len);
+    const output_offsets = try allocator.alloc(u32, coefficient_column_count);
     defer allocator.free(output_offsets);
-    var output_count: usize = 0;
-    for (tree_values, 0..) |values, index| {
-        output_offsets[index] = @intCast(output_count);
-        output_count += values.len;
+    var output_column_cursor: usize = 0;
+    var output_cursor: usize = 0;
+    for (tree_plans) |tree_plan| {
+        for (tree_plan.tree_values) |values| {
+            output_offsets[output_column_cursor] = @intCast(output_cursor);
+            output_column_cursor += 1;
+            output_cursor += values.len;
+        }
     }
+    std.debug.assert(output_column_cursor == coefficient_column_count);
+    std.debug.assert(output_cursor == output_count);
 
     var factor_cursor: usize = 0;
     var task_cursor: usize = 0;
     var basis_task_cursor: usize = 0;
     var basis_cursor: usize = 0;
-    for (plans) |plan| {
-        const plan_factor_start = factor_cursor;
-        for (plan.flat_factors) |factor| {
-            const coordinates = factor.toM31Array();
-            inline for (0..4) |coordinate| {
-                factor_words[factor_cursor] = coordinates[coordinate].v;
-                factor_cursor += 1;
+    var tree_column_base: usize = 0;
+    for (tree_plans) |tree_plan| {
+        for (tree_plan.plans) |plan| {
+            const plan_factor_start = factor_cursor;
+            for (plan.flat_factors) |factor| {
+                const coordinates = factor.toM31Array();
+                inline for (0..4) |coordinate| {
+                    factor_words[factor_cursor] = coordinates[coordinate].v;
+                    factor_cursor += 1;
+                }
             }
-        }
-        const plan_basis_start = basis_cursor;
-        const coefficient_length = @as(usize, 1) << @intCast(plan.coeff_log_size);
-        for (0..plan.normalized_points.len) |point_index| {
-            const base = basis_task_cursor * 4;
-            basis_task_words[base..][0..4].* = .{
-                @intCast(plan_factor_start + point_index * plan.coeff_log_size * 4),
-                plan.coeff_log_size,
-                @intCast(basis_cursor),
-                @intCast(coefficient_length),
-            };
-            basis_task_cursor += 1;
-            basis_cursor += coefficient_length;
-        }
-        for (plan.column_indices.items) |column_index| {
             for (0..plan.normalized_points.len) |point_index| {
-                const base = task_cursor * 5;
-                task_words[base..][0..5].* = .{
-                    coefficient_offsets[column_index],
-                    @intCast(coefficients[column_index].coefficients().len),
-                    @intCast(plan_basis_start + point_index * coefficient_length),
+                const base = basis_task_cursor * 4;
+                const coefficient_length = @as(usize, 1) << @intCast(plan.coeff_log_size);
+                basis_task_words[base..][0..4].* = .{
+                    @intCast(plan_factor_start + point_index * plan.coeff_log_size * 4),
                     plan.coeff_log_size,
-                    output_offsets[column_index] + @as(u32, @intCast(point_index)),
+                    @intCast(basis_cursor),
+                    @intCast(coefficient_length),
                 };
-                task_columns[task_cursor] = @intCast(column_index);
-                task_cursor += 1;
+                basis_task_cursor += 1;
+                basis_cursor += coefficient_length;
+            }
+            const coefficient_length = @as(usize, 1) << @intCast(plan.coeff_log_size);
+            const plan_basis_start = basis_cursor - plan.normalized_points.len * coefficient_length;
+            for (plan.column_indices.items) |column_index| {
+                if (column_index >= tree_plan.coefficients.len)
+                    return MetalError.PolynomialEvaluationFailed;
+                const global_column = tree_column_base + column_index;
+                for (0..plan.normalized_points.len) |point_index| {
+                    const base = task_cursor * 5;
+                    task_words[base..][0..5].* = .{
+                        coefficient_offsets[global_column],
+                        @intCast(tree_plan.coefficients[column_index].coefficients().len),
+                        @intCast(plan_basis_start + point_index * coefficient_length),
+                        plan.coeff_log_size,
+                        output_offsets[global_column] + @as(u32, @intCast(point_index)),
+                    };
+                    task_columns[task_cursor] = @intCast(global_column);
+                    task_cursor += 1;
+                }
             }
         }
+        tree_column_base += tree_plan.coefficients.len;
     }
+    std.debug.assert(factor_cursor == factor_word_count);
+    std.debug.assert(task_cursor == task_count);
+    std.debug.assert(basis_task_cursor == basis_task_count);
+    std.debug.assert(basis_cursor == basis_count);
 
     const output_words = try allocator.alloc(u32, output_count * 4);
     defer allocator.free(output_words);
@@ -388,7 +444,7 @@ pub fn evaluateCoefficientPlans(
         self.handle,
         coefficient_ptrs.ptr,
         coefficient_lengths.ptr,
-        @intCast(coefficients.len),
+        @intCast(coefficient_column_count),
         coefficient_count,
         factor_words.ptr,
         factor_words.len,
@@ -407,13 +463,18 @@ pub fn evaluateCoefficientPlans(
         std.log.err("Metal polynomial evaluation failed: {s}", .{std.mem.sliceTo(&message, 0)});
         return MetalError.PolynomialEvaluationFailed;
     }
-    for (tree_values, output_offsets) |values, output_offset| {
-        for (values, 0..) |*value, point_index| {
-            var coordinates: [4]@import("stwo_core").fields.m31.M31 = undefined;
-            inline for (0..4) |coordinate| {
-                coordinates[coordinate].v = output_words[(@as(usize, output_offset) + point_index) * 4 + coordinate];
+    output_column_cursor = 0;
+    for (tree_plans) |tree_plan| {
+        for (tree_plan.tree_values) |values| {
+            const output_offset = output_offsets[output_column_cursor];
+            for (values, 0..) |*value, point_index| {
+                var coordinates: [4]@import("stwo_core").fields.m31.M31 = undefined;
+                inline for (0..4) |coordinate| {
+                    coordinates[coordinate].v = output_words[(@as(usize, output_offset) + point_index) * 4 + coordinate];
+                }
+                value.* = @import("stwo_core").fields.qm31.QM31.fromM31Array(coordinates);
             }
-            value.* = @import("stwo_core").fields.qm31.QM31.fromM31Array(coordinates);
+            output_column_cursor += 1;
         }
     }
     return gpu_ms;

--- a/src/backends/metal/tests/polynomial_eval.zig
+++ b/src/backends/metal/tests/polynomial_eval.zig
@@ -15,6 +15,12 @@ const EvalPlan = struct {
     column_indices: std.ArrayList(usize),
 };
 
+const EvalTreePlan = struct {
+    coefficients: []const circle_poly.CircleCoefficients,
+    tree_values: []const []QM31,
+    plans: []const EvalPlan,
+};
+
 test "metal: polynomial evaluation shader unit matches scalar circle evaluation" {
     const allocator = std.testing.allocator;
     var runtime = try runtime_mod.Runtime.init();
@@ -68,6 +74,62 @@ test "metal: polynomial evaluation shader unit matches scalar circle evaluation"
 
     for (coefficients, outputs) |polynomial, output| {
         for (points, output) |point, actual| {
+            try std.testing.expect(polynomial.evalAtPoint(point).eql(actual));
+        }
+    }
+}
+
+test "metal: polynomial evaluation batches tree-local indices in one epoch" {
+    const allocator = std.testing.allocator;
+    var runtime = try runtime_mod.Runtime.init();
+    defer runtime.deinit();
+
+    const coefficient_values = [_][8]M31{
+        .{ .{ .v = 3 }, .{ .v = 5 }, .{ .v = 8 }, .{ .v = 13 }, .{ .v = 21 }, .{ .v = 34 }, .{ .v = 55 }, .{ .v = 89 } },
+        .{ .{ .v = 144 }, .{ .v = 233 }, .{ .v = 377 }, .{ .v = 610 }, .{ .v = 987 }, .{ .v = 1597 }, .{ .v = 2584 }, .{ .v = 4181 } },
+    };
+    const coefficients = [_]circle_poly.CircleCoefficients{
+        try circle_poly.CircleCoefficients.initBorrowed(&coefficient_values[0]),
+        try circle_poly.CircleCoefficients.initBorrowed(&coefficient_values[1]),
+    };
+    const points = [_]circle.CirclePointQM31{
+        circle.SECURE_FIELD_CIRCLE_GEN.mul(17),
+        circle.SECURE_FIELD_CIRCLE_GEN.mul(29),
+    };
+    var factors: [points.len * 3]QM31 = undefined;
+    circle_poly.fillEvalFactorsForPointsFolded(&points, 0, 3, &factors);
+
+    var first_indices = std.ArrayList(usize).empty;
+    defer first_indices.deinit(allocator);
+    try first_indices.append(allocator, 0);
+    var second_indices = std.ArrayList(usize).empty;
+    defer second_indices.deinit(allocator);
+    try second_indices.append(allocator, 0);
+    const first_plans = [_]EvalPlan{.{
+        .coeff_log_size = 3,
+        .normalized_points = &points,
+        .flat_factors = &factors,
+        .column_indices = first_indices,
+    }};
+    const second_plans = [_]EvalPlan{.{
+        .coeff_log_size = 3,
+        .normalized_points = &points,
+        .flat_factors = &factors,
+        .column_indices = second_indices,
+    }};
+    var first_output: [points.len]QM31 = undefined;
+    var second_output: [points.len]QM31 = undefined;
+    const first_outputs = [_][]QM31{&first_output};
+    const second_outputs = [_][]QM31{&second_output};
+    const tree_plans = [_]EvalTreePlan{
+        .{ .coefficients = coefficients[0..1], .tree_values = &first_outputs, .plans = &first_plans },
+        .{ .coefficients = coefficients[1..2], .tree_values = &second_outputs, .plans = &second_plans },
+    };
+
+    _ = try runtime.evaluateCoefficientTreePlans(allocator, &tree_plans);
+
+    for (coefficients, tree_plans) |polynomial, tree_plan| {
+        for (points, tree_plan.tree_values[0]) |point, actual| {
             try std.testing.expect(polynomial.evalAtPoint(point).eql(actual));
         }
     }

--- a/src/prover/pcs/sampled_values.zig
+++ b/src/prover/pcs/sampled_values.zig
@@ -214,6 +214,12 @@ const CoefficientEvalPlan = struct {
     }
 };
 
+const CoefficientEvalTreePlan = struct {
+    coefficients: []const prover_circle.CircleCoefficients,
+    tree_values: [][]QM31,
+    plans: []const CoefficientEvalPlan,
+};
+
 fn deinitCoefficientEvalPlans(
     allocator: std.mem.Allocator,
     plans: *std.ArrayList(CoefficientEvalPlan),
@@ -642,27 +648,73 @@ fn evaluateCoefficientTreesWithBackend(
         return false;
     };
 
+    if (comptime @hasDecl(B, "evaluateCoefficientTreePlans")) {
+        const plan_lists = try allocator.alloc(std.ArrayList(CoefficientEvalPlan), trees.len);
+        defer allocator.free(plan_lists);
+        var initialized: usize = 0;
+        defer for (plan_lists[0..initialized]) |*plans| {
+            deinitCoefficientEvalPlans(allocator, plans);
+        };
+
+        const tree_plans = try allocator.alloc(CoefficientEvalTreePlan, trees.len);
+        defer allocator.free(tree_plans);
+        for (trees, tree_points_list, out, 0..) |tree, tree_points, tree_values, tree_index| {
+            plan_lists[tree_index] = try buildCoefficientPlansForTree(
+                allocator,
+                tree.columns,
+                tree_points,
+                tree.coefficients.?,
+                lifting_log_size,
+            );
+            initialized += 1;
+            tree_plans[tree_index] = .{
+                .coefficients = tree.coefficients.?,
+                .tree_values = tree_values,
+                .plans = plan_lists[tree_index].items,
+            };
+        }
+        try B.evaluateCoefficientTreePlans(allocator, tree_plans);
+        return true;
+    }
+
     for (trees, tree_points_list, out) |tree, tree_points, tree_values| {
         const coefficients = tree.coefficients.?;
-        var plans = std.ArrayList(CoefficientEvalPlan).empty;
+        var plans = try buildCoefficientPlansForTree(
+            allocator,
+            tree.columns,
+            tree_points,
+            coefficients,
+            lifting_log_size,
+        );
         defer deinitCoefficientEvalPlans(allocator, &plans);
-        var plan_index = std.AutoHashMap(u64, usize).init(allocator);
-        defer plan_index.deinit();
-
-        for (tree.columns, tree_points, 0..) |column, points, column_idx| {
-            const plan = try getOrCreateCoefficientEvalPlan(
-                allocator,
-                &plan_index,
-                &plans,
-                coefficients[column_idx].logSize(),
-                lifting_log_size - column.log_size,
-                points,
-            );
-            try plan.column_indices.append(allocator, column_idx);
-        }
         try B.evaluateCoefficientPlans(allocator, coefficients, tree_values, plans.items);
     }
     return true;
+}
+
+fn buildCoefficientPlansForTree(
+    allocator: std.mem.Allocator,
+    columns: []const commitment_tree.ColumnEvaluation,
+    tree_points: [][]CirclePointQM31,
+    coefficients: []const prover_circle.CircleCoefficients,
+    lifting_log_size: u32,
+) !std.ArrayList(CoefficientEvalPlan) {
+    var plans = std.ArrayList(CoefficientEvalPlan).empty;
+    errdefer deinitCoefficientEvalPlans(allocator, &plans);
+    var plan_index = std.AutoHashMap(u64, usize).init(allocator);
+    defer plan_index.deinit();
+    for (columns, tree_points, 0..) |column, points, column_idx| {
+        const plan = try getOrCreateCoefficientEvalPlan(
+            allocator,
+            &plan_index,
+            &plans,
+            coefficients[column_idx].logSize(),
+            lifting_log_size - column.log_size,
+            points,
+        );
+        try plan.column_indices.append(allocator, column_idx);
+    }
+    return plans;
 }
 
 fn releaseTreeCoefficients(


### PR DESCRIPTION
## Outcome

Batches every commitment tree sampled-value plan into one existing Metal evaluator call. Physical sampled epochs fall 2→1 on small/wide and 3→1 on deep; shaders, ABI, proof protocol, and non-Metal paths are unchanged.

Paired Native Metal ReleaseFast results (seven AB/BA rounds, 10 warmups, 7 verified samples/process):

- small: ratio 0.9187 [0.6642, 0.9289], 8.13% lower latency; separately preconditioned confirmation 7.75%
- wide: ratio 0.9517 [0.9357, 0.9678], 4.83% lower latency
- deep: ratio 0.8767 [0.8742, 0.8789], 12.33% lower latency
- three-class geometric mean: 0.9152, 8.48% lower latency

All 294 primary paired proofs verified, matched exact predecessor hashes, and used zero CPU sampled-value fallbacks. Profiled sampled stages moved 1.355→0.800 ms wide and 2.111→0.661 ms deep.

## Validation

- full Zig tests
- Native Metal product and Metal compile gates
- authenticated AOT tooling and probe suites
- source conformance, formatting, and diff checks
- new two-tree local-index aliasing parity test
- broad Metal suite 80/83: two expected skips and the same pre-existing resident-FRI failure
- CPU S3 controls for small/wide/deep pass G1–G5 and all 12 guards; all are neutral as expected for a Metal-only hook

Submission package: autoresearch/submissions/2026-07-20-metal-batched-sampled-value-epoch