### PR TITLE
Metal: fuse shallow FRI Merkle tails

### DIFF
--- a/autoresearch/submissions/2026-07-21-metal-fri-merkle-tail-arena/delta.json
+++ b/autoresearch/submissions/2026-07-21-metal-fri-merkle-tail-arena/delta.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "564cea426cf4",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/backends/metal/runtime/fri_fold_commit.m": "sha256:3bb48927ac10a429f7884190b093902a3ec76d081867e4212ff3d45e73cd0c4b",
+    "src/backends/metal/tests/fri_fold_commit.zig": "sha256:f141c42ab7da9670f10fe089948be13ee167a1fb5325561cf71fe1bdab2354ad"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "7ca6a44a6ee0e462c04bc6025476717c7c11529df751d3cdb3ebd494a2dfbbcd",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-21-metal-fri-merkle-tail-arena/note.md
+++ b/autoresearch/submissions/2026-07-21-metal-fri-merkle-tail-arena/note.md
@@ -1,0 +1,108 @@
+# Fuse shallow FRI Merkle levels inside one Metal threadgroup
+
+## Model and harness
+
+GPT-5 Codex optimized clean candidate `e6aea4a37f5a` from recorded predecessor
+`564cea426cf4` on an Apple M5 Max running macOS 26.5.2. Native Metal evidence
+uses the real ReleaseFast `native-proof-bench-metal` product, functional
+protocol, independent proof verification, and `--metal-runtime source-jit`.
+Zig embeds the MSL and macOS compiles it with `newLibraryWithSource`; source
+compilation is backend initialization and is excluded from timed proofs.
+
+The manifest still has no enabled Metal scoring workload. Attached S3 verdicts
+are honest CPU no-regression controls; the performance claim below comes from
+the production-compatible Native Metal binary and is not labeled as CPU-board
+credit.
+
+## Hypothesis
+
+Fresh profiling placed the line-FRI cascade at about 3.65 ms of device time and
+169 dispatches on wide. The cascade already uses one command buffer, but it
+builds thirteen geometric Merkle trees with one buffer allocation and one
+dispatch per logical level. Once a tree reaches at most 256 parents, every
+remaining level fits in one threadgroup and needs only threadgroup barriers,
+not repeated grid dispatches.
+
+The repository already had an exact `blake2s_parent_tail_sparse` kernel for
+that reduction. FRI could not use it because its levels lived in separate
+buffers, while the tail kernel consumes offset-addressed levels in one arena.
+The prediction was fewer dispatches and Objective-C allocations with unchanged
+hashing, transcript order, proof bytes, command-buffer count, and fallback
+behavior.
+
+## Changes
+
+The resident line-FRI runtime now allocates one 256-byte-aligned arena for the
+transcript plus every logical Merkle level. Returned tree handles retain the
+same arena with exact per-level word offsets and lengths, which the existing
+root, layer-copy, selective-decommit, and destruction paths already support.
+
+Large parent levels still use the established grid kernel. The first level
+with at most 256 parents begins one `blake2s_parent_tail_sparse` dispatch,
+which holds hashes in threadgroup memory and reduces through the root. A
+single-level tail is left on the original path. No MSL, C ABI, shader export,
+pipeline identity, protocol, arithmetic, transcript, or generic prover code
+changed.
+
+The focused five-layer parity test now expects 30 rather than 45 dispatches
+and still compares every root, transcript challenge, terminal evaluation, and
+channel state with CPU. During development, a missing leaf-arena offset was
+caught because it overwrote the transcript header; Metal GPU validation and
+the fixed proof hashes verified the corrected offset-aware binding.
+
+## Results
+
+Seven clean paired rounds per class alternated A-B / B-A process order. Every
+process used ten warmups and seven timed verified proofs. Ratios use the
+repository's round-median Hodges--Lehmann estimator and deterministic
+100,000-resample bootstrap intervals.
+
+| class | predecessor | candidate | B/A (95% CI) | result |
+| --- | ---: | ---: | ---: | ---: |
+| small `wf_log10x8` | 2.888 ms | 2.732 ms | 0.9572 [0.9430, 1.0296] | 4.28% estimate |
+| wide `wf_log14x32` | 11.990 ms | 11.859 ms | 0.9854 [0.9651, 1.0018] | 1.46% estimate |
+| deep `plonk_log14` | 7.571 ms | 7.210 ms | 0.9489 [0.9352, 0.9587] | 5.11% confirmed |
+
+The suite geometric-mean ratio is 0.9637, about 3.63% less latency. Deep is the
+confirmed claim: all seven pairs improve and its upper confidence bound is
+0.9587. Small and wide intervals cross one and are not overclaimed.
+
+Debug GPU attribution shows wide line-FRI dispatches falling 169 -> 93 and its
+steady device timestamp moving from about 3.65 to 3.37 ms. The command remains
+one compute encoder, one command buffer, and one wait. The arena also replaces
+roughly one hundred per-level Metal buffer objects at the fixed wide/deep
+shape.
+
+All 294 formal timed proofs independently verified, were byte-identical within
+each process, matched across arms, reported `accelerated_without_fallbacks`,
+used zero CPU fallbacks, and retained one line-FRI epoch. Fixed hashes are:
+
+- small: `91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700`
+- wide: `57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374`
+- deep: `d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf`
+
+## Official controls and validation
+
+Fresh CPU S3 controls for all moved classes passed G1--G5, the pinned Rust
+oracle, proof-digest checks, request/RSS budgets, and all 12 regression guards.
+They are neutral as expected for Objective-C compiled only into Metal:
+small 1.0114 `[0.9886, 1.0256]`, wide 1.0077 `[0.9930, 1.0144]`, and deep
+0.9925 `[0.9847, 1.0019]`.
+
+Validation passes `zig build test`, `test-native-metal`, `metal-check`, both
+authenticated-AOT core compile/probe gates, source conformance, diff checks,
+Metal API/GPU validation, exact fixed proofs, and the modified cascade parity
+test. Broad `metal-test` is 80/83 with two expected skips and only the same
+pre-existing resident-policy assertion at `resident_data_test.zig:616`.
+
+## Caveats
+
+- No enabled Metal judge workload exists, so this cannot receive Metal-board
+  credit until the harness exposes one.
+- Full Metal System Trace is unavailable because this host has Command Line
+  Tools rather than full Xcode. Real source-JIT execution, GPU timestamps,
+  stage profiles, validation layers, and mechanism telemetry support the
+  attribution.
+- The single shared arena selects shared storage. This is the same storage mode
+  the predecessor selected for every level on the target unified-memory Apple
+  GPU; no claim is made for discrete Intel-era Macs.

--- a/autoresearch/submissions/2026-07-21-metal-fri-merkle-tail-arena/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-21-metal-fri-merkle-tail-arena/transcripts/session-01.md
@@ -1,0 +1,205 @@
+# Session 01 — extending the resident FRI epoch through the first layer
+
+Date: 2026-07-21
+Model: GPT-5 Codex
+
+## Objective and clean frontier
+
+Continue the user's Metal-backend optimization loop immediately after the
+sampled-value batch epoch merged and was recorded. The canonical updater moved
+main from `bbb8c8823cca` to recorded frontier `564cea426cf4`; the preceding
+submission is now listed neutral on the CPU-only judge board, while its Native
+Metal evidence remains a 0.9152 suite ratio. A fresh worktree and branch
+`autoresearch/metal-epoch3` were created at the exact recorded frontier, and
+repo setup passed before source work.
+
+The same five repository skills remain active: algorithm matching, Metal
+profiling, Metal performance design with the complete compute common-pattern
+reference, Zig profiling for host attribution, and reasoning-first submission
+transcripts. The prior iteration's durable note and packaged transcript are the
+immediate research prior. No production source has been edited.
+
+## Initial hypothesis pending fresh attribution
+
+The merged frontier's last profile left FRI quotient/build/commit at roughly
+4.2 ms wide and 4.6 ms deep, now the largest common residual. The existing
+resident line-FRI cascade starts only after the quotient column has been
+computed/committed, its root mixed on CPU, a circle challenge drawn, and the
+circle evaluation folded into a line evaluation. The next question is whether
+that complete prefix can join the resident cascade without changing any
+Fiat--Shamir state, proof byte, tree lifetime, or fallback contract. A fresh
+benchmark and source dependency map come before selection or editing.
+
+## Fresh frontier benchmark and device attribution
+
+The untouched recorded frontier was rebuilt as the production ReleaseFast,
+source-JIT Metal product and run locally before source work. Ten warmups and
+three timed, verified proofs gave 6.832 ms small, 12.573 ms wide, and 7.606 ms
+deep. All samples matched the established proof hashes, reported no fallback,
+and retained one physical sampled-value epoch and one physical line-FRI epoch.
+Fresh stage profiles put FRI at 3.746, 4.205, and 3.971 ms respectively; it is
+still the largest residual common stage.
+
+A Debug host build was then used only to expose the backend's command-buffer
+GPU timestamps after five proof warmups. A steady wide proof reported about
+0.63 ms for quotient plus its first Merkle tree, 0.04 ms for the circle fold,
+and 3.65 ms for the resident thirteen-tree line cascade. The cascade encodes
+169 dispatches in one command buffer. These timestamps are device attribution,
+not verdict timing: Debug host preparation is intentionally excluded from any
+performance claim.
+
+## Algorithmic match and architecture decision
+
+The remaining hot path is a geometric sequence of immutable Merkle reductions,
+interleaved with exact transcript and line-fold dependencies:
+
+```text
+line evaluation_i
+  -> coordinate planes_i
+  -> leaf hashes_i
+  -> parent level 1 -> ... -> parent level log_i -> root_i
+  -> transcript mix/draw -> fold -> line evaluation_(i+1)
+```
+
+The root dependency prevents different trees from running concurrently, but a
+Merkle tree's upper levels fit inside one Metal threadgroup. Once a level has
+at most 256 parent hashes, one kernel can retain those hashes in threadgroup
+memory and reduce all remaining levels with threadgroup barriers. The existing
+`stwo_zig_blake2s_parent_tail_sparse` kernel already implements precisely that
+mapping and is used by prepared resident Merkle plans. The FRI cascade misses
+it only because each logical hash level currently lives in a separate
+`MTLBuffer`, while the sparse-tail ABI addresses levels by offsets in one
+arena. This is an accelerator layout mismatch rather than a cryptographic or
+arithmetic problem.
+
+Candidate comparison before production editing:
+
+| Candidate | Physical effect | Main risk | Decision |
+| --- | --- | --- | --- |
+| Fuse quotient, circle, and line submissions | three waits to one; same ~4.3 ms device work | large generic FRI/quotient ownership surface | defer |
+| Fuse circle into line cascade | removes one ~0.04 ms kernel submission | limited ceiling | defer |
+| Generate inverse domains on GPU | removes small host preparation | more field kernels, unchanged 169 dispatches | defer |
+| One offset-addressed FRI Merkle arena plus threadgroup tails | ~76 fewer dispatches and ~100 fewer buffer allocations | layer-offset/decommit correctness | select |
+| New fused coordinate/leaf/tail kernel | can remove more late-tree dispatches | duplicates leaf/hash logic | follow-up only if needed |
+
+The selected layout is:
+
+```text
+one shared FRI hash arena
++--------------------+----------------+----------------+-----+
+| channel/roots/alpha| tree 0 levels  | tree 1 levels  | ... |
++--------------------+----------------+----------------+-----+
+                       ^ offsets retained by each Tree handle
+
+per tree execution
+coordinates -> leaves -> large parent levels -> [<=256-parent fused tail]
+                                                    |
+                                                    v
+                                           root slot in same arena
+```
+
+All level starts remain 256-byte aligned. Each returned tree keeps the same
+logical level lengths and now references the common arena plus exact word
+offsets, which the existing root, layer-copy, selective-hash, batch-decommit,
+and destruction paths already support. The root slot remains inside the
+transcript arena, so transcript ordering and challenge bytes do not change.
+On this unified-memory device, a single shared arena has the same CPU-visible
+storage mode already selected for all existing levels.
+
+Prediction: reduce the line cascade from 169 to about 93 dispatches and improve
+wide/deep end-to-end proof latency by at least 3%, with exact proof hashes,
+zero fallback, unchanged logical commitment counts, and no extra command
+buffer. Falsifiers are any offset/decommit parity failure, proof-byte mismatch,
+memory-lifetime error, or interleaved confidence interval crossing regression.
+
+## Implementation diagnostic and first exact result
+
+The first arena implementation failed before proof construction completed: the
+GPU transcript rejection sentinel was overwritten. Tail fusion was disabled,
+then the original parent pipeline was restored, and Metal API plus GPU shader
+validation were enabled; the corruption remained while the computed arena
+cursor exactly matched the allocation. Instrumentation showed channel word 9
+entered the command as zero and returned as a deterministic hash word rather
+than the rejection value `1`.
+
+The violated invariant was at the leaf boundary. Separate buffers had always
+bound every leaf destination at byte offset zero. Once all logical levels
+shared an arena, that unchanged binding made every later tree overwrite arena
+offset zero, which is the channel header. Applying the returned tree's recorded
+level-zero word offset fixed the fault. This diagnosis is retained because it
+is the central correctness trap in converting object-per-level Metal code to
+offset-addressed arenas.
+
+The corrected path passed a full small proof under Metal API and GPU shader
+validation with the canonical `91741aec...bea5700` hash. It reduced the
+nine-tree small cascade to 55 dispatches. A production-size Debug attribution
+run reduced the thirteen-tree wide cascade from 169 to 93 dispatches and its
+steady GPU timestamp from about 3.65 ms to roughly 3.37 ms. The smaller device
+gain is expected: all hashes remain, while dispatch setup/barriers and roughly
+one hundred Objective-C buffer allocations disappear.
+
+ReleaseFast process-level A/B checks used separate baseline/candidate binaries,
+ten warmups and seven verified samples per arm, alternating order for seven
+rounds. All proofs were exact and fallback-free. Preliminary median paired
+ratios were 0.950 small (one cold baseline outlier excluded by the median),
+0.980 wide, and 0.957 deep. Every deep pair improved; the earlier isolated
+8.72 ms deep reading was a warm-state/order artifact, as its individual samples
+continued falling from 10.66 to 7.22 ms despite the process warmups. Formal
+repository statistics and clean-commit evidence remain pending.
+
+## Frozen clean-commit Metal verdict
+
+Production and its focused expectation were frozen in source commit
+`e6aea4a37f5a` (`metal: fuse shallow FRI Merkle tails`) against recorded
+predecessor `564cea426cf4`. The transcript was stashed while both exact commits
+were rebuilt as clean ReleaseFast products, so every formal report asserted
+both `implementation_dirty=false` and `provenance.git_dirty=false`.
+
+Seven round pairs per class alternated A--B / B--A process order. Each arm used
+ten verified warmups and seven timed verified proofs. The repository's
+round-median Hodges--Lehmann estimator and deterministic 100,000-resample
+bootstrap produced:
+
+| Metal class | predecessor median | candidate median | B/A HL (95% CI) | latency reduction |
+| --- | ---: | ---: | ---: | ---: |
+| small, `wf_log10x8` | 2.888 ms | 2.732 ms | 0.9572 [0.9430, 1.0296] | 4.28% estimate |
+| wide, `wf_log14x32` | 11.990 ms | 11.859 ms | 0.9854 [0.9651, 1.0018] | 1.46% estimate |
+| deep, `plonk_log14` | 7.571 ms | 7.210 ms | 0.9489 [0.9352, 0.9587] | 5.11% confirmed |
+
+The three-class geometric-mean ratio is 0.9637, about 3.63% less proof latency.
+Deep is the formal significant claim: all seven pairs improved and its upper
+confidence bound is 0.9587. Small and wide point estimates improve, but their
+intervals cross one; they are reported as estimates, not confirmed claims.
+Small retained one cold-state process excursion and wide had two noisy pairs,
+consistent with the previously observed process-frequency behavior.
+
+The audit covered all 294 formal timed proofs. Every sample independently
+verified, was byte-identical within its process, matched the fixed cross-arm
+hash, reported `accelerated_without_fallbacks`, used zero CPU fallbacks, and
+retained exactly one line-FRI command epoch. Debug GPU attribution showed the
+mechanism directly: wide line-FRI dispatches fell 169 -> 93; the focused
+three-layer test fell 45 -> 30; command buffers and waits remained one.
+
+## Validation and official controls
+
+The frozen source passes `zig build test`, `test-native-metal`, `metal-check`,
+both authenticated-AOT core compile/probe gates, source conformance, diff
+checks, exact full-proof verification, and Metal API plus GPU shader
+validation. Broad `metal-test` is 80/83 with two expected skips and only the
+same pre-existing resident-policy assertion at
+`resident_data_test.zig:616`; the modified line-cascade parity test passes.
+
+The manifest still enables only the CPU board, so three official S3 CPU
+controls were run with all regression guards. Each passed G1--G5, the pinned
+Rust oracle, cross-arm proof-byte checks, request/RSS budgets, and all 12
+impact-mapped guards:
+
+| CPU control | ratio (95% CI) | classification |
+| --- | ---: | --- |
+| small | 1.0114 [0.9886, 1.0256] | confirmed neutral |
+| wide | 1.0077 [0.9930, 1.0144] | confirmed neutral |
+| deep | 0.9925 [0.9847, 1.0019] | confirmed neutral |
+
+The significant result is therefore honestly Metal-local and not represented
+as a CPU-board speedup. The submission packages all three neutral CPU verdicts
+for suite coverage while the note carries the exact Native Metal evidence.

--- a/autoresearch/submissions/2026-07-21-metal-fri-merkle-tail-arena/verdict-deep.json
+++ b/autoresearch/submissions/2026-07-21-metal-fri-merkle-tail-arena/verdict-deep.json
@@ -1,0 +1,310 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "a9faa70efc0d",
+  "repo_commit": "e6aea4a37f5a",
+  "predecessor_commit": "564cea426cf4",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 4.46
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.4664 vs targeted budget x1.02; regression guards 12/12 within budget; request ratio 0.9900 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "plonk_log14": {
+        "r": 0.992462,
+        "ci": [
+          0.984718,
+          1.001906
+        ],
+        "rounds": 15,
+        "a_median_ms": 6.730792,
+        "b_median_ms": 6.723625
+      }
+    },
+    "R_geomean": 0.992462,
+    "theta": 0.018278,
+    "aa_dispersion": 0.009139,
+    "significant": false,
+    "neutral": true
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {
+    "guard_blake_10x10": {
+      "r": 1.005441,
+      "ci": [
+        0.993194,
+        1.011585
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "4153acd6e32a98b9d240730062f7fa35e2e31eca915f01c179337f04d409cbd2"
+    },
+    "guard_blake_12x16": {
+      "r": 1.020104,
+      "ci": [
+        1.007464,
+        1.032853
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "70e516957d2d38ed78214bfda5b0b2bdfe41f1c93439fb68e124bfef096fbc9f"
+    },
+    "guard_plonk_14": {
+      "r": 1.014767,
+      "ci": [
+        1.01281,
+        1.018106
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf"
+    },
+    "guard_plonk_16": {
+      "r": 0.978979,
+      "ci": [
+        0.972336,
+        0.987012
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "cfb36bf17fb3526bf1bdd9401fb885fd91ca46b9982fee1ca5fad33a1d574b72"
+    },
+    "guard_poseidon_10": {
+      "r": 1.004605,
+      "ci": [
+        0.990679,
+        1.038537
+      ],
+      "rounds": 7,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "af33240da8e7947362fdf7e78d306f2e11cb2e3df7e1b6f498a6e86ac3ae7b1b"
+    },
+    "guard_poseidon_13": {
+      "r": 1.004469,
+      "ci": [
+        1.001254,
+        1.007261
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "f196835da5d4a155c6311bafb44335c2863cc028879d69a7ae53b802321200f1"
+    },
+    "guard_sm_14": {
+      "r": 0.998072,
+      "ci": [
+        0.986878,
+        1.005084
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "488fadeeb4e5d76b6fc0a9c10ab258bab6673de8e912ae5de927561650920b37"
+    },
+    "guard_sm_16": {
+      "r": 1.016134,
+      "ci": [
+        1.013371,
+        1.024312
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "88ec35ee88a05ce0a5db4b6cb063f4cf7824ee65284db0908a62a9362879af73"
+    },
+    "guard_wf_14x32": {
+      "r": 0.988445,
+      "ci": [
+        0.963671,
+        1.003669
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374"
+    },
+    "guard_wf_16x64": {
+      "r": 1.028898,
+      "ci": [
+        1.021734,
+        1.046864
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "42086545b7a170c5868afcc390f83d964e06d528e2d1039420fc6bfd7a6aac74"
+    },
+    "guard_xor_14": {
+      "r": 1.003506,
+      "ci": [
+        0.98362,
+        1.019663
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "35bb35714e10888c786a71ccdfe31d2b9b4651c567fac5ba4c9543bc247cad80"
+    },
+    "guard_xor_16": {
+      "r": 0.999399,
+      "ci": [
+        0.985232,
+        1.007766
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "56163b8ea3d877b3b9bf15753b7c0175d4a6ead493640eef8210c59ba7e5215c"
+    }
+  },
+  "rust_oracle": [
+    {
+      "workload": "plonk_log14",
+      "verified": true,
+      "artifact_sha256": "ed64ff803f2e7ec8c5eeb81f520ee3cb228c6811795a53137092a8632f9e5e68"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "plonk_log14": {
+        "round_ratios": [
+          1.007618,
+          0.992121,
+          0.987365,
+          0.971344,
+          0.991231,
+          0.975518,
+          1.006686,
+          1.02531,
+          1.010727,
+          0.985584,
+          0.989051,
+          0.987223,
+          1.013191,
+          0.958066,
+          0.998091
+        ],
+        "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf",
+        "request_ratio": 0.990035,
+        "report_sha256s": [
+          "e7315729f293002968731dfaee5abd86bf58de33c600902b274cebde6bcc99cb",
+          "89442801a98abf0612a77884081e221c72d80bd0f2ce09aae34953596f7ff332",
+          "5de0c2f88047886ef1bc20097ab82b5f642d69353add4ec6e600a84c5eb07e0d",
+          "5fc4927f4bdde433ec581d2536e7f795caa2c573970f63dfa2e9611d66ac48e2",
+          "d232c60545e742e933da7bb27e3167daa1312cd8daf92dc1e6f309e2d395dc47",
+          "ebb7f8682b5367f3b3258cc9330bbe614107dcedf6cf6871104dc8f5e7eb79c9",
+          "3457628c96ebfc4baeae714db626677b4b14bbcbd46b15e0ffeef153b7bdfa41",
+          "a5d9c51a1ab829d473f24730acf7c71e977daf48d95acacc1ceb90bad333b0de",
+          "655a8fef7eb92fe3f91c01319f54779b4129810948e610704e10858653c25ca1",
+          "75dd56690146de72fbf1488eb31517cc30b570e3037d0e5215084dee355e945c",
+          "c23128725ff32d73edf3688c7c4e522f2bdc9f59be70327845737ea7cd2e82f1",
+          "a6b5edb2b9b2f4b001f66823daf086c7d9954336819f8fb88b5fa7c4d23bd9cf",
+          "eba05e44111da9c721b21249d562ebe012e9177b3892ab5ce5a443e0e171e8b3",
+          "29c93359c170934a149a189c9bef266d0182020c6d2ae2cf8ee9c78272866062",
+          "5fc06d8064f74735f386d01ad1dda7fbb32b4ddb6ec4def7475ef737f3bbb11c",
+          "6c369715d1be0d68daad390764a3d0522c27a565aa8a6fdc25a0dd32948249bf",
+          "ac3c711f55244f5573de8687f2d39e82d5dec8cc81a6a07a172a9b10cf8128cc",
+          "ec80c89ec62e5cd01a8bc8de7621d0072835dae584b646a4ad0c09fdcd6874e0",
+          "b61b60533df684b1a90f575d7cf2a3dadb0fa81b301aabeece4afb44f1a5c183",
+          "6c300b33d2bb3c0dfa3d4b3e318edd834dc534008d26d67827891163865ac355",
+          "3bc44329672ed1bbd0670131c92a5a2f12f7c73fcc2d5aaef0efd553e691aa24",
+          "7ffe532d3fc829aaf748c5bd38ee2a64e5f8b685153cd4a10168681c05854642",
+          "6ba50db79e15db4df48358cf1165197543ce16c5c8db5acdb859ae3e1ff4740d",
+          "faea8e241f6e0e8b4988c87e9c3e2e0fc77ef440860f6414729e12fb16970567",
+          "94d10d60a11ccac4623574d03195e19ff3e4bdfdc73a7cdd93e9f68ba44eed51",
+          "907cd57a7a6ec013c019cb07f3f4f2a7451bf4fbe1505ef0414212c54fc706a0",
+          "fca4eb0265931aea7ff166d1f2306ae4c52bd431f57123274333eeb8cabaae41",
+          "f4d81f87d9dada6de9a17a1572c2702b6a8ac9e12be65ab9e9994874c1e22f5a",
+          "0de005ae8284cfb72b3709038bdb8a3442a105f21fd98aeb23c41e6139acde63",
+          "b9bcb736746575bee4da000e068c20cbebea79b38ef49024de532562360e1e44"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.b10.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.a11.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.b11.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.a12.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.b12.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.a13.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.b13.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.a14.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.b14.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.a15.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/plonk_log14.b15.json"
+    ]
+  }
+}

--- a/autoresearch/submissions/2026-07-21-metal-fri-merkle-tail-arena/verdict-wide.json
+++ b/autoresearch/submissions/2026-07-21-metal-fri-merkle-tail-arena/verdict-wide.json
@@ -1,0 +1,285 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "a9faa70efc0d",
+  "repo_commit": "e6aea4a37f5a",
+  "predecessor_commit": "564cea426cf4",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "wide",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 3.13
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.6190 vs targeted budget x1.02; regression guards 12/12 within budget; request ratio 1.0098 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log14x32": {
+        "r": 1.007741,
+        "ci": [
+          0.993011,
+          1.014394
+        ],
+        "rounds": 10,
+        "a_median_ms": 10.824,
+        "b_median_ms": 10.929583
+      }
+    },
+    "R_geomean": 1.007741,
+    "theta": 0.02929,
+    "aa_dispersion": 0.014645,
+    "significant": false,
+    "neutral": true
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {
+    "guard_blake_10x10": {
+      "r": 0.993624,
+      "ci": [
+        0.987498,
+        1.006556
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "4153acd6e32a98b9d240730062f7fa35e2e31eca915f01c179337f04d409cbd2"
+    },
+    "guard_blake_12x16": {
+      "r": 0.998764,
+      "ci": [
+        0.985708,
+        1.024141
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "70e516957d2d38ed78214bfda5b0b2bdfe41f1c93439fb68e124bfef096fbc9f"
+    },
+    "guard_plonk_14": {
+      "r": 1.00026,
+      "ci": [
+        0.9849,
+        1.008737
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf"
+    },
+    "guard_plonk_16": {
+      "r": 0.994513,
+      "ci": [
+        0.980169,
+        1.017263
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "cfb36bf17fb3526bf1bdd9401fb885fd91ca46b9982fee1ca5fad33a1d574b72"
+    },
+    "guard_poseidon_10": {
+      "r": 1.011734,
+      "ci": [
+        1.003099,
+        1.018812
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "af33240da8e7947362fdf7e78d306f2e11cb2e3df7e1b6f498a6e86ac3ae7b1b"
+    },
+    "guard_poseidon_13": {
+      "r": 0.995274,
+      "ci": [
+        0.993341,
+        0.996888
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "f196835da5d4a155c6311bafb44335c2863cc028879d69a7ae53b802321200f1"
+    },
+    "guard_sm_14": {
+      "r": 1.00279,
+      "ci": [
+        0.987356,
+        1.010002
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "488fadeeb4e5d76b6fc0a9c10ab258bab6673de8e912ae5de927561650920b37"
+    },
+    "guard_sm_16": {
+      "r": 0.987988,
+      "ci": [
+        0.977888,
+        1.016088
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "88ec35ee88a05ce0a5db4b6cb063f4cf7824ee65284db0908a62a9362879af73"
+    },
+    "guard_wf_14x32": {
+      "r": 1.006675,
+      "ci": [
+        0.983812,
+        1.016416
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374"
+    },
+    "guard_wf_16x64": {
+      "r": 0.989985,
+      "ci": [
+        0.981638,
+        0.995834
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "42086545b7a170c5868afcc390f83d964e06d528e2d1039420fc6bfd7a6aac74"
+    },
+    "guard_xor_14": {
+      "r": 0.991533,
+      "ci": [
+        0.98302,
+        0.995604
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "35bb35714e10888c786a71ccdfe31d2b9b4651c567fac5ba4c9543bc247cad80"
+    },
+    "guard_xor_16": {
+      "r": 1.006632,
+      "ci": [
+        0.995622,
+        1.032957
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "56163b8ea3d877b3b9bf15753b7c0175d4a6ead493640eef8210c59ba7e5215c"
+    }
+  },
+  "rust_oracle": [
+    {
+      "workload": "wf_log14x32",
+      "verified": true,
+      "artifact_sha256": "d32393fe3b1f9abbc4795d87c3b3316e06111f014ec30f0635f13ec0ff0587f9"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "wf_log14x32": {
+        "round_ratios": [
+          0.835824,
+          1.010491,
+          1.007884,
+          1.018012,
+          1.011772,
+          1.003803,
+          1.017017,
+          0.993011,
+          1.022264,
+          0.998464
+        ],
+        "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374",
+        "request_ratio": 1.009812,
+        "report_sha256s": [
+          "480f8709e9d4d35698d03e7e93ebac45feee7f4c517cc6a54ede4ea0c70e8247",
+          "7c075133b2fe9ec80368fa09d34b2a66b53ecfaf5a757664a022c14fe4718f4a",
+          "1e0a2dd5e649fb277ec2697b9de113422d2a8e21424b94fb74334d0fbe3804cc",
+          "e6584f0f7a068a6070b77dfd48daeb7cec3202a3cb54e12619242c0d985d1c9c",
+          "412beff4e3842501a0f20ce132abde40cebb1d35bba52f213a980b8122a06519",
+          "fdb22b5b698327271ee1068c124105336246f4d55f7f77b387e19675b8b09787",
+          "c873768f89c8eeffc026e6685e251d8e262e5f0273896cbb9be98f5b1eabd540",
+          "c639f455e78970a41e6cc8de45ba918c7e28775f90e7f9d2bed7b2d5bea85d5f",
+          "6a963ed958e9ab2c82638426f43d9a51d136a58680490f7d502427c97f1973c8",
+          "cdf0629a000dbd216f1c6636768a6df19c022a323fe3f70494e8aed0e0a067cd",
+          "e82f5fd3ec2309b8eb8f87e9ca5a9fe9f56213dcd37494c316eb6b1cd58edd50",
+          "8d79204a563dba45c13a5b4db5d22677c6e69ae829fd89b6729890aaa0068e4d",
+          "3a02f7b31072dc34ed25e6d6296cbf71ab431dad655151a92667981d043a9d4f",
+          "9cecfe896e74bdb871731f5df56aacf9765415ec25c21d2196bf8dfc0b61580a",
+          "b963c0fc1d803c94398939790c74830640cfb16e31393c47708e7fdac82e3981",
+          "d5ccb7ed06440f1545d8e0ca53931498fdaca9913601742460524272129443d1",
+          "c3c46ad01a4b659f74a02690f87521a555ead624d3375cd13d734ecbe7071c8d",
+          "ee64b4a158c835ba27ee93fbc5ce499610fda81b7ba137967eaf37f0efb191cb",
+          "221e347f244c6b80d504d6ef79640284cc5a535aaf1672042195ac76ba24457b",
+          "193af256e708ea4794a4a4b107da060c26e25fd34c953e1851734c49689cd16a"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log14x32.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log14x32.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log14x32.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log14x32.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log14x32.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log14x32.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log14x32.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log14x32.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log14x32.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log14x32.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log14x32.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log14x32.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log14x32.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log14x32.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log14x32.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log14x32.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log14x32.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log14x32.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log14x32.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log14x32.b10.json"
+    ]
+  }
+}

--- a/autoresearch/submissions/2026-07-21-metal-fri-merkle-tail-arena/verdict.json
+++ b/autoresearch/submissions/2026-07-21-metal-fri-merkle-tail-arena/verdict.json
@@ -1,0 +1,300 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "a9faa70efc0d",
+  "repo_commit": "e6aea4a37f5a",
+  "predecessor_commit": "564cea426cf4",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 2.14
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.5563 vs targeted budget x1.02; regression guards 12/12 within budget; request ratio 1.0138 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log10x8": {
+        "r": 1.01137,
+        "ci": [
+          0.988632,
+          1.025566
+        ],
+        "rounds": 13,
+        "a_median_ms": 1.53575,
+        "b_median_ms": 1.551542
+      }
+    },
+    "R_geomean": 1.01137,
+    "theta": 0.037308,
+    "aa_dispersion": 0.018654,
+    "significant": false,
+    "neutral": true
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {
+    "guard_blake_10x10": {
+      "r": 0.996061,
+      "ci": [
+        0.994855,
+        0.997063
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "4153acd6e32a98b9d240730062f7fa35e2e31eca915f01c179337f04d409cbd2"
+    },
+    "guard_blake_12x16": {
+      "r": 0.989277,
+      "ci": [
+        0.980925,
+        1.000842
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "70e516957d2d38ed78214bfda5b0b2bdfe41f1c93439fb68e124bfef096fbc9f"
+    },
+    "guard_plonk_14": {
+      "r": 1.012072,
+      "ci": [
+        1.003386,
+        1.024899
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf"
+    },
+    "guard_plonk_16": {
+      "r": 0.99196,
+      "ci": [
+        0.97483,
+        1.003039
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "cfb36bf17fb3526bf1bdd9401fb885fd91ca46b9982fee1ca5fad33a1d574b72"
+    },
+    "guard_poseidon_10": {
+      "r": 1.010735,
+      "ci": [
+        0.991417,
+        1.018417
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "af33240da8e7947362fdf7e78d306f2e11cb2e3df7e1b6f498a6e86ac3ae7b1b"
+    },
+    "guard_poseidon_13": {
+      "r": 1.006497,
+      "ci": [
+        0.996258,
+        1.031191
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "f196835da5d4a155c6311bafb44335c2863cc028879d69a7ae53b802321200f1"
+    },
+    "guard_sm_14": {
+      "r": 1.006207,
+      "ci": [
+        0.998642,
+        1.017803
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "488fadeeb4e5d76b6fc0a9c10ab258bab6673de8e912ae5de927561650920b37"
+    },
+    "guard_sm_16": {
+      "r": 0.998803,
+      "ci": [
+        0.992495,
+        1.009156
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "88ec35ee88a05ce0a5db4b6cb063f4cf7824ee65284db0908a62a9362879af73"
+    },
+    "guard_wf_14x32": {
+      "r": 0.99678,
+      "ci": [
+        0.979341,
+        1.004902
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374"
+    },
+    "guard_wf_16x64": {
+      "r": 1.013049,
+      "ci": [
+        0.981531,
+        1.028911
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "42086545b7a170c5868afcc390f83d964e06d528e2d1039420fc6bfd7a6aac74"
+    },
+    "guard_xor_14": {
+      "r": 1.000932,
+      "ci": [
+        0.995975,
+        1.009003
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "35bb35714e10888c786a71ccdfe31d2b9b4651c567fac5ba4c9543bc247cad80"
+    },
+    "guard_xor_16": {
+      "r": 1.011604,
+      "ci": [
+        0.999528,
+        1.024431
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "56163b8ea3d877b3b9bf15753b7c0175d4a6ead493640eef8210c59ba7e5215c"
+    }
+  },
+  "rust_oracle": [
+    {
+      "workload": "wf_log10x8",
+      "verified": true,
+      "artifact_sha256": "6a2250b56d5e10b6385e3a0f617ef4cee001b5279fd3bbef404a5ccb58ccd7ce"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "wf_log10x8": {
+        "round_ratios": [
+          0.988235,
+          1.085391,
+          1.029376,
+          1.037821,
+          1.014291,
+          1.025474,
+          1.025566,
+          0.953926,
+          0.95179,
+          1.01137,
+          0.96449,
+          0.99842,
+          1.016494
+        ],
+        "proof_digest": "91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700",
+        "request_ratio": 1.013777,
+        "report_sha256s": [
+          "28d759c71a0124b97a95fa6c60594d560c81e14bc648180912de7aeb4d8f5b78",
+          "648b9ce9ee357efb7495ad385695cb0113ac9898125c4d53c6a31bca15f03d9a",
+          "8d7878e8cadc9f793db4bbc776d90006e51e57d52e0b1d05df57353fe9862a64",
+          "f24fd54faf01e0f5d13dc35ffe0bb050d529cb6b63d575c23a2ada10a8088be1",
+          "8ff5b69d9a0ffa83f581f4bac77a5f9a5f82c7b81a78f6e771f615138f2967c8",
+          "bc42c6ea03b91ca0dd9ea43c3b78cdc9528a62659db784c5f1fd704466a09235",
+          "47edf94433eecc869c714982cd09e5c1c37b6371bb8453a3c0fedf6a6665ac5e",
+          "1047b0436c9e8314137f1e2661d5e53cef1d45f385f7b750cf66b0ef24a29a59",
+          "0bd0db0f93996ed539850eaaf62d38d3824e126445ad19b9f64154dc1acae41e",
+          "1526241669d7a8384082f85dcd8e041d61845317cda6f930c12285f0dc663edb",
+          "52619dadac595ca960ef3f8afc7d3d28ba53bc838310cb959fbf47d4c24b6b25",
+          "11d33c6950334b0fa9a23122f31d63bd43e256d8411be88182cee0b2a3918d92",
+          "43672a745f9c65c4e918377bdaa105d459ac417af015c7dcae189ac332d05cf4",
+          "6a1f6673e26e89c1eddb6828dcfaccb20b36ad77c324f64b4b3ccc13453716d5",
+          "a9025723163060b5aa1593424d6351b440a25206c2a9f8879bac4a8ed6f2457b",
+          "791a7b59beb3d586d8d22bcecaa7f3f61d580f3d6525857d3cae55138b84682d",
+          "1ce6ed5305f0dcac69fd74d80f4cf8a7e390575b128efd148c7ce18d3b358a4e",
+          "cbc8472b19ee1db6e61be4f4b5419bc59fcaaff58a569a09ad247559f867370c",
+          "e154e9abb6e44cd4a1ce6e62f91e8287f115357999ccd7a38b54993b21e5bc5f",
+          "5e2987e1cc9d0a1203645460ab929d9a3290d54c8ab33fa450eca4790d1f5a67",
+          "fe666740ddb80360d24d641fc7527bf825bd0aa26707b393e99ee828757d48c6",
+          "8e690c109864e6fd54f805a2d30dcb4a941155b4e755c957a8ac17f5173b6d1d",
+          "90fc34ca2f3b62047c263940d0b0603e5cbc00ed5d0fb7ca5e6a2869670a249f",
+          "3d0b783f1b0a72361250eaf0b5ed4d8c36da79fa42008a4e6f59040626fddc4a",
+          "b475e97e6f92beb5d5d8820ea0e054dcd6eb8f2184580df5a90601d2cb60656f",
+          "e03a62ff9410c4352c3d92e65a6edac4cc4bef471bdaa30777f2effc91513984"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.b10.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.a11.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.b11.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.a12.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.b12.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.a13.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch3/autoresearch/.runs/latest/wf_log10x8.b13.json"
+    ]
+  }
+}

--- a/src/backends/metal/runtime/fri_fold_commit.m
+++ b/src/backends/metal/runtime/fri_fold_commit.m
@@ -262,8 +262,26 @@ bool stwo_zig_metal_fri_line_cascade(
         const uint32_t transcript_root_base = 16u;
         const uint32_t transcript_alpha_base = transcript_root_base + fri_layer_count * 8u;
         const uint32_t transcript_words = transcript_alpha_base + fri_layer_count * 4u;
+        // A single offset-addressed arena makes every tree tail eligible for
+        // the threadgroup-local parent reduction and avoids one buffer object
+        // per logical Merkle level. Keep every level 256-byte aligned.
+        uint64_t arena_words = ((uint64_t)transcript_words + 63u) & ~63u;
+        count = source_count;
+        for (uint32_t stage = 0u; stage < fri_layer_count; ++stage) {
+            uint32_t layer_nodes = count;
+            while (layer_nodes > 1u) {
+                arena_words = (arena_words + 63u) & ~63u;
+                arena_words += (uint64_t)layer_nodes * 8u;
+                layer_nodes >>= 1u;
+            }
+            count >>= 1u;
+        }
+        if (arena_words > UINT32_MAX || arena_words > SIZE_MAX / sizeof(uint32_t)) {
+            write_error(error_message, error_message_len, @"Metal FRI cascade arena is too large");
+            return false;
+        }
         id<MTLBuffer> transcript_arena = [runtime.device newBufferWithLength:
-            (NSUInteger)transcript_words * sizeof(uint32_t)
+            (NSUInteger)arena_words * sizeof(uint32_t)
             options:MTLResourceStorageModeShared];
         id<MTLBuffer> leaf_seed_buffer = [runtime.device newBufferWithBytes:leaf_seed
             length:8u * sizeof(uint32_t) options:MTLResourceStorageModeShared];
@@ -274,13 +292,14 @@ bool stwo_zig_metal_fri_line_cascade(
             write_error(error_message, error_message_len, @"Metal FRI cascade parameter allocation failed");
             return false;
         }
-        memset(transcript_arena.contents, 0, transcript_arena.length);
+        memset(transcript_arena.contents, 0, (NSUInteger)transcript_words * sizeof(uint32_t));
         memcpy(transcript_arena.contents, channel_state, 10u * sizeof(uint32_t));
 
         NSMutableArray<StwoZigMetalTree *> *trees =
             [NSMutableArray arrayWithCapacity:fri_layer_count];
         NSMutableArray<id<MTLBuffer>> *destinations =
             [NSMutableArray arrayWithCapacity:fri_layer_count];
+        uint32_t arena_cursor = (transcript_words + 63u) & ~63u;
         count = source_count;
         for (uint32_t stage = 0u; stage < fri_layer_count; ++stage) {
             id<MTLBuffer> coordinates = (__bridge id<MTLBuffer>)coordinate_ptrs[stage];
@@ -302,20 +321,14 @@ bool stwo_zig_metal_fri_line_cascade(
             const uint32_t root_word_offset = transcript_root_base + stage * 8u;
             uint32_t layer_nodes = count;
             for (uint32_t level = 0u; level <= tree_log_size; ++level) {
-                id<MTLBuffer> layer = transcript_arena;
-                if (level != tree_log_size) {
-                    MTLResourceOptions storage = runtime.device.hasUnifiedMemory
-                        ? MTLResourceStorageModeShared
-                        : MTLResourceStorageModePrivate;
-                    layer = [runtime.device newBufferWithLength:(NSUInteger)layer_nodes * 32u
-                        options:storage];
+                [layers addObject:transcript_arena];
+                if (level == tree_log_size) {
+                    layer_word_offsets[level] = root_word_offset;
+                } else {
+                    arena_cursor = (arena_cursor + 63u) & ~63u;
+                    layer_word_offsets[level] = arena_cursor;
+                    arena_cursor += layer_nodes * 8u;
                 }
-                if (layer == nil) {
-                    write_error(error_message, error_message_len, @"Metal FRI cascade tree allocation failed");
-                    return false;
-                }
-                [layers addObject:layer];
-                layer_word_offsets[level] = level == tree_log_size ? root_word_offset : 0u;
                 layer_word_lengths[level] = layer_nodes * 8u;
                 layer_nodes >>= 1u;
             }
@@ -341,6 +354,10 @@ bool stwo_zig_metal_fri_line_cascade(
             [destinations addObject:destination];
             count = destination_count;
         }
+        if (arena_cursor != (uint32_t)arena_words) {
+            write_error(error_message, error_message_len, @"Metal FRI cascade arena layout mismatch");
+            return false;
+        }
 
         id<MTLCommandBuffer> command = [runtime.queue commandBuffer];
         if (command == nil) {
@@ -357,6 +374,12 @@ bool stwo_zig_metal_fri_line_cascade(
         count = source_count;
         NSUInteger inverse_offset = 0u;
         uint64_t compute_encoders = 1u, dispatches = 0u;
+        NSUInteger tail_static_bytes = runtime.parentTailSparse.staticThreadgroupMemoryLength;
+        NSUInteger tail_available_bytes = runtime.device.maxThreadgroupMemoryLength > tail_static_bytes
+            ? runtime.device.maxThreadgroupMemoryLength - tail_static_bytes : 0u;
+        uint32_t tail_capacity = (uint32_t)MIN((NSUInteger)256u,
+            MIN(runtime.parentTailSparse.maxTotalThreadsPerThreadgroup,
+                tail_available_bytes / (8u * sizeof(uint32_t))));
         for (uint32_t stage = 0u; stage < fri_layer_count; ++stage) {
             id<MTLBuffer> coordinates = (__bridge id<MTLBuffer>)coordinate_ptrs[stage];
             StwoZigMetalTree *tree = trees[stage];
@@ -380,7 +403,9 @@ bool stwo_zig_metal_fri_line_cascade(
             [encoder setBuffer:coordinates offset:0u atIndex:0];
             [encoder setBytes:column_offsets length:sizeof(column_offsets) atIndex:1];
             [encoder setBytes:column_logs length:sizeof(column_logs) atIndex:2];
-            [encoder setBuffer:tree.layers[0] offset:0u atIndex:3];
+            [encoder setBuffer:tree.layers[0]
+                offset:(NSUInteger)tree_layer_word_offset(tree, 0u) * sizeof(uint32_t)
+                atIndex:3];
             [encoder setBytes:&column_count length:sizeof(column_count) atIndex:4];
             [encoder setBytes:&tree_log_size length:sizeof(tree_log_size) atIndex:5];
             [encoder setBuffer:leaf_seed_buffer offset:0u atIndex:6];
@@ -392,25 +417,58 @@ bool stwo_zig_metal_fri_line_cascade(
             [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
             dispatches += 1u;
 
+            uint32_t child_offsets[31], destination_offsets[31], parent_counts[31];
+            uint32_t tail_level = tree_log_size + 1u;
             uint32_t parent_count = count >> 1u;
             for (uint32_t level = 1u; level <= tree_log_size; ++level) {
+                child_offsets[level - 1u] = tree_layer_word_offset(tree, level - 1u);
+                destination_offsets[level - 1u] = tree_layer_word_offset(tree, level);
+                parent_counts[level - 1u] = parent_count;
+                // Leave a one-level tail alone; fusing is useful only when a
+                // single threadgroup replaces at least two dispatches.
+                if (tail_level > tree_log_size && level < tree_log_size &&
+                    parent_count <= tail_capacity)
+                    tail_level = level;
+                parent_count >>= 1u;
+            }
+            for (uint32_t level = 1u; level < tail_level; ++level) {
+                uint32_t level_index = level - 1u;
                 [encoder setComputePipelineState:runtime.parents];
-                [encoder setBuffer:tree.layers[level - 1u]
-                    offset:(NSUInteger)tree_layer_word_offset(tree, level - 1u) * sizeof(uint32_t)
-                    atIndex:0];
-                [encoder setBuffer:tree.layers[level]
-                    offset:(NSUInteger)tree_layer_word_offset(tree, level) * sizeof(uint32_t)
-                    atIndex:1];
-                [encoder setBytes:&parent_count length:sizeof(parent_count) atIndex:2];
+                [encoder setBuffer:transcript_arena
+                    offset:(NSUInteger)child_offsets[level_index] * sizeof(uint32_t) atIndex:0];
+                [encoder setBuffer:transcript_arena
+                    offset:(NSUInteger)destination_offsets[level_index] * sizeof(uint32_t) atIndex:1];
+                [encoder setBytes:&parent_counts[level_index] length:sizeof(uint32_t) atIndex:2];
                 [encoder setBuffer:node_seed_buffer offset:0u atIndex:3];
                 [encoder setBytes:&domain_prefix_bytes length:sizeof(domain_prefix_bytes) atIndex:4];
                 NSUInteger parent_width = MIN(runtime.parents.maxTotalThreadsPerThreadgroup,
                                               runtime.parents.threadExecutionWidth * 8u);
-                [encoder dispatchThreads:MTLSizeMake(parent_count, 1u, 1u)
+                [encoder dispatchThreads:MTLSizeMake(parent_counts[level_index], 1u, 1u)
                      threadsPerThreadgroup:MTLSizeMake(parent_width, 1u, 1u)];
                 [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
                 dispatches += 1u;
-                parent_count >>= 1u;
+            }
+            if (tail_level <= tree_log_size) {
+                uint32_t tail_index = tail_level - 1u;
+                uint32_t tail_levels = tree_log_size - tail_index;
+                uint32_t tail_width = parent_counts[tail_index];
+                [encoder setComputePipelineState:runtime.parentTailSparse];
+                [encoder setBuffer:transcript_arena offset:0u atIndex:0];
+                [encoder setBytes:child_offsets + tail_index
+                    length:(NSUInteger)tail_levels * sizeof(uint32_t) atIndex:1];
+                [encoder setBytes:destination_offsets + tail_index
+                    length:(NSUInteger)tail_levels * sizeof(uint32_t) atIndex:2];
+                [encoder setBytes:parent_counts + tail_index
+                    length:(NSUInteger)tail_levels * sizeof(uint32_t) atIndex:3];
+                [encoder setBytes:&tail_levels length:sizeof(tail_levels) atIndex:4];
+                [encoder setBuffer:node_seed_buffer offset:0u atIndex:5];
+                [encoder setBytes:&domain_prefix_bytes length:sizeof(domain_prefix_bytes) atIndex:6];
+                [encoder setThreadgroupMemoryLength:(NSUInteger)tail_width * 8u * sizeof(uint32_t)
+                    atIndex:0];
+                [encoder dispatchThreadgroups:MTLSizeMake(1u, 1u, 1u)
+                     threadsPerThreadgroup:MTLSizeMake(tail_width, 1u, 1u)];
+                [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+                dispatches += 1u;
             }
 
             uint32_t root_base = transcript_root_base + stage * 8u;

--- a/src/backends/metal/tests/fri_fold_commit.zig
+++ b/src/backends/metal/tests/fri_fold_commit.zig
@@ -392,7 +392,7 @@ test "metal: line FRI cascade preserves every root, challenge, and final value" 
     try std.testing.expectEqual(@as(u64, 1), result.stats.command_buffers);
     try std.testing.expectEqual(@as(u64, 1), result.stats.wait_count);
     try std.testing.expectEqual(@as(u64, 1), result.stats.compute_encoders);
-    try std.testing.expectEqual(@as(u64, 45), result.stats.dispatches);
+    try std.testing.expectEqual(@as(u64, 30), result.stats.dispatches);
     for (result.trees, expected_roots) |tree, expected_root| {
         const actual_root = try tree.root();
         try std.testing.expectEqualSlices(u8, &expected_root, &actual_root.hash);


### PR DESCRIPTION
## Summary

- pack every line-FRI Merkle level into one aligned Metal arena
- reuse the existing threadgroup-local parent-tail kernel below 256 parents
- reduce wide cascade dispatches from 169 to 93 without changing proof bytes, protocol, ABI, or fallback behavior

## Performance

Clean ReleaseFast, source-JIT Native Metal, seven alternating process pairs per class, 10 warmups + 7 verified samples/arm:

- deep: 7.571 -> 7.210 ms, HL ratio 0.9489 [0.9352, 0.9587], 5.11% confirmed
- wide: 11.990 -> 11.859 ms, ratio 0.9854 [0.9651, 1.0018]
- small: 2.888 -> 2.732 ms, ratio 0.9572 [0.9430, 1.0296]
- suite geometric mean: 0.9637

All 294 timed Metal proofs verified, matched fixed hashes, stayed accelerated-without-fallbacks, and used zero CPU fallbacks.

## Validation

- `zig build test`
- `zig build test-native-metal`
- `zig build metal-check`
- `zig build test-metal-core-aot`
- `zig build test-metal-core-aot-probe`
- source conformance
- Metal API + GPU validation
- CPU S3 controls: G1-G5 and 12/12 guards for small, wide, deep

Broad `metal-test` is 80/83: two expected skips and the same pre-existing resident-policy assertion at `resident_data_test.zig:616`; the modified cascade parity test passes.
