### PR TITLE
metal: pack generic Merkle commitment arenas

### DIFF
--- a/autoresearch/submissions/2026-07-21-metal-generic-merkle-tail-arena/delta.json
+++ b/autoresearch/submissions/2026-07-21-metal-generic-merkle-tail-arena/delta.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "f81b2cc64f7f",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/backends/metal/runtime/lifecycle_and_tree.m": "sha256:264e191100b0d127346c544fd4d26ed3d122daf2597c9da78300dc32963b2927",
+    "src/backends/metal/runtime/quotients.m": "sha256:7076a7f7c54d70fa657862786eed326056c8ea34087a3955fdd32fae936eb74b"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "11609d0faef8e94a59967e63344d0123ccf4d84a24a05aee80a983470f4d651f",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-21-metal-generic-merkle-tail-arena/note.md
+++ b/autoresearch/submissions/2026-07-21-metal-generic-merkle-tail-arena/note.md
@@ -1,0 +1,107 @@
+# Pack generic Metal Merkle commitments into tail-fused arenas
+
+## Model and harness
+
+GPT-5 Codex optimized clean candidate `4dd2b795fea1` from recorded predecessor
+`f81b2cc64f7f` on an Apple M5 Max with 64 GB unified memory running macOS
+26.5.2. Native Metal evidence uses the real ReleaseFast
+`native-proof-bench-metal` product, functional protocol, independent proof
+verification, and `--metal-runtime source-jit`.
+
+Zig embeds the MSL source and macOS compiles it at initialization through
+`newLibraryWithSource`. That initialization is excluded from timed proofs.
+This host has Command Line Tools but no offline `metal` compiler, which is not
+needed for source-JIT execution. The manifest still has no enabled Metal
+scoring workload, so the attached S3 verdicts are honest CPU no-regression
+controls; the performance claim below comes from the production Native Metal
+binary and is not labeled as CPU-board credit.
+
+## Hypothesis
+
+Fresh profiles placed generic main and composition commitments at 1.767 and
+1.701 ms on wide, while the already-optimized quotient and FRI commitments
+used offset-addressed arenas and a vetted shallow-parent tail kernel. Generic
+commitments still allocated one `MTLBuffer` and launched one parent grid for
+every logical Merkle level.
+
+Once a tree reaches at most 256 parents, every remaining level fits in one
+threadgroup. Packing all levels into an aligned arena permits the existing
+`blake2s_parent_tail_sparse` kernel to reduce those shallow levels through the
+root using threadgroup barriers. The prediction was fewer dispatches and Metal
+objects in every main/composition commitment, with unchanged hashes, proof
+bytes, transcript order, shader ABI, and fallback behavior.
+
+## Changes
+
+The generic Metal commitment runtime now stores every logical Merkle level in
+one 256-byte-aligned word-addressed arena. Returned tree handles retain that
+arena with exact per-level offsets and lengths, preserving root reads,
+full-layer copies, selective hash reads, batched decommitment, and destruction.
+Large parent levels use the established sparse grid kernel. The first eligible
+shallow level enters one established threadgroup-local tail dispatch.
+
+A log-14 tree therefore uses five large parent grids plus one tail instead of
+fourteen parent grids; log-15 uses six grids plus one tail instead of fifteen.
+The arena also replaces 15 or 16 hash buffers with one. A one-leaf tree keeps a
+leaf-only path. Unified-memory devices expose the arena root directly;
+non-unified devices retain a private arena and explicit 32-byte root readback.
+
+The already-packed quotient tree had one remaining shared-to-shared 32-byte
+root blit on unified memory. It now retains its shared arena and root offset
+directly, while keeping the private-device fallback. No MSL, C ABI, shader
+export, core shader identity, protocol operation, or generic prover code
+changed.
+
+## Results
+
+Seven clean paired rounds per class alternated A-B / B-A process order. Every
+process ran from its own exact clean checkout with ten warmups and seven timed
+verified proofs. Ratios use the repository's round-median Hodges--Lehmann
+estimator and a deterministic 100,000-resample percentile bootstrap.
+
+| class | predecessor | candidate | B/A (95% CI) | result |
+| --- | ---: | ---: | ---: | ---: |
+| small `wf_log10x8` | 2.687 ms | 2.709 ms | 0.9949 [0.7840, 1.0458] | neutral |
+| wide `wf_log14x32` | 11.936 ms | 11.800 ms | 0.9845 [0.9589, 0.9970] | 1.55% confirmed |
+| deep `plonk_log14` | 7.258 ms | 7.135 ms | 0.9812 [0.9270, 0.9899] | 1.88% confirmed |
+
+The suite geometric-mean ratio is 0.9869, about 1.31% less proof latency.
+Wide won 6/7 pairs and deep won 7/7. Small is not overclaimed; two opposite
+cold-state excursions widened its interval, and no round was deleted.
+
+Three additional clean alternating profiled pairs tied the result to the
+target path on Plonk: median main Merkle time fell 0.419 -> 0.390 ms, total
+main commit 0.680 -> 0.650 ms, and composition commit 0.777 -> 0.744 ms.
+Untouched sampled evaluation remained 0.662 -> 0.662 ms and FRI was effectively
+flat at 3.778 -> 3.773 ms.
+
+All 294 formal timed proofs independently verified, were byte-identical within
+each process, matched across arms and rounds, reported
+`accelerated_without_fallbacks`, and used zero CPU fallbacks. Fixed hashes are:
+
+- small: `91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700`
+- wide: `57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374`
+- deep: `d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf`
+
+Frozen validation passes `zig build test`, `test-native-metal`, `metal-check`,
+`metal-test`, source conformance, both authenticated-AOT core compile/probe
+contract tests, diff checks, exact complete proofs, and a proof with both
+Metal API and GPU shader validation enabled. Fresh CPU S3 controls passed
+G1--G5, the pinned Rust oracle, cross-arm proof checks, request/RSS budgets,
+and impact-mapped guards. They are neutral as expected: small 1.0134
+`[1.0020, 1.0350]`, wide 1.0102 `[0.9993, 1.0231]`, and deep 1.0008
+`[0.9934, 1.0106]`.
+
+## Caveats
+
+- No enabled Metal judge workload exists, so the current harness cannot award
+  Metal-board credit. The attached CPU verdicts are controls, not the source
+  of this performance claim.
+- Full Metal System Trace is unavailable without the full Xcode application.
+  Real source-JIT execution, stage profiles, validation layers, exact proofs,
+  and source-visible dispatch topology provide the local attribution.
+- This Apple GPU executes the unified-memory branch. The private-storage root
+  copy compiles and retains its prior contract but cannot be exercised here.
+- AOT shader compilation requires an offline Metal toolchain elsewhere. The
+  deterministic AOT tooling and acceptance-probe contracts pass, and this
+  change does not alter shader artifacts or their ABI.

--- a/autoresearch/submissions/2026-07-21-metal-generic-merkle-tail-arena/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-21-metal-generic-merkle-tail-arena/transcripts/session-01.md
@@ -1,0 +1,196 @@
+# Session 01 — fourth Metal-backend architecture campaign
+
+Date: 2026-07-21
+Model: GPT-5 Codex
+
+## Recorded frontier and objective
+
+PR #27 merged the shared FRI hash arena and threadgroup-local shallow Merkle
+tails. The autoresearch recorder classified its CPU-only verdict neutral and
+advanced the canonical frontier and repo-resident CLI to
+`f81b2cc64f7f`. A fresh workspace passed `stwo-perf setup` and branch
+`autoresearch/metal-epoch4` was created at that exact recorded commit.
+
+The five repository skills remain active: algorithm matching, Metal
+performance design plus the full compute common-pattern reference, Metal
+profiling, Zig host profiling, and reasoning-first submission transcripts.
+The preceding submission note/transcript is the immediate research prior.
+No production source has been edited.
+
+This iteration will first rerun all three production Native Metal shapes and a
+fresh stage/device attribution. The leading candidates are a FRI-specific
+kernel that fuses coordinate conversion, leaf hashing, and threadgroup parent
+tails for late small trees, versus extending the resident epoch backward
+through circle fold or quotient commitment. Selection waits on the new
+frontier measurements and an exact dependency/resource map.
+
+## Fresh frontier benchmark and residual attribution
+
+The untouched recorded frontier was rebuilt as ReleaseFast source-JIT Metal
+and run with ten warmups plus three timed, verified profiled samples per fixed
+shape. Medians were 5.875 ms small, 12.141 ms wide, and 7.309 ms deep. Every
+proof matched its fixed digest and reported zero fallback. FRI remains the
+largest common stage at 3.204, 4.075, and 3.764 ms. Wide also spends 1.767 ms
+in main trace commit and 1.701 ms in composition commit; deep spends 0.693 and
+0.787 ms respectively.
+
+Fresh Debug device attribution confirms the merged line cascade at 93
+dispatches in one command buffer/wait. Wide settles around 3.2--3.5 ms for the
+cascade, plus roughly 0.62--0.66 ms quotient/Merkle and 0.03--0.04 ms circle
+fold. Deep device timestamps ramp sharply across early proofs, reinforcing the
+need for clean alternating end-to-end verdicts rather than isolated readings.
+
+## Candidate architecture comparison
+
+The 93-dispatch cascade still performs coordinate conversion and leaf hashing
+as separate grids for every tree. A fused kernel could reduce it to about 73
+dispatches, but adding a new eager shader export requires advancing the core
+Metal ABI and invalidating authenticated AOT libraries for a limited ceiling.
+The earlier resident-cascade research explicitly removed a custom shader for
+the same compatibility reason.
+
+Source tracing exposed a broader mismatch. The quotient tree already uses an
+offset-addressed arena and the vetted `blake2s_parent_tail_sparse` kernel, and
+the line-FRI trees now do too. Generic main/composition commitments still use
+one `MTLBuffer` and one parent grid per logical level even though they invoke
+the same hashes:
+
+```text
+current generic commitment
+leaves -> buffer L0 -> dispatch -> buffer L1 -> ... -> buffer root
+          (log+1 buffers, log parent dispatches)
+
+selected generic commitment
+leaves -> [L0 | L1 | ... | root] aligned shared arena
+          large grids -> one <=256-parent threadgroup tail
+          (one buffer, about six parent dispatches at log 14)
+```
+
+| Candidate | Scope/effect | Compatibility | Decision |
+| --- | --- | --- | --- |
+| New coordinate+leaf(+tail) shader | line FRI, ~20 dispatches | core shader ABI bump | defer |
+| Fuse circle submission into line cascade | one wait/command boundary | generic FRI hook/ownership work | defer |
+| Alias quotient root readback on UMA | one tiny blit/allocation | no ABI change, small ceiling | follow-up |
+| Extend packed Merkle arena/tail to generic commits | main, composition, fallback FRI trees | reuses authenticated kernels/ABI | select |
+
+The selected change is a data-layout/scheduling optimization, not a hash or
+protocol change. All logical levels remain available through the existing tree
+offset metadata used by root reads, full layer copies, selective hash reads,
+batch decommitment, and destruction. On the target Apple unified-memory GPU,
+the predecessor already chooses shared storage for every separate level; one
+shared arena changes object granularity, not storage mode. Non-unified devices
+retain a private arena plus an explicit 32-byte root readback.
+
+Prediction: cut each production log-14/15 generic tree from 14/15 parent grids
+and 15/16 hash buffers to roughly six parent grids and one arena. Main and
+composition commit stages should fall by 8--20%, producing at least a 2%
+end-to-end wide/deep win with exact roots/proofs and no fallback. Falsifiers
+are any copy/decommit offset mismatch, non-unified root visibility failure,
+new shader/AOT ABI requirement, or clean paired interval crossing regression.
+
+## Implementation and first falsification pass
+
+The generic commitment runtime now lays all logical Merkle levels into one
+256-byte-aligned word-addressed arena.  The immutable tree handle points every
+logical level at that arena and carries the existing per-level offsets and
+lengths, so root reads, full-layer copies, selective reads, and batched
+decommitment retain their public behavior.  Large parent levels use the
+existing sparse grid kernel; the first eligible shallow level enters the
+already-authenticated threadgroup-local parent-tail kernel.  A one-leaf tree
+retains a leaf-only path.  On non-unified devices the arena is private and an
+explicit 32-byte root copy remains.
+
+The same ownership analysis exposed one remaining redundant UMA operation in
+the already-packed quotient tree: it copied the root from a shared arena into
+a second 32-byte shared buffer.  The shared-device path now retains the arena
+directly and records the root word offset, while the private-device fallback
+is unchanged.  Neither change touches MSL, shader exports, the core shader ABI,
+hash definitions, transcript order, proof format, or generic prover code.
+
+The first Debug build produced exact independently verified fixed proofs for
+small, wide, and Plonk with zero fallback.  Metal API and GPU validation were
+then enabled together for a complete small proof and reported no error.  A
+mistaken diagnostic invocation reused the installed Debug product after a
+ReleaseFast test step; its provenance said `Debug`, so those apparent stage
+numbers were discarded before any performance conclusion.
+
+An explicit ReleaseFast rebuild showed wide main commitment at 1.706 ms versus
+the fresh 1.767 ms frontier reading and composition commitment at 1.387 ms
+versus 1.701 ms; proof time was 11.704 versus 12.141 ms.  Temperature drift
+made independent small/deep process medians unsuitable, so four alternating
+process pairs per class were run with ten warmups and seven timed verified
+proofs per process.  Before the quotient-root cleanup, candidate wins were
+4/4 wide, 4/4 small, and 3/4 deep.  After that cleanup, a second four-pair wide
+screen again won 4/4, with candidate medians 1.0--2.8% below their adjacent
+predecessors.  Every diagnostic proof matched its fixed digest and reported
+zero CPU fallback.  This clears the threshold for a clean, committed,
+promotion-grade paired experiment; the diagnostic numbers themselves are not
+the verdict.
+
+At the freeze candidate, `zig build test`, `test-native-metal`, `metal-check`,
+and the broad `metal-test` closure complete successfully.  Allocation failure
+checks occur before inserting the arena into Objective-C arrays, and the
+private-device root copy remains compile-covered even though this Apple GPU
+can execute only the unified-memory branch.
+
+## Frozen clean-commit Metal verdict
+
+The production change was frozen as `4dd2b795fea1` (`metal: pack generic
+Merkle commitment arenas`) against recorded predecessor `f81b2cc64f7f`.  The
+transcript was stashed and both exact checkouts were rebuilt as clean
+ReleaseFast products.  A first formal wide pass revealed that product
+provenance is discovered from the process working directory: launching both
+binaries from the candidate checkout labeled both arms with the candidate
+commit.  Although the binaries and timings were distinct, that pass was
+rejected.  Every accepted process below ran with its own checkout as cwd and
+reported the expected exact commit, `git_dirty=false`, `complete=true`, and
+`ReleaseFast`.
+
+Seven round pairs per class alternated A--B / B--A process order.  Each arm
+used ten verified warmups and seven timed verified proofs.  Applying the
+repository's round-median Hodges--Lehmann estimator and a deterministic
+100,000-resample percentile bootstrap (seed 20260721) gives:
+
+| Metal class | predecessor median | candidate median | B/A HL (95% CI) | paired wins |
+| --- | ---: | ---: | ---: | ---: |
+| small, `wf_log10x8` | 2.687 ms | 2.709 ms | 0.9949 [0.7840, 1.0458] | 5/7, neutral |
+| wide, `wf_log14x32` | 11.936 ms | 11.800 ms | 0.9845 [0.9589, 0.9970] | 6/7, confirmed |
+| deep, `plonk_log14` | 7.258 ms | 7.135 ms | 0.9812 [0.9270, 0.9899] | 7/7, confirmed |
+
+The three-class geometric-mean ratio is 0.9869, about 1.31% less proof
+latency.  Wide and deep independently clear one; small is not overclaimed.
+Small's interval reflects two opposite cold-state excursions in its first two
+pairs (ratios 0.569 and 1.097), which the robust location estimator contains
+without deleting data.  Wide's confirmed estimate is a 1.55% reduction and
+deep's is 1.88%.
+
+All 294 formal timed proofs independently verified, were byte-identical within
+each process, matched the fixed digest across arms and rounds, reported
+`accelerated_without_fallbacks`, and used zero CPU fallbacks.  The hashes are
+`91741aec...bea5700` small, `57a7d291...0f3374` wide, and
+`d63a2c92...69dbaf` deep.
+
+Three clean alternating profiled pairs per production-sized class tied the
+result to the intended path.  On deep, median main Merkle time moved
+0.419 -> 0.390 ms, total main commit 0.680 -> 0.650 ms, and composition commit
+0.777 -> 0.744 ms.  Sampled evaluation remained 0.662 -> 0.662 ms, while FRI
+varied only 3.778 -> 3.773 ms.  The source schedule explains the mechanism:
+a log-14 generic tree now uses five large parent grids plus one shallow-tail
+dispatch rather than fourteen parent grids; log-15 uses six grids plus one
+tail rather than fifteen.  Each tree also uses one arena rather than 15 or 16
+hash buffers.  Wide stage timers were noisier, but its clean end-to-end CI and
+six paired wins confirm that the same shared generic path produces a net gain.
+
+Frozen validation passes `zig build test`, `test-native-metal`, `metal-check`,
+`metal-test`, `source-conformance`, both authenticated-AOT core compile/probe
+contract tests, exact full-proof verification, diff checks, and a complete
+proof with both Metal API and GPU shader validation enabled.  No MSL or shader
+ABI changed, and runtime source-JIT compilation remains outside post-warmup
+samples.
+
+The manifest still has no enabled Metal scoring group, so official S3 runs are
+CPU no-regression controls rather than the performance claim.  All three pass
+G1--G5, the pinned Rust oracle, cross-arm digests, request/RSS budgets, and the
+impact-mapped guards: small 1.0134 [1.0020, 1.0350], wide 1.0102
+[0.9993, 1.0231], and deep 1.0008 [0.9934, 1.0106].  Each is classified
+confirmed-neutral under its measured threshold.

--- a/autoresearch/submissions/2026-07-21-metal-generic-merkle-tail-arena/verdict-deep.json
+++ b/autoresearch/submissions/2026-07-21-metal-generic-merkle-tail-arena/verdict-deep.json
@@ -1,0 +1,137 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "7d32a7a3364b",
+  "repo_commit": "4dd2b795fea1",
+  "predecessor_commit": "f81b2cc64f7f",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 2.2
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.4704 vs targeted budget x1.02; request ratio 0.9998 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "plonk_log14": {
+        "r": 1.000753,
+        "ci": [
+          0.993403,
+          1.01062
+        ],
+        "rounds": 7,
+        "a_median_ms": 6.755625,
+        "b_median_ms": 6.781667
+      }
+    },
+    "R_geomean": 1.000753,
+    "theta": 0.018278,
+    "aa_dispersion": 0.009139,
+    "significant": false,
+    "neutral": true
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "plonk_log14",
+      "verified": true,
+      "artifact_sha256": "ed64ff803f2e7ec8c5eeb81f520ee3cb228c6811795a53137092a8632f9e5e68"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "plonk_log14": {
+        "round_ratios": [
+          1.017386,
+          1.0119,
+          1.003855,
+          0.993561,
+          0.993403,
+          0.999209,
+          0.988048
+        ],
+        "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf",
+        "request_ratio": 0.999778,
+        "report_sha256s": [
+          "06a8faaaa2e2e2043b05dfce7be16f6eb6cea7d0ab571db20918a77a536e8333",
+          "044ed46fce0a737f958f4b27b8ccc58c2c8514d004e5db5aa98decb6c7370e4c",
+          "594ac684ee8fc0a362fd712b114629d3fbfcda9c6e071f5e9a25e07064512b3b",
+          "8cf292e5a92f8470fba8795a5f9b78d4d37a9bfb811bb2b49ea8a0691f6ab442",
+          "1e571c9f03599274655b7f1065c36a121dd2bdf028a6607d9bd8868bca3bcc04",
+          "2f8f47b748255e603116c5345d0810ceac29f0b4ec067ae3b0f3b60c8af014ca",
+          "58cdd54991e877410b818de8003edd9d5d8f23d1830216b50d0caaffe923b1fb",
+          "4d2dba019726e97f9c34c5062ab526122b3b929ac350d4d8813e12541b331fa1",
+          "88597083d8cf2b6632e70a3cbb7f2760f99862c60f7053c887a2f00768b2d77a",
+          "4f17ad30555daabda2f347d0d9df093f2a84068beb2a3beee597683b9b0f33e3",
+          "3c10b8bd5c05d645c658cdf645787cb66bf928eeeae5eebaaac117f2ce606ba7",
+          "a008605306c127a01ad8b8cc4b90da1d13eeddce785870db15a5095eb6728d83",
+          "9bb6d2f788e3dabe8b987dbb35fadf690d758cc550ff5a2e4727dc9069e8e65d",
+          "f8a45131186f121d34a6164a5bfda2a604c7e2d7c164ae01602a77e1d90e505f"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/plonk_log14.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/plonk_log14.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/plonk_log14.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/plonk_log14.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/plonk_log14.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/plonk_log14.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/plonk_log14.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/plonk_log14.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/plonk_log14.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/plonk_log14.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/plonk_log14.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/plonk_log14.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/plonk_log14.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/plonk_log14.b7.json"
+    ]
+  }
+}

--- a/autoresearch/submissions/2026-07-21-metal-generic-merkle-tail-arena/verdict-wide.json
+++ b/autoresearch/submissions/2026-07-21-metal-generic-merkle-tail-arena/verdict-wide.json
@@ -1,0 +1,142 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "7d32a7a3364b",
+  "repo_commit": "4dd2b795fea1",
+  "predecessor_commit": "f81b2cc64f7f",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "wide",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 2.15
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.6153 vs targeted budget x1.02; request ratio 1.0129 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log14x32": {
+        "r": 1.010167,
+        "ci": [
+          0.999346,
+          1.02314
+        ],
+        "rounds": 8,
+        "a_median_ms": 10.723083,
+        "b_median_ms": 10.862875
+      }
+    },
+    "R_geomean": 1.010167,
+    "theta": 0.02929,
+    "aa_dispersion": 0.014645,
+    "significant": false,
+    "neutral": true
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "wf_log14x32",
+      "verified": true,
+      "artifact_sha256": "d32393fe3b1f9abbc4795d87c3b3316e06111f014ec30f0635f13ec0ff0587f9"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "wf_log14x32": {
+        "round_ratios": [
+          1.021864,
+          1.02697,
+          1.003306,
+          0.988776,
+          1.013336,
+          1.029573,
+          0.991967,
+          1.009565
+        ],
+        "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374",
+        "request_ratio": 1.01286,
+        "report_sha256s": [
+          "e6693173405a44062e817259219f721a93ed1899c4d7185b05ad809d95511b51",
+          "c8f9d56cfbd40e0841d6ed28959338cec7ec77c5881707e9ccaccf256be4eea6",
+          "56f6ec60c7e5d52b61f3aa2d57f9fb4e650465cfb1018b1db533e040574d9ba8",
+          "5cbb2027cc3a9917e60017377c4f0bcebfb43646d2ed86b083d6bddba1c62183",
+          "695b61da0daee4d7d8faef3a5497c9a79879e408523c3b47b6c3e96bf594749d",
+          "7c429495d3dc8cd3cfcb3e7d53b1563c61a9882d8f56cec4c838d00807a6b32b",
+          "72c3cce89f79544d060f86b702d66667d62e32211d6cb925ee4ba52c2adf5f72",
+          "92fbc0982a1f6725e2be0724b80f38352251c3c35e8465a305eba7633380e8a6",
+          "0f7fdd1dfc4515ad19cffd5686fa922b72a8afddfc02b8e755537b65d3fa4e74",
+          "06b64ac4d528ad05a31bb404607105aabd4364bf7d0f56d3cfb38c32fc6d0f2f",
+          "6de95ac38c6b4c1e9fd1e7aedf5c87c6523f9536458ef2458bc50e44e25282d1",
+          "c01d75d4d15dd4f2ec1fe14b2a96ef56552a788fd00c37e21de42a9adbd94b38",
+          "83f833b1e868ad892eeecccc8a63b867f384e0a4e43e56a77e6648507b5a4e3d",
+          "26f1be5e4a24dcd6421f1363c960c2134164f4aa7b5f96c7f4de6387be5d8e64",
+          "c48386a35f814f0b378b06d15f49bffc4cb885719ce7bce40975b3380e28f42b",
+          "8aecc306aa63138274d1594ee9b1d0258891c27693afaa5757ef779c89d18746"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log14x32.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log14x32.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log14x32.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log14x32.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log14x32.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log14x32.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log14x32.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log14x32.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log14x32.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log14x32.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log14x32.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log14x32.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log14x32.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log14x32.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log14x32.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log14x32.b8.json"
+    ]
+  }
+}

--- a/autoresearch/submissions/2026-07-21-metal-generic-merkle-tail-arena/verdict.json
+++ b/autoresearch/submissions/2026-07-21-metal-generic-merkle-tail-arena/verdict.json
@@ -1,0 +1,172 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "7d32a7a3364b",
+  "repo_commit": "4dd2b795fea1",
+  "predecessor_commit": "f81b2cc64f7f",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 1.69
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.5568 vs targeted budget x1.02; request ratio 1.0138 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log10x8": {
+        "r": 1.013446,
+        "ci": [
+          1.001977,
+          1.034997
+        ],
+        "rounds": 14,
+        "a_median_ms": 1.534083,
+        "b_median_ms": 1.552959
+      }
+    },
+    "R_geomean": 1.013446,
+    "theta": 0.037308,
+    "aa_dispersion": 0.018654,
+    "significant": false,
+    "neutral": true
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "wf_log10x8",
+      "verified": true,
+      "artifact_sha256": "6a2250b56d5e10b6385e3a0f617ef4cee001b5279fd3bbef404a5ccb58ccd7ce"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "wf_log10x8": {
+        "round_ratios": [
+          1.009172,
+          1.117263,
+          1.013446,
+          0.999101,
+          0.998522,
+          1.004853,
+          1.043585,
+          0.999732,
+          1.032828,
+          0.966884,
+          1.056547,
+          1.005495,
+          1.026753,
+          0.999295
+        ],
+        "proof_digest": "91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700",
+        "request_ratio": 1.01381,
+        "report_sha256s": [
+          "b57872d8092743cc076222652ca9d2b1df7e05f743e323986f20498fa9550e77",
+          "96e6250f4de39634628e45ce6ca36d71b5cf47bc062d104b0c2112378a4f789b",
+          "1287d99155348a0ad8361fddde6ac1477dae3916bc7512767c6e1a1790568303",
+          "2090f93c5c8a3af051a8ca8bf5d7a0f22b3566f1776481f5ce6d67998e16c4fb",
+          "a1d50c60168894f0185a245796a6418e143da851cb6cb2d1726db4b98e024a92",
+          "61ae892a80ce0857eb26151b1a90251f23282268112b7c01d8873f874ecc4d3d",
+          "85cbbea31089ffff1f1d2ebb5198805713dbe727116703ae6c72c602b6cad140",
+          "e8952157c2b42ccb742cc5be55d0e04ebaa4783a343c120526b1df08c3032ae4",
+          "d6054c6e48247b8640852a8a95aa4e00f823701bf3124bbc9c9f99876f049f5e",
+          "8f43768f11e12f8190b9c825294b2cafb1c7bad0fad93a1ad296d1d445fd5b32",
+          "5422249af587fc1a2565b528061fb458014d77a3712560d5ea3144025e2989ba",
+          "8b88926d0a68f73517556021a87130c36aea40e3fdc6ad612c6cbd79399565aa",
+          "9ab60112ddab9b741ffd37eb9c26095216956cd7fc3d8d12b7edd0ec29113d44",
+          "33f157bfb375ebacc23a1d4030f3707001acc939e593896dd93f6a1b70d6cd2c",
+          "b2f8f8a3b17cbf7619745f740d8e9048412e2222bcbb1e927d51bd0e22bf0d14",
+          "1f2c940556c14d71615e42012476f0b130521765a8ef06fd401d0107857791d0",
+          "404d91df611fc552c19c50791c5e04bc0df1f3ed2c2d0614e9781c452e9dcf06",
+          "55498e85e6d569710238b8aa7177e1b6e438dde5865e327df1668a18c17abef4",
+          "f889563b4cacad798d18724311a4837b57985bb04ce5e1653bddc46383ffbcf2",
+          "5136105d3c90951d44a7e6e871afe2840f238a5830f7be184363bd3fece49ecb",
+          "9e3e6df456174ad7383e2e5080f47d1572fa80929c39290f882c7c4bd7fad476",
+          "00bcdf1579b08b4b3e956232f93b9a9a458cec7a8f957ab41808b97575beb643",
+          "f2aa540f96eae8fa56010682c10250cfb5f4c8c1427eb591918c2c90285ace9e",
+          "b7c6e755728f1733cfe202d2d383d60017a3493d4f52993d665fb436f372b07e",
+          "ff0eee81332df9b53a83994319ce55cfb4b3a3638681653579a0dde2930425ba",
+          "9eb2525b14d759d397d6d22060cf499b8d7d5c41ee6cd8df50aba62f8aadaed6",
+          "7c36fb67b52c7fd50796410f55533c27323189e10613fb33fcb1f3bddcf9d1a7",
+          "9b27e44370dd10cc898a769a39f4dc115f8981a1cfdcca39312ccab7be2140f6"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.b10.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.a11.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.b11.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.a12.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.b12.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.a13.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.b13.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.a14.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch4/autoresearch/.runs/latest/wf_log10x8.b14.json"
+    ]
+  }
+}

--- a/src/backends/metal/runtime/lifecycle_and_tree.m
+++ b/src/backends/metal/runtime/lifecycle_and_tree.m
@@ -63,11 +63,8 @@ void *stwo_zig_metal_merkle_commit(
         id<MTLBuffer> leaf_seed_buffer = [runtime.device newBufferWithBytes:leaf_seed
                                                                      length:8u * sizeof(uint32_t)
                                                                     options:MTLResourceStorageModeShared];
-        id<MTLBuffer> node_seed_buffer = [runtime.device newBufferWithBytes:node_seed
-                                                                     length:8u * sizeof(uint32_t)
-                                                                    options:MTLResourceStorageModeShared];
         if (staging == nil || offsets == nil || log_sizes == nil ||
-            leaf_seed_buffer == nil || node_seed_buffer == nil) {
+            leaf_seed_buffer == nil) {
             write_error(error_message, error_message_len, @"Metal Merkle allocation failed");
             return NULL;
         }
@@ -86,23 +83,61 @@ void *stwo_zig_metal_merkle_commit(
 
         uint32_t leaf_count = 1u << lifting_log_size;
         NSMutableArray<id<MTLBuffer>> *layers = [NSMutableArray arrayWithCapacity:lifting_log_size + 1u];
+        uint32_t layer_word_offsets[31] = { 0u };
+        uint32_t layer_word_lengths[31] = { 0u };
         uint32_t layer_count = leaf_count;
+        uint64_t arena_words = 0u;
         for (uint32_t level = 0; level <= lifting_log_size; ++level) {
-            // The tree is immutable after this command completes and the CPU
-            // later reads sparse authentication nodes.  On unified-memory
-            // devices, keeping those nodes shared avoids a second command
-            // buffer solely to make a few hashes CPU-visible.
-            MTLResourceOptions storage = level == lifting_log_size || runtime.device.hasUnifiedMemory
-                ? MTLResourceStorageModeShared
-                : MTLResourceStorageModePrivate;
-            id<MTLBuffer> layer = [runtime.device newBufferWithLength:(NSUInteger)layer_count * 32u
-                                                              options:storage];
-            if (layer == nil) {
-                write_error(error_message, error_message_len, @"Metal Merkle layer allocation failed");
+            arena_words = (arena_words + 63u) & ~UINT64_C(63);
+            uint64_t length_words = (uint64_t)layer_count * 8u;
+            if (arena_words > UINT32_MAX || length_words > UINT32_MAX ||
+                arena_words + length_words > UINT32_MAX) {
+                write_error(error_message, error_message_len, @"Metal Merkle arena exceeds word offsets");
                 return NULL;
             }
-            [layers addObject:layer];
+            layer_word_offsets[level] = (uint32_t)arena_words;
+            layer_word_lengths[level] = (uint32_t)length_words;
+            arena_words += length_words;
             layer_count >>= 1u;
+        }
+        id<MTLBuffer> hash_arena = [runtime.device newBufferWithLength:
+            (NSUInteger)arena_words * sizeof(uint32_t)
+            options:runtime.device.hasUnifiedMemory
+                ? MTLResourceStorageModeShared : MTLResourceStorageModePrivate];
+        id<MTLBuffer> root_readback = runtime.device.hasUnifiedMemory ? hash_arena
+            : [runtime.device newBufferWithLength:32u options:MTLResourceStorageModeShared];
+        NSData *layer_word_offsets_data = [NSData dataWithBytes:layer_word_offsets
+            length:(NSUInteger)(lifting_log_size + 1u) * sizeof(uint32_t)];
+        NSData *layer_word_lengths_data = [NSData dataWithBytes:layer_word_lengths
+            length:(NSUInteger)(lifting_log_size + 1u) * sizeof(uint32_t)];
+        if (hash_arena == nil || root_readback == nil || layer_word_offsets_data == nil ||
+            layer_word_lengths_data == nil) {
+            write_error(error_message, error_message_len, @"Metal Merkle arena allocation failed");
+            return NULL;
+        }
+        for (uint32_t level = 0u; level <= lifting_log_size; ++level)
+            [layers addObject:hash_arena];
+
+        StwoZigMerkleParentChain *parent_plan = nil;
+        if (lifting_log_size != 0u) {
+            uint32_t child_offsets[30] = { 0u };
+            uint32_t destination_offsets[30] = { 0u };
+            uint32_t parent_counts[30] = { 0u };
+            for (uint32_t level = 0u; level < lifting_log_size; ++level) {
+                child_offsets[level] = layer_word_offsets[level];
+                destination_offsets[level] = layer_word_offsets[level + 1u];
+                parent_counts[level] = leaf_count >> (level + 1u);
+            }
+            void *parent_plan_ptr = stwo_zig_metal_merkle_parent_chain_prepare(
+                runtime_ptr, child_offsets, destination_offsets, parent_counts,
+                lifting_log_size, node_seed, domain_prefix_bytes,
+                error_message, error_message_len);
+            if (parent_plan_ptr != NULL)
+                parent_plan = (__bridge_transfer StwoZigMerkleParentChain *)parent_plan_ptr;
+        }
+        if (lifting_log_size != 0u && parent_plan == nil) {
+            write_error(error_message, error_message_len, @"Metal Merkle parent-chain allocation failed");
+            return NULL;
         }
 
         id<MTLCommandBuffer> command = [runtime.queue commandBuffer];
@@ -147,7 +182,8 @@ void *stwo_zig_metal_merkle_commit(
         [leaf_encoder setBuffer:staging offset:0 atIndex:0];
         [leaf_encoder setBuffer:offsets offset:0 atIndex:1];
         [leaf_encoder setBuffer:log_sizes offset:0 atIndex:2];
-        [leaf_encoder setBuffer:layers[0] offset:0 atIndex:3];
+        [leaf_encoder setBuffer:hash_arena
+                         offset:(NSUInteger)layer_word_offsets[0] * sizeof(uint32_t) atIndex:3];
         [leaf_encoder setBytes:&column_count length:sizeof(column_count) atIndex:4];
         [leaf_encoder setBytes:&lifting_log_size length:sizeof(lifting_log_size) atIndex:5];
         [leaf_encoder setBuffer:leaf_seed_buffer offset:0 atIndex:6];
@@ -158,21 +194,24 @@ void *stwo_zig_metal_merkle_commit(
                 threadsPerThreadgroup:MTLSizeMake(leaf_width, 1, 1)];
         [leaf_encoder endEncoding];
 
-        uint32_t parents = leaf_count >> 1u;
-        for (uint32_t level = 1; level <= lifting_log_size; ++level) {
-            id<MTLComputeCommandEncoder> encoder = [command computeCommandEncoder];
-            [encoder setComputePipelineState:runtime.parents];
-            [encoder setBuffer:layers[level - 1u] offset:0 atIndex:0];
-            [encoder setBuffer:layers[level] offset:0 atIndex:1];
-            [encoder setBytes:&parents length:sizeof(parents) atIndex:2];
-            [encoder setBuffer:node_seed_buffer offset:0 atIndex:3];
-            [encoder setBytes:&domain_prefix_bytes length:sizeof(domain_prefix_bytes) atIndex:4];
-            NSUInteger width = MIN(runtime.parents.maxTotalThreadsPerThreadgroup,
-                                   runtime.parents.threadExecutionWidth * 8u);
-            [encoder dispatchThreads:MTLSizeMake(parents, 1, 1)
-                    threadsPerThreadgroup:MTLSizeMake(width, 1, 1)];
-            [encoder endEncoding];
-            parents >>= 1u;
+        if (parent_plan != nil) {
+            uint64_t parent_encoders = 0u, parent_dispatches = 0u;
+            if (!encode_merkle_parent_chain_prepared(runtime, hash_arena, parent_plan, command,
+                                                      &parent_encoders, &parent_dispatches)) {
+                write_error(error_message, error_message_len, @"Metal Merkle parent-chain encoding failed");
+                return NULL;
+            }
+        }
+        if (!runtime.device.hasUnifiedMemory) {
+            id<MTLBlitCommandEncoder> root_copy = [command blitCommandEncoder];
+            if (root_copy == nil) {
+                write_error(error_message, error_message_len, @"Metal Merkle root encoder allocation failed");
+                return NULL;
+            }
+            [root_copy copyFromBuffer:hash_arena
+                         sourceOffset:(NSUInteger)layer_word_offsets[lifting_log_size] * sizeof(uint32_t)
+                             toBuffer:root_readback destinationOffset:0u size:32u];
+            [root_copy endEncoding];
         }
 
         [command commit];
@@ -185,7 +224,11 @@ void *stwo_zig_metal_merkle_commit(
 
         StwoZigMetalTree *tree = [StwoZigMetalTree new];
         tree.layers = layers;
-        tree.rootReadback = layers.lastObject;
+        tree.layerWordOffsets = layer_word_offsets_data;
+        tree.layerWordLengths = layer_word_lengths_data;
+        tree.rootReadback = root_readback;
+        tree.rootReadbackWordOffset = runtime.device.hasUnifiedMemory
+            ? layer_word_offsets[lifting_log_size] : 0u;
         tree.logSize = lifting_log_size;
         tree.gpuMilliseconds = (command.GPUEndTime - command.GPUStartTime) * 1000.0;
         return (__bridge_retained void *)tree;

--- a/src/backends/metal/runtime/quotients.m
+++ b/src/backends/metal/runtime/quotients.m
@@ -138,12 +138,19 @@ bool stwo_zig_metal_compute_quotients(
                                                      options:runtime.device.hasUnifiedMemory
                                                          ? MTLResourceStorageModeShared
                                                          : MTLResourceStorageModePrivate];
-            root_readback = [runtime.device newBufferWithLength:32u options:MTLResourceStorageModeShared];
-            for (uint32_t level = 0u; level <= lifting_log_size; ++level) [layers addObject:hash_arena];
+            root_readback = runtime.device.hasUnifiedMemory ? hash_arena
+                : [runtime.device newBufferWithLength:32u options:MTLResourceStorageModeShared];
             layer_word_offsets_data = [NSData dataWithBytes:layer_word_offsets
                                                     length:(NSUInteger)(lifting_log_size + 1u) * sizeof(uint32_t)];
             layer_word_lengths_data = [NSData dataWithBytes:layer_word_lengths
                                                     length:(NSUInteger)(lifting_log_size + 1u) * sizeof(uint32_t)];
+            if (column_offsets == nil || column_logs == nil || leaf_seed_buffer == nil ||
+                hash_arena == nil || root_readback == nil || layer_word_offsets_data == nil ||
+                layer_word_lengths_data == nil) {
+                write_error(error_message, error_message_len, @"Resident quotient Merkle metadata allocation failed");
+                return false;
+            }
+            for (uint32_t level = 0u; level <= lifting_log_size; ++level) [layers addObject:hash_arena];
 
             uint32_t child_offsets[30] = { 0u };
             uint32_t destination_offsets[30] = { 0u };
@@ -158,9 +165,8 @@ bool stwo_zig_metal_compute_quotients(
                 lifting_log_size, node_seed, domain_prefix_bytes, error_message, error_message_len);
             if (parent_plan_ptr != NULL)
                 parent_plan = (__bridge_transfer StwoZigMerkleParentChain *)parent_plan_ptr;
-            if (column_offsets == nil || column_logs == nil || leaf_seed_buffer == nil ||
-                hash_arena == nil || root_readback == nil || parent_plan == nil) {
-                write_error(error_message, error_message_len, @"Resident quotient Merkle metadata allocation failed");
+            if (parent_plan == nil) {
+                write_error(error_message, error_message_len, @"Resident quotient parent-chain allocation failed");
                 return false;
             }
         }
@@ -298,15 +304,17 @@ bool stwo_zig_metal_compute_quotients(
                 write_error(error_message, error_message_len, @"Resident quotient parent-chain encoding failed");
                 return false;
             }
-            id<MTLBlitCommandEncoder> root_copy = [command blitCommandEncoder];
-            if (root_copy == nil) {
-                write_error(error_message, error_message_len, @"Resident quotient root encoder allocation failed");
-                return false;
+            if (!runtime.device.hasUnifiedMemory) {
+                id<MTLBlitCommandEncoder> root_copy = [command blitCommandEncoder];
+                if (root_copy == nil) {
+                    write_error(error_message, error_message_len, @"Resident quotient root encoder allocation failed");
+                    return false;
+                }
+                [root_copy copyFromBuffer:hash_arena
+                             sourceOffset:(NSUInteger)layer_word_offsets[lifting_log_size] * sizeof(uint32_t)
+                                 toBuffer:root_readback destinationOffset:0u size:32u];
+                [root_copy endEncoding];
             }
-            [root_copy copyFromBuffer:hash_arena
-                         sourceOffset:(NSUInteger)layer_word_offsets[lifting_log_size] * sizeof(uint32_t)
-                             toBuffer:root_readback destinationOffset:0u size:32u];
-            [root_copy endEncoding];
         }
         [command commit];
         [command waitUntilCompleted];
@@ -326,6 +334,8 @@ bool stwo_zig_metal_compute_quotients(
             tree.layerWordOffsets = layer_word_offsets_data;
             tree.layerWordLengths = layer_word_lengths_data;
             tree.rootReadback = root_readback;
+            tree.rootReadbackWordOffset = runtime.device.hasUnifiedMemory
+                ? layer_word_offsets[lifting_log_size] : 0u;
             tree.logSize = lifting_log_size;
             tree.gpuMilliseconds = gpu_milliseconds != NULL ? *gpu_milliseconds : 0.0;
             *tree_out = (__bridge_retained void *)tree;


### PR DESCRIPTION
Packs generic main/composition Merkle levels into one aligned arena and reuses the existing shallow-parent tail kernel. On UMA, quotient roots now alias their shared arena instead of taking a redundant 32-byte blit.

Clean Native Metal A/B (7 alternating process pairs/class, 10 warmups + 7 verified samples/arm):
- wide: 0.9845 [0.9589, 0.9970], 1.55% confirmed
- deep: 0.9812 [0.9270, 0.9899], 1.88% confirmed
- three-class geomean: 0.9869

All 294 timed proofs verified with exact cross-arm hashes and zero fallback. CPU S3 controls are neutral and pass G1-G5. Full tests, Native Metal product, Metal parity/static checks, source conformance, AOT contracts, and API/GPU validation pass. Submission note and reasoning transcript are included.