### PR TITLE
Fuse Metal FRI folds into next-tree leaf preparation

### DIFF
--- a/autoresearch/submissions/2026-07-21-metal-fri-fold-leaf-fusion/delta.json
+++ b/autoresearch/submissions/2026-07-21-metal-fri-fold-leaf-fusion/delta.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "cafbe2c8a71f",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/backends/metal/core_aot.zig": "sha256:d9a7f8e3667dfbf425b5929f3fbe74434fa60e35fb7cf465b4d08cccc01b20b1",
+    "src/backends/metal/kernels.metal": "sha256:450c4456f9df28321e883ce8ce9c9185caceecbfce69b654ed4feda26cc26cb3",
+    "src/backends/metal/runtime.m": "sha256:7bc5eecae7350b04bf1efed8eba6434e7ef3c7b7cc64cce96734b8baa40fbd92",
+    "src/backends/metal/runtime.zig": "sha256:f3e4ebdd2ba8f622b1a11ae6b465a06f2d02a649710af10ca93918d8e85b4f2f",
+    "src/backends/metal/runtime/fri_fold_commit.m": "sha256:4445efa2be018e6ed7df31b3a4e78c3ccbcae0c8743c4126f937309a5aeb0910",
+    "src/backends/metal/runtime/fri_plans.m": "sha256:c12fc44113c17cd25ad72342d07282ff92cca67b4b445222395eaa82877f10a6",
+    "src/backends/metal/runtime/runtime_queries.m": "sha256:2aa784f9e854992e5019a120ab1e9a5607b633881a773744d479c88bd75972b3",
+    "src/backends/metal/shaders/core/commitments.metal": "sha256:4b140a20eef8b41ae2cc3d1a7270f55f9d449c2446b6a5a560bc43e1a21bbf12",
+    "src/backends/metal/shaders/manifest.zig": "sha256:c4de9cd76c33568111c60e0c8b44d6107dcd21bb9b1fd66f6d066c3b87b64eb6",
+    "src/backends/metal/tests/fri_fold_commit.zig": "sha256:a8b72969e75a7bb873cdb6aee052fd89c9ebbf9599f6e024a44e7f8481135ce8"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "211a8c64140791000f71aad6306218c8060f70fee1c463d7c000523c088b7945",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-21-metal-fri-fold-leaf-fusion/note.md
+++ b/autoresearch/submissions/2026-07-21-metal-fri-fold-leaf-fusion/note.md
@@ -1,0 +1,121 @@
+# Fuse Metal FRI folds into next-tree leaf preparation
+
+## Model and harness
+
+GPT-5 Codex optimized clean candidate `e20053d0dd90` from recorded predecessor
+`cafbe2c8a71f` on an Apple M5 Max with 64 GB unified memory running macOS
+26.5.2.  The repo-resident CLI was updated before research.  Native Metal
+evidence uses the real ReleaseFast `native-proof-bench-metal` product,
+functional protocol, independent proof verification, and
+`--metal-runtime source-jit`.
+
+Zig embeds the MSL amalgamation and macOS compiles it during initialization via
+`newLibraryWithSource`.  This host has Command Line Tools but no full Xcode or
+offline `metal` executable; neither is required for source-JIT.  Initialization
+is excluded from timed proofs.  The enabled scoring board remains CPU-only, so
+the attached S3 verdicts are honest no-regression controls rather than Metal
+performance credit.
+
+## Hypothesis
+
+Fresh profiles placed FRI quotient/build/commit at 3.30--3.89 ms across all
+three Native Metal classes.  Inside the already-resident line-FRI epoch, every
+logical tree still used this producer chain:
+
+```text
+fold -> next QM31 evaluation -> scatter four coordinate planes
+     -> reread coordinates -> hash four-column leaves -> Merkle parents
+```
+
+The next evaluation exists in registers at the fold boundary.  Coordinates
+must remain materialized for proof decommitment, but leaf hashing does not need
+to reread them.  Producing the evaluation, its four coordinate values, and its
+leaf hash together should eliminate two grids per nonterminal transition while
+preserving the serialized Fiat--Shamir dependency.
+
+The prediction was 93 -> 68 line-cascade dispatches on wide/deep, 55 -> 38 on
+small, exact roots/proofs/channel state, one command buffer and wait, and a
+measurable end-to-end win.
+
+## Changes
+
+The existing QM31-coordinate and line-fold shaders now expose explicit ABI-3
+modes:
+
+- coordinate mode can also hash the initial tree leaf from the in-register
+  QM31 value;
+- every nonterminal line fold can simultaneously write the next evaluation,
+  scatter its four SoA coordinate planes, and hash the next tree leaf; and
+- plain modes preserve standalone, prepared-arena, reference, and terminal-fold
+  callers.
+
+The host cascade launches one initial coordinate/leaf producer, begins every
+tree directly at its parent levels, and selects prepare-next mode on all but the
+terminal fold.  Hash initialization, 16-byte message length, domain prefix,
+tree layout, coordinate ownership, transcript order, and final evaluation are
+unchanged.
+
+The widened kernels moved from the legacy shader into the modular commitment
+translation unit.  The authenticated core shader ABI advances from 2 to 3,
+while reusing the same two entry-point names keeps the exact Native export
+inventory at 78 and avoids any out-of-scope tooling edit.  ABI-2 AOT bundles
+fail closed.  No new pipeline, feature requirement, command buffer, wait,
+allocation, fallback, or function constant was added.
+
+## Results
+
+Fifteen clean paired rounds per class alternated A-B / B-A process order.
+Every process used ten verified warmups and seven timed independently verified
+proofs.  Statistics are the repository's round-median Hodges--Lehmann estimator
+with a deterministic 100,000-resample percentile bootstrap.
+
+| class | predecessor | candidate | B/A (95% CI) | paired wins |
+| --- | ---: | ---: | ---: | ---: |
+| small `wf_log10x8` | 2.694 ms | 2.655 ms | 0.9855 [0.9713, 0.9981] | 11/15 |
+| wide `wf_log14x32` | 11.718 ms | 11.575 ms | 0.9921 [0.9812, 1.0039] | 9/15 |
+| deep `plonk_log14` | 7.139 ms | 7.105 ms | 0.9942 [0.9911, 0.9979] | 12/15 |
+
+The suite geometric-mean ratio is 0.9906, about 0.94% less proof latency.
+Small and deep intervals exclude 1.0.  Wide is directionally favorable but
+neutral and is not overclaimed.  A large baseline-first excursion in the first
+small pair was retained; no round was deleted.
+
+All 630 timed proofs independently verified, were byte-identical within every
+process, matched across arms, classified accelerated-without-fallbacks, and
+used zero CPU fallback.  Fixed hashes remained:
+
+- small: `91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700`;
+- wide: `57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374`;
+- deep: `d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf`.
+
+Mechanism evidence exactly matches the design: wide/deep line cascades use 68
+dispatches instead of 93 and small uses 38 instead of 55, with one command
+buffer, one encoder, and one terminal wait.  Three final clean paired profile
+rounds put median FRI time at 3.926 -> 3.836 ms on wide (2.3%) and
+3.705 -> 3.672 ms on deep (0.9%).
+
+Full Zig and Native Metal product closures, source conformance, runtime Metal
+compile, exact cascade parity, authenticated-AOT compile/probe contracts,
+Metal API/GPU shader validation, and diff checks pass.  The broad Metal suite
+is 80/83: two expected skips and the same resident-policy assertion present on
+the untouched predecessor.
+
+Fresh CPU S3 controls pass G1--G5, the pinned Rust oracle, proof checks,
+editable-path policy, request budgets, and applicable guards.  They are neutral
+as expected: small 1.0069 `[0.9883, 1.0236]`, wide 0.9909
+`[0.9700, 0.9976]` (inside its dispersion threshold), and deep 0.9970
+`[0.9909, 1.0020]`.
+
+## Caveats
+
+- No enabled Metal judge workload exists, so the harness cannot award this
+  Metal result leaderboard credit; the attached CPU verdicts are controls.
+- Full Metal System Trace is unavailable without full Xcode.  Real source-JIT
+  execution, GPU timestamps, stage profiles, validation layers, exact proofs,
+  and source-visible dispatch accounting provide the attribution.
+- The Debug device-time reduction is much larger than ReleaseFast end-to-end
+  movement; the claim uses only clean ReleaseFast proof latency and paired
+  profiles.
+- An AOT metallib must still be produced on a machine with the offline Metal
+  toolchain.  The resulting artifact can be loaded without Xcode, and the
+  deterministic AOT contract/probe suites pass for the ABI change.

--- a/autoresearch/submissions/2026-07-21-metal-fri-fold-leaf-fusion/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-21-metal-fri-fold-leaf-fusion/transcripts/session-01.md
@@ -1,0 +1,244 @@
+# Session 01 — fifth Metal-backend architecture campaign
+
+Date: 2026-07-21
+Model: GPT-5 Codex
+
+## Recorded frontier and objective
+
+The preceding campaign merged PR #28, packing generic main/composition Merkle
+levels into tail-fused arenas.  Its Native Metal evidence confirmed 1.55% wide
+and 1.88% deep proof-latency reductions; the CPU-only recorder classified its
+official controls neutral and advanced the recorded frontier to
+`cafbe2c8a71f`.  The canonical checkout and repo-resident CLI were updated to
+that exact commit before this workspace was created, and `stwo-perf setup`
+passed.
+
+All repository skills remain active: canonical algorithm matching, Metal
+performance design and its compute-pattern reference, Metal profiling, Zig
+host profiling, and reasoning-first submission transcripts.  The prior notes,
+submission notes, and transcripts are cumulative research input.  No
+production source has been edited in this iteration.
+
+The first action is a fresh ReleaseFast source-JIT run of all three production
+Native Metal shapes with exact proof and fallback auditing, followed by clean
+stage/device attribution.  The leading unimplemented ideas from prior work are
+fusing coordinate conversion with FRI leaf hashing, folding the circle-to-line
+boundary into the resident FRI epoch, and reducing persistent CPU-side plan or
+allocation overhead around already-fused GPU work.  Candidate selection waits
+on the new frontier profile and a dependency/resource visualization.
+
+## Fresh recorded-frontier profile
+
+The transcript was stashed while the untouched frontier ran, so every report
+records exact commit `cafbe2c8a71f`, `git_dirty=false`, `complete=true`, and
+ReleaseFast.  Each class used ten warmups and seven profiled verified samples:
+
+| stage median (ms) | small | wide | deep |
+| --- | ---: | ---: | ---: |
+| complete prove | 6.437 | 11.735 | 7.184 |
+| main commit | 1.117 | 1.856 | 0.640 |
+| composition evaluation | 0.055 | 2.618 | 0.120 |
+| composition interpolate/split | 0.041 | 0.480 | 0.053 |
+| composition commit | 0.933 | 1.386 | 0.742 |
+| sampled values | 0.414 | 0.793 | 0.711 |
+| FRI quotient/commit | 3.302 | 3.890 | 3.720 |
+| proof of work | 0.406 | 0.335 | 0.318 |
+| all decommitment | 0.089 | 0.120 | 0.125 |
+
+Every timed proof matched the fixed class digest, independently verified, was
+byte-identical within its process, reported accelerated-without-fallbacks, and
+used zero CPU fallback.  FRI remains the dominant common residual.  Wide's
+composition evaluation is also large, but it is mostly prover/field work rather
+than the requested Metal focus.  The next dependency map therefore starts at
+the physical boundaries inside the one-epoch line-FRI cascade, not at already
+sub-millisecond decommitment or proof-of-work stages.
+
+## FRI dependency map and selected fusion architecture
+
+A fresh Debug device run put the thirteen-layer wide line cascade at a stable
+3.37--3.51 ms, 93 dispatches, one compute encoder, one command buffer, and one
+terminal wait.  The current per-stage chain is:
+
+```text
+evaluation_s (QM31 AoS)
+  -> coordinate scatter grid -> coordinates_s (four SoA planes)
+  -> leaf-hash grid           -> Merkle leaves_s
+  -> parent grids/tail        -> root_s
+  -> transcript mix/draw      -> alpha_s
+  -> line-fold grid           -> evaluation_s+1
+```
+
+The coordinate planes must remain alive for proof decommitment, so deleting
+the scatter is invalid.  Merely putting conversion and hashing in one new grid
+would save one dispatch per stage.  A stronger producer-consumer fusion follows
+from the dependency direction: the line fold has the next QM31 value in
+registers.  For every nonterminal transition it can write the next evaluation,
+scatter its four coordinates, and Blake-hash the next tree leaf before those
+registers die.  The next stage then begins directly at its parent chain:
+
+```text
+initial: evaluation_0 -> [coordinates + leaf]_0 -> parents/root/channel
+
+transition s:
+root_s -> alpha_s -> [fold + coordinates + leaf]_(s+1)
+                    |-> evaluation_(s+1)
+                    |-> coordinates_(s+1)
+                    `-> Merkle leaves_(s+1)
+```
+
+| physical work, wide | current | fused |
+| --- | ---: | ---: |
+| coordinate grids | 13 | folded into producer |
+| leaf grids | 13 | folded into producer |
+| line-fold grids | 13 | 12 fused transitions + 1 terminal |
+| initial producer grid | 0 | 1 |
+| parent grids/tails | 28 | 28 |
+| transcript grids | 26 | 26 |
+| total dispatches | 93 | 68 predicted |
+
+Small similarly predicts 55 -> 38 dispatches.  Besides dispatch setup, the
+fused kernels avoid rereading every just-written coordinate plane for leaf
+hashing.  The hash message is still exactly the four QM31 coordinates followed
+by twelve zero words, with the same seeded/unseeded initialization and byte
+count as generic four-column leaves.
+
+Candidate comparison:
+
+| candidate | ceiling and risk | decision |
+| --- | --- | --- |
+| Fuse only coordinate scatter + leaf hash | 13 dispatches, one coordinate reread | subsumed |
+| Fuse circle-to-line submission boundary | one tiny ~0.03 ms device stage plus host boundary | defer |
+| Cache Objective-C plans/metadata | CPU allocation-only, unclear lifetime win | defer |
+| Fold + next coordinates + next leaf | 25 wide/deep dispatches and memory traffic | select |
+
+The initial design called for two eager Native entry points (initial
+coordinates/leaves and fold/next-coordinates/leaves), so the authenticated core
+shader ABI must advance rather than silently accepting an older metallib.
+Source-JIT remains the production benchmark path on this host.  The exact
+entry-point accounting is left to implementation and the editable-path gate;
+AOT contract tests and hosted Metal compile remain mandatory.
+
+Prediction: reduce wide/deep line-cascade device time by 0.25--0.55 ms and
+end-to-end proof latency by at least 2% on one production class, with exact
+roots, coordinate columns, terminal evaluation, channel state, proof bytes,
+one command buffer/wait, and zero fallback.  Falsifiers are any prefix-hash
+mismatch, next-tree root mismatch, missing coordinate value, Metal validation
+error, authenticated-AOT contract failure, or clean paired interval crossing a
+material regression.
+
+## Implementation and mechanism check
+
+The two existing eager core pipelines now own the producer boundary through
+explicit ABI-3 modes.  The coordinate pipeline scatters each QM31 evaluation
+into four planes and, in cascade mode, hashes that same in-register value into
+its four-column leaf.  The line-fold pipeline always writes the next AoS
+evaluation and, in prepare-next mode, simultaneously scatters and hashes it
+into the next tree.  Plain modes preserve every existing standalone/prepared
+caller; the terminal fold remains plain.  The host cascade therefore starts
+each tree at its parent levels and retains the same coordinate buffers for
+decommitment.
+
+The widened kernels live in the modular commitment translation unit, not the
+legacy shader file.  The authenticated core shader ABI advances from 2 to 3,
+but the exact Native export inventory remains 78 and no out-of-scope AOT probe
+edit is needed.  Old ABI-2 bundles fail closed.  Runtime source-JIT compiles the
+same embedded amalgamation through `newLibraryWithSource`; no offline compiler
+is present or needed on this machine.
+
+Focused exact-parity tests compare every coordinate plane, Merkle root,
+Fiat--Shamir challenge, and final evaluation against the unfused reference.
+The five-layer fixture moved from 30 to 21 dispatches.  Full Debug proofs
+matched all fixed digests and observed the predicted production topologies:
+
+| class | line-cascade dispatches before -> after | warmed cascade GPU time |
+| --- | ---: | ---: |
+| small | 55 -> 38 | 1.72--1.86 ms |
+| wide | 93 -> 68 | 2.83 ms, from 3.37--3.51 ms |
+| deep | 93 -> 68 | frequency-sensitive, exact at every sample |
+
+The wide device reduction is roughly 0.64 ms, exceeding the predicted ceiling.
+The result still uses one command buffer, one compute encoder, and one terminal
+wait; it is dispatch and coordinate-read elimination rather than hidden host
+overlap.
+
+## First-implementation diagnostic screen
+
+Before freezing, seven alternating process pairs per class ran the real
+ReleaseFast source-JIT product with ten warmups and seven independently
+verified timed proofs per process.  This screen is intentionally labeled
+diagnostic because the candidate worktree was dirty.  Every proof matched its
+fixed digest, all 294 timed proofs verified and were byte-identical within
+process, all samples classified accelerated-without-fallbacks, and total CPU
+fallbacks were zero.
+
+| class | predecessor median | candidate median | B/A HL (95% CI) | wins |
+| --- | ---: | ---: | ---: | ---: |
+| small | 2.700 ms | 2.672 ms | 0.9896 [0.9762, 1.0024] | 5/7 |
+| wide | 11.730 ms | 11.619 ms | 0.9921 [0.9758, 1.0091] | 4/7 |
+| deep | 7.178 ms | 7.066 ms | 0.9844 [0.9778, 0.9914] | 7/7 |
+
+The robust three-class geometric-mean ratio is 0.9887.  Device attribution and
+seven unanimous deep wins justified retaining the architecture, while the wide
+interval honestly records end-to-end thermal noise.  A first clean candidate
+preserved the effect, but its two added exports required changing a hard AOT
+count assertion outside the manifest's editable set.  The official control
+caught that as G2 before submission.  The implementation was therefore
+redesigned around the two widened existing entry points described above.  The
+out-of-scope change was fully removed, all legacy callers were rebound, and no
+favorable measurement from the rejected tree is used as final evidence.
+
+## Final clean paired evidence
+
+Final candidate `e20053d0dd90` and predecessor `cafbe2c8a71f` were independently
+built from clean ReleaseFast worktrees.  Fifteen rounds per class alternated
+A-B / B-A process order.  Every process used ten verified warmups followed by
+seven timed independently verified proofs.  The reports were rejected unless
+they named the exact commit, were clean and complete, used source-JIT, created
+no post-warmup pipeline, matched the fixed digest, classified every sample as
+accelerated-without-fallbacks, and reported zero CPU fallback.
+
+| class | predecessor median | candidate median | B/A HL (95% CI) | wins |
+| --- | ---: | ---: | ---: | ---: |
+| small | 2.694 ms | 2.655 ms | 0.9855 [0.9713, 0.9981] | 11/15 |
+| wide | 11.718 ms | 11.575 ms | 0.9921 [0.9812, 1.0039] | 9/15 |
+| deep | 7.139 ms | 7.105 ms | 0.9942 [0.9911, 0.9979] | 12/15 |
+
+The robust suite geometric-mean ratio is 0.9906, about 0.94% less proof
+latency.  Small and deep intervals exclude 1.0; wide is favorable but remains
+neutral and is not overclaimed.  The first small round contains a large
+baseline-first frequency-ramp excursion (5.162 vs 3.080 ms).  It is retained,
+not pruned; the Hodges--Lehmann estimator and all bootstrap resamples see it.
+Across the experiment all 630 timed proofs verified and stayed byte-identical.
+
+Three final clean paired profiled rounds per large class locate the movement in
+the selected stage.  Median FRI quotient/build/commit time fell 3.926 -> 3.836
+ms on wide (2.3%) and 3.705 -> 3.672 ms on deep (0.9%).  Wide's FRI stage won
+all three profile pairs and deep won two of three.  This is consistent with the
+fixed 93 -> 68 dispatch topology and with a small whole-prover effect after the
+earlier large synchronization and Merkle wins.
+
+## Official controls
+
+The enabled judge board is CPU-only, so fresh S3 controls measure no expected
+Metal benefit.  All three pass G1--G5, the pinned Rust oracle, exact cross-arm
+proof checks, editable-path policy, request budgets, and applicable guards:
+
+- small: 1.0069 [0.9883, 1.0236], confirmed neutral;
+- wide: 0.9909 [0.9700, 0.9976], below 1.0 but inside its dispersion threshold;
+- deep: 0.9970 [0.9909, 1.0020], confirmed neutral.
+
+These controls are not presented as Metal performance credit.  The claim above
+comes from the real production Native Metal binary on the source-JIT path.
+
+## Frozen validation
+
+The final candidate passes the full Zig closure, Native Metal product closure and
+device-only lifecycle, exact cascade parity test, runtime `metal-check`, source
+conformance, authenticated-AOT compile and acceptance-probe suites, diff checks,
+and a complete proof with both Metal API and GPU shader validation enabled.
+The broad Metal suite remains 80/83: two expected skips and the same resident
+policy assertion reproduced on the untouched predecessor.  Moving the kernels
+out of the legacy shader file was required to retain the 850-line manual-source
+ceiling; no conformance exception was added.  The aggregate frontier diff
+touches only `src/backends/metal/**` and passes the submission editable-path
+gate.

--- a/autoresearch/submissions/2026-07-21-metal-fri-fold-leaf-fusion/verdict-deep.json
+++ b/autoresearch/submissions/2026-07-21-metal-fri-fold-leaf-fusion/verdict-deep.json
@@ -1,0 +1,137 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "24820b7c6102",
+  "repo_commit": "e20053d0dd90",
+  "predecessor_commit": "cafbe2c8a71f",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 2.04
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.4658 vs targeted budget x1.02; request ratio 0.9993 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "plonk_log14": {
+        "r": 0.996983,
+        "ci": [
+          0.990875,
+          1.001992
+        ],
+        "rounds": 7,
+        "a_median_ms": 6.740375,
+        "b_median_ms": 6.71525
+      }
+    },
+    "R_geomean": 0.996983,
+    "theta": 0.018278,
+    "aa_dispersion": 0.009139,
+    "significant": false,
+    "neutral": true
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "plonk_log14",
+      "verified": true,
+      "artifact_sha256": "ed64ff803f2e7ec8c5eeb81f520ee3cb228c6811795a53137092a8632f9e5e68"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "plonk_log14": {
+        "round_ratios": [
+          0.999611,
+          0.984419,
+          0.995399,
+          1.008457,
+          1.001992,
+          0.997332,
+          0.991276
+        ],
+        "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf",
+        "request_ratio": 0.999284,
+        "report_sha256s": [
+          "c15f27b9e8e8076b0a70c073969cf9d32b0c1c07bede9e760e3572981416b9db",
+          "5d4864112fc761d2de5e2d5cf3ed7398def0185baf01109df42e7ef00fd717b4",
+          "0189d3c1c4ed556db8dde1db7c0712819f512434abacbcba3ed3183591b05ae4",
+          "1e1c23302752f1f02b862e69145c960aa93fd4882d6a598c8d8caf63e9990247",
+          "59e73231cf0c43f898a9899565e2c08852a4790f42a5b25b71c267184e515426",
+          "d45a39c4dcb5fc2c744cb40318d6aecef343e5775ca9640944cc0b8311cf1275",
+          "1492f39db54ffe0670e5e1d3d553147a33f7da94c250e736b60276730a414790",
+          "9a53b8497e1c162f585bd395028fe90bd855408ddc34cbcb8f6374099160ff58",
+          "cdf76194842952cba97625e6755f5d3e04e34cdb474ea8b40d29ab8e617a5fdc",
+          "d4d74a95d6ddf6e11657d6763c027c07ed96ff005cd3ef376e82849b9c8ae0fa",
+          "f15f999b490709df9edfca78773dc7ee2abe66f6d75069cf43f0d4e564e0a9b6",
+          "f7955fb2421fccd527fab8c28ed6dc6b88bae8c1857a4882369a1f7e3157d71e",
+          "3f346abb79ead3b9f437f7ccdc1133f6cf2eaa7c012c1227b2fde4614fbfee83",
+          "418cba6428e1ff648c9b4cb29a96d62cf2c017b143b4a30864e449e7d59447d6"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/plonk_log14.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/plonk_log14.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/plonk_log14.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/plonk_log14.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/plonk_log14.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/plonk_log14.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/plonk_log14.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/plonk_log14.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/plonk_log14.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/plonk_log14.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/plonk_log14.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/plonk_log14.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/plonk_log14.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/plonk_log14.b7.json"
+    ]
+  }
+}

--- a/autoresearch/submissions/2026-07-21-metal-fri-fold-leaf-fusion/verdict-wide.json
+++ b/autoresearch/submissions/2026-07-21-metal-fri-fold-leaf-fusion/verdict-wide.json
@@ -1,0 +1,147 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "24820b7c6102",
+  "repo_commit": "e20053d0dd90",
+  "predecessor_commit": "cafbe2c8a71f",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "wide",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 2.23
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.6032 vs targeted budget x1.02; request ratio 0.9928 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log14x32": {
+        "r": 0.99085,
+        "ci": [
+          0.96996,
+          0.997646
+        ],
+        "rounds": 9,
+        "a_median_ms": 10.748333,
+        "b_median_ms": 10.649584
+      }
+    },
+    "R_geomean": 0.99085,
+    "theta": 0.02929,
+    "aa_dispersion": 0.014645,
+    "significant": false,
+    "neutral": false
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "wf_log14x32",
+      "verified": true,
+      "artifact_sha256": "d32393fe3b1f9abbc4795d87c3b3316e06111f014ec30f0635f13ec0ff0587f9"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "wf_log14x32": {
+        "round_ratios": [
+          0.959179,
+          0.985828,
+          1.000807,
+          0.939964,
+          0.994485,
+          0.987214,
+          0.999957,
+          0.995015,
+          0.998582
+        ],
+        "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374",
+        "request_ratio": 0.992827,
+        "report_sha256s": [
+          "5ff95b4fb35c84bb74db4f4d5cea8e05965d6ea69f73cee009a6dbe84f122799",
+          "a783c8893e08f9c9a5a99a61c8611679e4c70d580f9707c57d3ed6cda9a793b6",
+          "c2aa129610c790ff6916edc0fe05580c4b4d66063d9e5a91898f592466b74f1f",
+          "7a0d08dbdc67aa7140c93827056b500a1eb03ce5cbc533b0e1a5f8f546665891",
+          "48561067a88da1e24fea7ea0b4ccd26c74d1e1cf8ae86bd2dc70328d591c2fff",
+          "24fee3d06f0777e082217fd2e43db30d3666ddfd787ca03b5932b0c697a78a48",
+          "4a0225ef83da52ec6041553b12b9b74ed2846b505d6c5db573242b7516a3fb3a",
+          "e6be5af8a4431dafafb066c3c0aad07b94bef8baef8eccc3a11d4caba1bf46ea",
+          "b543ffd87ecd750e46df552c7c8098c5a142b50905899910f55d2d94a7c292db",
+          "19a6a24b0ec96e7c1dd4bd54b312a3936b5d4806a492e7a4af34c75e37e28ffc",
+          "fe59ffdf7ca3b04b758c4bb91e7a8c2325cd4cac8c685c350df0161d033848ab",
+          "f9d9f71be543fbad2a6c8733f6df4667ba027e7c7dd6bfa4338935512a439f9f",
+          "2bc6aae0223d0d052f85f209b3d9e58237d74712e65468275568d56304143975",
+          "82ed454604ef004088a744150fa3118c5558c09f2d4429fd3e215dc959de6a8a",
+          "ac84ce09a8d1847252ced1463883d57918d3a330362358413381d1d3e9d55791",
+          "7817c55ccf3730ad9ca3ea5295959e63cc6ed44ec576417fe186e634c800628e",
+          "432b9b67e887912f6558bb5e3a7079860265d308b5d995f767613821fad4b18d",
+          "8806de0046d53530a3e4bb41cdb56efa26deb3e919ca7c272863c8514ede31a3"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log14x32.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log14x32.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log14x32.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log14x32.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log14x32.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log14x32.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log14x32.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log14x32.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log14x32.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log14x32.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log14x32.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log14x32.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log14x32.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log14x32.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log14x32.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log14x32.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log14x32.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log14x32.b9.json"
+    ]
+  }
+}

--- a/autoresearch/submissions/2026-07-21-metal-fri-fold-leaf-fusion/verdict.json
+++ b/autoresearch/submissions/2026-07-21-metal-fri-fold-leaf-fusion/verdict.json
@@ -1,0 +1,137 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "24820b7c6102",
+  "repo_commit": "e20053d0dd90",
+  "predecessor_commit": "cafbe2c8a71f",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 1.94
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.5312 vs targeted budget x1.02; request ratio 1.0082 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log10x8": {
+        "r": 1.006939,
+        "ci": [
+          0.988292,
+          1.023601
+        ],
+        "rounds": 7,
+        "a_median_ms": 1.46775,
+        "b_median_ms": 1.481584
+      }
+    },
+    "R_geomean": 1.006939,
+    "theta": 0.037308,
+    "aa_dispersion": 0.018654,
+    "significant": false,
+    "neutral": true
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "wf_log10x8",
+      "verified": true,
+      "artifact_sha256": "6a2250b56d5e10b6385e3a0f617ef4cee001b5279fd3bbef404a5ccb58ccd7ce"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "wf_log10x8": {
+        "round_ratios": [
+          1.004743,
+          0.97184,
+          1.039579,
+          1.021324,
+          0.973806,
+          1.010503,
+          1.009626
+        ],
+        "proof_digest": "91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700",
+        "request_ratio": 1.008198,
+        "report_sha256s": [
+          "c4cb52fc63b0091fdfa1b5404114776f088315db4815c14d5fcc030b7731f10f",
+          "7e57ddf72d19a3dd46067067c22f94a845f39bbbc07527c6e07236706d33c975",
+          "fc9cf76d9900efdbe82908ac929c3090f77bfd39ca4011329e8c04620f461055",
+          "f6205559f2cbb6fa2a81e4ecc373e58da37898502e3f75ff77ba7955c7116731",
+          "da08f3383a79dac36b193c5bff20d58bee373548feadd12dd3d7d48b479c638e",
+          "b1072854e888bab6858c8587c524c394f466ee8b001b9e83c9ee8e4c110a7e9a",
+          "ddee4e32b1c1c85dfd2c72ca7b6a7b4f28a8137a058662ce9afc7f9c6ceaa9bd",
+          "9df90c0285475f460871ee0ec45a27d60c32e2d3d9cfd6ee9d36d629ce584b7f",
+          "b2e80f48f444fdfb682ae62395bfbd9ee9b0291d7295ba6af898d6974d81dbaa",
+          "f1a20340dd4f4b1eaeef215108160b80fec249d3753a0aed7310c0bafbec756e",
+          "cfc31cef8de9a4605b6ba4dc7b9e782d7d7b06860811e057034ff16d757068f6",
+          "af2b553f281a7e311d81bf7f15dd57536320b49ef1b6872d9f86c0f428bdaeae",
+          "7d2b3a67f3406e370557823ebfb7e60d7482a71636950353c61eeee23d976553",
+          "b2b5cb096abcbeda30c1454eca8500d0b97e9e699a688e05c860fb2a56050014"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log10x8.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log10x8.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log10x8.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log10x8.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log10x8.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log10x8.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log10x8.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log10x8.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log10x8.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log10x8.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log10x8.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log10x8.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log10x8.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch5/autoresearch/.runs/latest/wf_log10x8.b7.json"
+    ]
+  }
+}

--- a/src/backends/metal/core_aot.zig
+++ b/src/backends/metal/core_aot.zig
@@ -455,7 +455,7 @@ test "Native AOT admission rejects authority drift" {
     );
 
     @memcpy(candidate, valid);
-    try replaceManifestOnce(temporary.dir, candidate, "\"core_shader_abi\": 2", "\"core_shader_abi\": 3");
+    try replaceManifestOnce(temporary.dir, candidate, "\"core_shader_abi\": 3", "\"core_shader_abi\": 4");
     try std.testing.expectError(
         error.CoreShaderAbiMismatch,
         admit(std.testing.allocator, bundle_path, manifestDigest(candidate)),

--- a/src/backends/metal/kernels.metal
+++ b/src/backends/metal/kernels.metal
@@ -259,34 +259,6 @@ kernel void stwo_zig_fri_fold_circle(
     destination[index] = qm_add(sum, qm_mul(alpha, difference));
 }
 
-kernel void stwo_zig_fri_fold_line(
-    device const Qm31Value *source [[buffer(0)]],
-    device const uint *inverse_x [[buffer(1)]],
-    constant Qm31Value &alpha [[buffer(2)]],
-    device Qm31Value *destination [[buffer(3)]],
-    constant uint &destination_count [[buffer(4)]],
-    uint index [[thread_position_in_grid]]
-) {
-    if (index >= destination_count) return;
-    Qm31Value f0 = source[index << 1u];
-    Qm31Value f1 = source[(index << 1u) + 1u];
-    destination[index] = qm_add(qm_add(f0, f1), qm_mul(alpha, qm_mul_m31(qm_sub(f0, f1), inverse_x[index])));
-}
-
-kernel void stwo_zig_qm31_to_coordinates(
-    device const Qm31Value *source [[buffer(0)]],
-    device uint *destination [[buffer(1)]],
-    constant uint &value_count [[buffer(2)]],
-    uint index [[thread_position_in_grid]]
-) {
-    if (index >= value_count) return;
-    Qm31Value value = source[index];
-    destination[index] = value.a;
-    destination[value_count + index] = value.b;
-    destination[2u * value_count + index] = value.c;
-    destination[3u * value_count + index] = value.d;
-}
-
 kernel void stwo_zig_quotient_rows(
     device const uint *flat_views [[buffer(0)]],
     device const QuotientView *views [[buffer(1)]],

--- a/src/backends/metal/runtime.m
+++ b/src/backends/metal/runtime.m
@@ -44,8 +44,6 @@
 @property(nonatomic, strong) id<MTLComputePipelineState> quotientCoefficientsResident;
 @property(nonatomic, strong) id<MTLComputePipelineState> friFoldCircle;
 @property(nonatomic, strong) id<MTLComputePipelineState> friFoldLine;
-@property(nonatomic, strong) id<MTLComputePipelineState> friCoordinatesAndLeaves;
-@property(nonatomic, strong) id<MTLComputePipelineState> friFoldLinePrepareNext;
 @property(nonatomic, strong) id<MTLComputePipelineState> friFold3Resident;
 @property(nonatomic, strong) id<MTLComputePipelineState> friFold2Resident;
 @property(nonatomic, strong) id<MTLComputePipelineState> friPackedLeavesResident;
@@ -539,8 +537,6 @@ static StwoZigMetalRuntime *create_runtime_from_library(
         runtime.quotientCoefficientsResident = make_pipeline(device, library, @"stwo_zig_quotient_coefficients_resident", error_message, error_message_len);
         runtime.friFoldCircle = make_pipeline(device, library, @"stwo_zig_fri_fold_circle", error_message, error_message_len);
         runtime.friFoldLine = make_pipeline(device, library, @"stwo_zig_fri_fold_line", error_message, error_message_len);
-        runtime.friCoordinatesAndLeaves = make_pipeline(device, library, @"stwo_zig_fri_coordinates_and_leaves", error_message, error_message_len);
-        runtime.friFoldLinePrepareNext = make_pipeline(device, library, @"stwo_zig_fri_fold_line_prepare_next", error_message, error_message_len);
         runtime.friFold3Resident = make_pipeline(device, library, @"stwo_zig_fri_fold3_resident", error_message, error_message_len);
         runtime.friFold2Resident = make_pipeline(device, library, @"stwo_zig_fri_fold2_resident", error_message, error_message_len);
         runtime.friPackedLeavesResident = make_pipeline(device, library, @"stwo_zig_fri_packed_leaves_resident", error_message, error_message_len);
@@ -605,9 +601,7 @@ static StwoZigMetalRuntime *create_runtime_from_library(
             runtime.quotientNumerator == nil || runtime.quotientFinalize == nil ||
             runtime.quotientDomainPointsResident == nil || runtime.quotientDenominatorsResident == nil ||
             runtime.quotientCombineResident == nil || runtime.quotientCoefficientsResident == nil ||
-            runtime.friFoldCircle == nil || runtime.friFoldLine == nil ||
-            runtime.friCoordinatesAndLeaves == nil || runtime.friFoldLinePrepareNext == nil ||
-            runtime.friFold3Resident == nil ||
+            runtime.friFoldCircle == nil || runtime.friFoldLine == nil || runtime.friFold3Resident == nil ||
             runtime.friFold2Resident == nil || runtime.friPackedLeavesResident == nil || runtime.friFinalLineResident == nil ||
             runtime.transcriptInitResident == nil || runtime.transcriptMixResident == nil ||
             runtime.transcriptDrawSecureResident == nil || runtime.transcriptDrawQueriesResident == nil ||
@@ -656,6 +650,39 @@ static StwoZigMetalRuntime *create_runtime_from_library(
         }
         return runtime;
     }
+}
+
+static void bind_qm31_coordinate_kernel(
+    id<MTLComputeCommandEncoder> encoder, id<MTLBuffer> source,
+    id<MTLBuffer> coordinates, uint32_t value_count, id<MTLBuffer> leaves,
+    id<MTLBuffer> leaf_seed, uint32_t prefix_bytes, uint32_t write_leaf
+) {
+    [encoder setBuffer:source offset:0u atIndex:0];
+    [encoder setBuffer:coordinates offset:0u atIndex:1];
+    [encoder setBytes:&value_count length:sizeof(value_count) atIndex:2];
+    [encoder setBuffer:leaves offset:0u atIndex:3];
+    [encoder setBuffer:leaf_seed offset:0u atIndex:4];
+    [encoder setBytes:&prefix_bytes length:sizeof(prefix_bytes) atIndex:5];
+    [encoder setBytes:&write_leaf length:sizeof(write_leaf) atIndex:6];
+}
+
+static void bind_fri_line_kernel(
+    id<MTLComputeCommandEncoder> encoder, id<MTLBuffer> source,
+    NSUInteger inverse_offset, id<MTLBuffer> inverse, id<MTLBuffer> alpha,
+    NSUInteger alpha_offset, id<MTLBuffer> destination, uint32_t destination_count,
+    id<MTLBuffer> coordinates, id<MTLBuffer> leaves, id<MTLBuffer> leaf_seed,
+    uint32_t prefix_bytes, uint32_t prepare_next
+) {
+    [encoder setBuffer:source offset:0u atIndex:0];
+    [encoder setBuffer:inverse offset:inverse_offset atIndex:1];
+    [encoder setBuffer:alpha offset:alpha_offset atIndex:2];
+    [encoder setBuffer:destination offset:0u atIndex:3];
+    [encoder setBytes:&destination_count length:sizeof(destination_count) atIndex:4];
+    [encoder setBuffer:coordinates offset:0u atIndex:5];
+    [encoder setBuffer:leaves offset:0u atIndex:6];
+    [encoder setBuffer:leaf_seed offset:0u atIndex:7];
+    [encoder setBytes:&prefix_bytes length:sizeof(prefix_bytes) atIndex:8];
+    [encoder setBytes:&prepare_next length:sizeof(prepare_next) atIndex:9];
 }
 
 #import "runtime/initialization.m"

--- a/src/backends/metal/runtime.m
+++ b/src/backends/metal/runtime.m
@@ -44,6 +44,8 @@
 @property(nonatomic, strong) id<MTLComputePipelineState> quotientCoefficientsResident;
 @property(nonatomic, strong) id<MTLComputePipelineState> friFoldCircle;
 @property(nonatomic, strong) id<MTLComputePipelineState> friFoldLine;
+@property(nonatomic, strong) id<MTLComputePipelineState> friCoordinatesAndLeaves;
+@property(nonatomic, strong) id<MTLComputePipelineState> friFoldLinePrepareNext;
 @property(nonatomic, strong) id<MTLComputePipelineState> friFold3Resident;
 @property(nonatomic, strong) id<MTLComputePipelineState> friFold2Resident;
 @property(nonatomic, strong) id<MTLComputePipelineState> friPackedLeavesResident;
@@ -537,6 +539,8 @@ static StwoZigMetalRuntime *create_runtime_from_library(
         runtime.quotientCoefficientsResident = make_pipeline(device, library, @"stwo_zig_quotient_coefficients_resident", error_message, error_message_len);
         runtime.friFoldCircle = make_pipeline(device, library, @"stwo_zig_fri_fold_circle", error_message, error_message_len);
         runtime.friFoldLine = make_pipeline(device, library, @"stwo_zig_fri_fold_line", error_message, error_message_len);
+        runtime.friCoordinatesAndLeaves = make_pipeline(device, library, @"stwo_zig_fri_coordinates_and_leaves", error_message, error_message_len);
+        runtime.friFoldLinePrepareNext = make_pipeline(device, library, @"stwo_zig_fri_fold_line_prepare_next", error_message, error_message_len);
         runtime.friFold3Resident = make_pipeline(device, library, @"stwo_zig_fri_fold3_resident", error_message, error_message_len);
         runtime.friFold2Resident = make_pipeline(device, library, @"stwo_zig_fri_fold2_resident", error_message, error_message_len);
         runtime.friPackedLeavesResident = make_pipeline(device, library, @"stwo_zig_fri_packed_leaves_resident", error_message, error_message_len);
@@ -601,7 +605,9 @@ static StwoZigMetalRuntime *create_runtime_from_library(
             runtime.quotientNumerator == nil || runtime.quotientFinalize == nil ||
             runtime.quotientDomainPointsResident == nil || runtime.quotientDenominatorsResident == nil ||
             runtime.quotientCombineResident == nil || runtime.quotientCoefficientsResident == nil ||
-            runtime.friFoldCircle == nil || runtime.friFoldLine == nil || runtime.friFold3Resident == nil ||
+            runtime.friFoldCircle == nil || runtime.friFoldLine == nil ||
+            runtime.friCoordinatesAndLeaves == nil || runtime.friFoldLinePrepareNext == nil ||
+            runtime.friFold3Resident == nil ||
             runtime.friFold2Resident == nil || runtime.friPackedLeavesResident == nil || runtime.friFinalLineResident == nil ||
             runtime.transcriptInitResident == nil || runtime.transcriptMixResident == nil ||
             runtime.transcriptDrawSecureResident == nil || runtime.transcriptDrawQueriesResident == nil ||

--- a/src/backends/metal/runtime.zig
+++ b/src/backends/metal/runtime.zig
@@ -8,7 +8,7 @@ const command_epoch = @import("command_epoch.zig");
 const shader_manifest = @import("shaders/manifest.zig");
 
 comptime {
-    if (shader_manifest.core_shader_abi != 2) @compileError("Metal core shader ABI drift");
+    if (shader_manifest.core_shader_abi != 3) @compileError("Metal core shader ABI drift");
 }
 
 pub const CommandEpoch = command_epoch.CommandEpoch;

--- a/src/backends/metal/runtime/fri_fold_commit.m
+++ b/src/backends/metal/runtime/fri_fold_commit.m
@@ -104,11 +104,11 @@ void *stwo_zig_metal_fri_fold_line_and_commit(
                 return NULL;
             }
             [encoder setComputePipelineState:runtime.friFoldLine];
-            [encoder setBuffer:fold_source offset:0u atIndex:0];
-            [encoder setBuffer:inverse_buffer offset:inverse_byte_offset atIndex:1];
-            [encoder setBuffer:alpha_buffer offset:(NSUInteger)step * 16u atIndex:2];
-            [encoder setBuffer:fold_destination offset:0u atIndex:3];
-            [encoder setBytes:&output_count length:sizeof(output_count) atIndex:4];
+            bind_fri_line_kernel(
+                encoder, fold_source, inverse_byte_offset, inverse_buffer,
+                alpha_buffer, (NSUInteger)step * 16u, fold_destination, output_count,
+                fold_destination, fold_destination, inverse_buffer, 0u, 0u
+            );
             NSUInteger width = MIN(runtime.friFoldLine.maxTotalThreadsPerThreadgroup,
                                    runtime.friFoldLine.threadExecutionWidth * 8u);
             [encoder dispatchThreads:MTLSizeMake(output_count, 1u, 1u)
@@ -127,9 +127,10 @@ void *stwo_zig_metal_fri_fold_line_and_commit(
             return NULL;
         }
         [conversion setComputePipelineState:runtime.qm31ToCoordinates];
-        [conversion setBuffer:destination offset:0u atIndex:0];
-        [conversion setBuffer:coordinates offset:0u atIndex:1];
-        [conversion setBytes:&final_count length:sizeof(final_count) atIndex:2];
+        bind_qm31_coordinate_kernel(
+            conversion, destination, coordinates, final_count,
+            coordinates, destination, 0u, 0u
+        );
         NSUInteger conversion_width = MIN(runtime.qm31ToCoordinates.maxTotalThreadsPerThreadgroup,
                                           runtime.qm31ToCoordinates.threadExecutionWidth * 8u);
         [conversion dispatchThreads:MTLSizeMake(final_count, 1u, 1u)
@@ -372,17 +373,19 @@ bool stwo_zig_metal_fri_line_cascade(
 
         id<MTLBuffer> initial_coordinates = (__bridge id<MTLBuffer>)coordinate_ptrs[0];
         StwoZigMetalTree *initial_tree = trees[0];
-        [encoder setComputePipelineState:runtime.friCoordinatesAndLeaves];
+        [encoder setComputePipelineState:runtime.qm31ToCoordinates];
         [encoder setBuffer:initial_source offset:0u atIndex:0];
         [encoder setBuffer:initial_coordinates offset:0u atIndex:1];
+        [encoder setBytes:&source_count length:sizeof(source_count) atIndex:2];
         [encoder setBuffer:transcript_arena
             offset:(NSUInteger)tree_layer_word_offset(initial_tree, 0u) * sizeof(uint32_t)
-            atIndex:2];
-        [encoder setBytes:&source_count length:sizeof(source_count) atIndex:3];
+            atIndex:3];
         [encoder setBuffer:leaf_seed_buffer offset:0u atIndex:4];
         [encoder setBytes:&domain_prefix_bytes length:sizeof(domain_prefix_bytes) atIndex:5];
-        NSUInteger initial_width = MIN(runtime.friCoordinatesAndLeaves.maxTotalThreadsPerThreadgroup,
-                                       runtime.friCoordinatesAndLeaves.threadExecutionWidth * 8u);
+        uint32_t write_initial_leaf = 1u;
+        [encoder setBytes:&write_initial_leaf length:sizeof(write_initial_leaf) atIndex:6];
+        NSUInteger initial_width = MIN(runtime.qm31ToCoordinates.maxTotalThreadsPerThreadgroup,
+                                       runtime.qm31ToCoordinates.threadExecutionWidth * 8u);
         [encoder dispatchThreads:MTLSizeMake(source_count, 1u, 1u)
              threadsPerThreadgroup:MTLSizeMake(initial_width, 1u, 1u)];
         [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
@@ -481,29 +484,32 @@ bool stwo_zig_metal_fri_line_cascade(
 
             uint32_t destination_count = count >> 1u;
             id<MTLBuffer> destination = destinations[stage];
-            id<MTLComputePipelineState> fold_pipeline = runtime.friFoldLine;
+            uint32_t prepare_next = stage + 1u != fri_layer_count ? 1u : 0u;
+            [encoder setComputePipelineState:runtime.friFoldLine];
             [encoder setBuffer:evaluation offset:0u atIndex:0];
             [encoder setBuffer:inverse_buffer offset:inverse_offset atIndex:1];
             [encoder setBuffer:transcript_arena
                 offset:(NSUInteger)alpha_base * sizeof(uint32_t) atIndex:2];
             [encoder setBuffer:destination offset:0u atIndex:3];
-            if (stage + 1u != fri_layer_count) {
-                fold_pipeline = runtime.friFoldLinePrepareNext;
+            [encoder setBytes:&destination_count length:sizeof(destination_count) atIndex:4];
+            if (prepare_next != 0u) {
                 id<MTLBuffer> next_coordinates = (__bridge id<MTLBuffer>)coordinate_ptrs[stage + 1u];
                 StwoZigMetalTree *next_tree = trees[stage + 1u];
-                [encoder setBuffer:next_coordinates offset:0u atIndex:4];
+                [encoder setBuffer:next_coordinates offset:0u atIndex:5];
                 [encoder setBuffer:transcript_arena
                     offset:(NSUInteger)tree_layer_word_offset(next_tree, 0u) * sizeof(uint32_t)
-                    atIndex:5];
-                [encoder setBytes:&destination_count length:sizeof(destination_count) atIndex:6];
+                    atIndex:6];
                 [encoder setBuffer:leaf_seed_buffer offset:0u atIndex:7];
                 [encoder setBytes:&domain_prefix_bytes length:sizeof(domain_prefix_bytes) atIndex:8];
             } else {
-                [encoder setBytes:&destination_count length:sizeof(destination_count) atIndex:4];
+                [encoder setBuffer:destination offset:0u atIndex:5];
+                [encoder setBuffer:destination offset:0u atIndex:6];
+                [encoder setBuffer:inverse_buffer offset:inverse_offset atIndex:7];
+                [encoder setBytes:&domain_prefix_bytes length:sizeof(domain_prefix_bytes) atIndex:8];
             }
-            [encoder setComputePipelineState:fold_pipeline];
-            NSUInteger fold_width = MIN(fold_pipeline.maxTotalThreadsPerThreadgroup,
-                                        fold_pipeline.threadExecutionWidth * 8u);
+            [encoder setBytes:&prepare_next length:sizeof(prepare_next) atIndex:9];
+            NSUInteger fold_width = MIN(runtime.friFoldLine.maxTotalThreadsPerThreadgroup,
+                                        runtime.friFoldLine.threadExecutionWidth * 8u);
             [encoder dispatchThreads:MTLSizeMake(destination_count, 1u, 1u)
                  threadsPerThreadgroup:MTLSizeMake(fold_width, 1u, 1u)];
             if (stage + 1u != fri_layer_count)

--- a/src/backends/metal/runtime/fri_fold_commit.m
+++ b/src/backends/metal/runtime/fri_fold_commit.m
@@ -370,10 +370,27 @@ bool stwo_zig_metal_fri_line_cascade(
             return false;
         }
 
+        id<MTLBuffer> initial_coordinates = (__bridge id<MTLBuffer>)coordinate_ptrs[0];
+        StwoZigMetalTree *initial_tree = trees[0];
+        [encoder setComputePipelineState:runtime.friCoordinatesAndLeaves];
+        [encoder setBuffer:initial_source offset:0u atIndex:0];
+        [encoder setBuffer:initial_coordinates offset:0u atIndex:1];
+        [encoder setBuffer:transcript_arena
+            offset:(NSUInteger)tree_layer_word_offset(initial_tree, 0u) * sizeof(uint32_t)
+            atIndex:2];
+        [encoder setBytes:&source_count length:sizeof(source_count) atIndex:3];
+        [encoder setBuffer:leaf_seed_buffer offset:0u atIndex:4];
+        [encoder setBytes:&domain_prefix_bytes length:sizeof(domain_prefix_bytes) atIndex:5];
+        NSUInteger initial_width = MIN(runtime.friCoordinatesAndLeaves.maxTotalThreadsPerThreadgroup,
+                                       runtime.friCoordinatesAndLeaves.threadExecutionWidth * 8u);
+        [encoder dispatchThreads:MTLSizeMake(source_count, 1u, 1u)
+             threadsPerThreadgroup:MTLSizeMake(initial_width, 1u, 1u)];
+        [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+
         id<MTLBuffer> evaluation = initial_source;
         count = source_count;
         NSUInteger inverse_offset = 0u;
-        uint64_t compute_encoders = 1u, dispatches = 0u;
+        uint64_t compute_encoders = 1u, dispatches = 1u;
         NSUInteger tail_static_bytes = runtime.parentTailSparse.staticThreadgroupMemoryLength;
         NSUInteger tail_available_bytes = runtime.device.maxThreadgroupMemoryLength > tail_static_bytes
             ? runtime.device.maxThreadgroupMemoryLength - tail_static_bytes : 0u;
@@ -381,41 +398,8 @@ bool stwo_zig_metal_fri_line_cascade(
             MIN(runtime.parentTailSparse.maxTotalThreadsPerThreadgroup,
                 tail_available_bytes / (8u * sizeof(uint32_t))));
         for (uint32_t stage = 0u; stage < fri_layer_count; ++stage) {
-            id<MTLBuffer> coordinates = (__bridge id<MTLBuffer>)coordinate_ptrs[stage];
             StwoZigMetalTree *tree = trees[stage];
             uint32_t tree_log_size = tree.logSize;
-
-            [encoder setComputePipelineState:runtime.qm31ToCoordinates];
-            [encoder setBuffer:evaluation offset:0u atIndex:0];
-            [encoder setBuffer:coordinates offset:0u atIndex:1];
-            [encoder setBytes:&count length:sizeof(count) atIndex:2];
-            NSUInteger conversion_width = MIN(runtime.qm31ToCoordinates.maxTotalThreadsPerThreadgroup,
-                                              runtime.qm31ToCoordinates.threadExecutionWidth * 8u);
-            [encoder dispatchThreads:MTLSizeMake(count, 1u, 1u)
-                 threadsPerThreadgroup:MTLSizeMake(conversion_width, 1u, 1u)];
-            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
-            dispatches += 1u;
-
-            uint32_t column_offsets[4] = { 0u, count, 2u * count, 3u * count };
-            uint32_t column_logs[4] = { tree_log_size, tree_log_size, tree_log_size, tree_log_size };
-            uint32_t column_count = 4u;
-            [encoder setComputePipelineState:runtime.leaves];
-            [encoder setBuffer:coordinates offset:0u atIndex:0];
-            [encoder setBytes:column_offsets length:sizeof(column_offsets) atIndex:1];
-            [encoder setBytes:column_logs length:sizeof(column_logs) atIndex:2];
-            [encoder setBuffer:tree.layers[0]
-                offset:(NSUInteger)tree_layer_word_offset(tree, 0u) * sizeof(uint32_t)
-                atIndex:3];
-            [encoder setBytes:&column_count length:sizeof(column_count) atIndex:4];
-            [encoder setBytes:&tree_log_size length:sizeof(tree_log_size) atIndex:5];
-            [encoder setBuffer:leaf_seed_buffer offset:0u atIndex:6];
-            [encoder setBytes:&domain_prefix_bytes length:sizeof(domain_prefix_bytes) atIndex:7];
-            NSUInteger leaf_width = MIN(runtime.leaves.maxTotalThreadsPerThreadgroup,
-                                        runtime.leaves.threadExecutionWidth * 8u);
-            [encoder dispatchThreads:MTLSizeMake(count, 1u, 1u)
-                 threadsPerThreadgroup:MTLSizeMake(leaf_width, 1u, 1u)];
-            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
-            dispatches += 1u;
 
             uint32_t child_offsets[31], destination_offsets[31], parent_counts[31];
             uint32_t tail_level = tree_log_size + 1u;
@@ -497,15 +481,29 @@ bool stwo_zig_metal_fri_line_cascade(
 
             uint32_t destination_count = count >> 1u;
             id<MTLBuffer> destination = destinations[stage];
-            [encoder setComputePipelineState:runtime.friFoldLine];
+            id<MTLComputePipelineState> fold_pipeline = runtime.friFoldLine;
             [encoder setBuffer:evaluation offset:0u atIndex:0];
             [encoder setBuffer:inverse_buffer offset:inverse_offset atIndex:1];
             [encoder setBuffer:transcript_arena
                 offset:(NSUInteger)alpha_base * sizeof(uint32_t) atIndex:2];
             [encoder setBuffer:destination offset:0u atIndex:3];
-            [encoder setBytes:&destination_count length:sizeof(destination_count) atIndex:4];
-            NSUInteger fold_width = MIN(runtime.friFoldLine.maxTotalThreadsPerThreadgroup,
-                                        runtime.friFoldLine.threadExecutionWidth * 8u);
+            if (stage + 1u != fri_layer_count) {
+                fold_pipeline = runtime.friFoldLinePrepareNext;
+                id<MTLBuffer> next_coordinates = (__bridge id<MTLBuffer>)coordinate_ptrs[stage + 1u];
+                StwoZigMetalTree *next_tree = trees[stage + 1u];
+                [encoder setBuffer:next_coordinates offset:0u atIndex:4];
+                [encoder setBuffer:transcript_arena
+                    offset:(NSUInteger)tree_layer_word_offset(next_tree, 0u) * sizeof(uint32_t)
+                    atIndex:5];
+                [encoder setBytes:&destination_count length:sizeof(destination_count) atIndex:6];
+                [encoder setBuffer:leaf_seed_buffer offset:0u atIndex:7];
+                [encoder setBytes:&domain_prefix_bytes length:sizeof(domain_prefix_bytes) atIndex:8];
+            } else {
+                [encoder setBytes:&destination_count length:sizeof(destination_count) atIndex:4];
+            }
+            [encoder setComputePipelineState:fold_pipeline];
+            NSUInteger fold_width = MIN(fold_pipeline.maxTotalThreadsPerThreadgroup,
+                                        fold_pipeline.threadExecutionWidth * 8u);
             [encoder dispatchThreads:MTLSizeMake(destination_count, 1u, 1u)
                  threadsPerThreadgroup:MTLSizeMake(fold_width, 1u, 1u)];
             if (stage + 1u != fri_layer_count)

--- a/src/backends/metal/runtime/fri_plans.m
+++ b/src/backends/metal/runtime/fri_plans.m
@@ -51,6 +51,14 @@ bool stwo_zig_metal_fri_fold_prepared(
         [encoder setBuffer:arena offset:plan.alphaByteOffset atIndex:2];
         [encoder setBuffer:arena offset:plan.destinationByteOffset atIndex:3];
         [encoder setBytes:&destination_count length:sizeof(destination_count) atIndex:4];
+        if (!plan.circle) {
+            uint32_t disabled = 0u;
+            [encoder setBuffer:arena offset:plan.destinationByteOffset atIndex:5];
+            [encoder setBuffer:arena offset:plan.destinationByteOffset atIndex:6];
+            [encoder setBuffer:arena offset:plan.inverseByteOffset atIndex:7];
+            [encoder setBytes:&disabled length:sizeof(disabled) atIndex:8];
+            [encoder setBytes:&disabled length:sizeof(disabled) atIndex:9];
+        }
         NSUInteger width = MIN(pipeline.maxTotalThreadsPerThreadgroup, pipeline.threadExecutionWidth * 8u);
         [encoder dispatchThreads:MTLSizeMake(destination_count, 1u, 1u)
              threadsPerThreadgroup:MTLSizeMake(width, 1u, 1u)];

--- a/src/backends/metal/runtime/runtime_queries.m
+++ b/src/backends/metal/runtime/runtime_queries.m
@@ -73,8 +73,10 @@ bool stwo_zig_metal_qm31_to_coordinates(
         id<MTLCommandBuffer> command = [runtime.queue commandBuffer];
         id<MTLComputeCommandEncoder> encoder = [command computeCommandEncoder];
         [encoder setComputePipelineState:runtime.qm31ToCoordinates];
-        [encoder setBuffer:source_buffer offset:0 atIndex:0]; [encoder setBuffer:destination_buffer offset:0 atIndex:1];
-        [encoder setBytes:&value_count length:sizeof(value_count) atIndex:2];
+        bind_qm31_coordinate_kernel(
+            encoder, source_buffer, destination_buffer, value_count,
+            destination_buffer, source_buffer, 0u, 0u
+        );
         NSUInteger width = MIN(runtime.qm31ToCoordinates.maxTotalThreadsPerThreadgroup, runtime.qm31ToCoordinates.threadExecutionWidth * 8u);
         [encoder dispatchThreads:MTLSizeMake(value_count, 1u, 1u) threadsPerThreadgroup:MTLSizeMake(width, 1u, 1u)];
         [encoder endEncoding]; [command commit]; [command waitUntilCompleted];
@@ -187,6 +189,12 @@ bool stwo_zig_metal_fri_fold_line(
         [encoder setBuffer:source_buffer offset:0 atIndex:0]; [encoder setBuffer:inverse_buffer offset:0 atIndex:1];
         [encoder setBytes:alpha length:4u * sizeof(uint32_t) atIndex:2]; [encoder setBuffer:destination_buffer offset:0 atIndex:3];
         [encoder setBytes:&destination_count length:sizeof(destination_count) atIndex:4];
+        uint32_t disabled = 0u;
+        [encoder setBuffer:destination_buffer offset:0 atIndex:5];
+        [encoder setBuffer:destination_buffer offset:0 atIndex:6];
+        [encoder setBuffer:inverse_buffer offset:0 atIndex:7];
+        [encoder setBytes:&disabled length:sizeof(disabled) atIndex:8];
+        [encoder setBytes:&disabled length:sizeof(disabled) atIndex:9];
         NSUInteger width = MIN(runtime.friFoldLine.maxTotalThreadsPerThreadgroup, runtime.friFoldLine.threadExecutionWidth * 8u);
         [encoder dispatchThreads:MTLSizeMake(destination_count, 1u, 1u) threadsPerThreadgroup:MTLSizeMake(width, 1u, 1u)];
         [encoder endEncoding]; [command commit]; [command waitUntilCompleted];

--- a/src/backends/metal/shaders/core/commitments.metal
+++ b/src/backends/metal/shaders/core/commitments.metal
@@ -32,31 +32,41 @@ inline void fri_store_coordinates_and_leaf(
     for (uint word = 0u; word < 8u; ++word) leaves[index * 8u + word] = state[word];
 }
 
-kernel void stwo_zig_fri_coordinates_and_leaves(
+kernel void stwo_zig_qm31_to_coordinates(
     device const Qm31Value *source [[buffer(0)]],
     device uint *coordinates [[buffer(1)]],
-    device uint *leaves [[buffer(2)]],
-    constant uint &value_count [[buffer(3)]],
+    constant uint &value_count [[buffer(2)]],
+    device uint *leaves [[buffer(3)]],
     constant uint *leaf_seed [[buffer(4)]],
     constant uint &prefix_bytes [[buffer(5)]],
+    constant uint &write_leaf [[buffer(6)]],
     uint index [[thread_position_in_grid]]
 ) {
     if (index >= value_count) return;
-    fri_store_coordinates_and_leaf(
-        coordinates, leaves, value_count, index, source[index], leaf_seed, prefix_bytes
-    );
+    Qm31Value value = source[index];
+    if (write_leaf != 0u)
+        fri_store_coordinates_and_leaf(
+            coordinates, leaves, value_count, index, value, leaf_seed, prefix_bytes
+        );
+    else {
+        coordinates[index] = value.a;
+        coordinates[value_count + index] = value.b;
+        coordinates[2u * value_count + index] = value.c;
+        coordinates[3u * value_count + index] = value.d;
+    }
 }
 
-kernel void stwo_zig_fri_fold_line_prepare_next(
+kernel void stwo_zig_fri_fold_line(
     device const Qm31Value *source [[buffer(0)]],
     device const uint *inverse_x [[buffer(1)]],
     constant Qm31Value &alpha [[buffer(2)]],
     device Qm31Value *destination [[buffer(3)]],
-    device uint *coordinates [[buffer(4)]],
-    device uint *leaves [[buffer(5)]],
-    constant uint &destination_count [[buffer(6)]],
+    constant uint &destination_count [[buffer(4)]],
+    device uint *coordinates [[buffer(5)]],
+    device uint *leaves [[buffer(6)]],
     constant uint *leaf_seed [[buffer(7)]],
     constant uint &prefix_bytes [[buffer(8)]],
+    constant uint &prepare_next [[buffer(9)]],
     uint index [[thread_position_in_grid]]
 ) {
     if (index >= destination_count) return;
@@ -64,9 +74,10 @@ kernel void stwo_zig_fri_fold_line_prepare_next(
         source[index << 1u], source[(index << 1u) + 1u], inverse_x[index], alpha
     );
     destination[index] = value;
-    fri_store_coordinates_and_leaf(
-        coordinates, leaves, destination_count, index, value, leaf_seed, prefix_bytes
-    );
+    if (prepare_next != 0u)
+        fri_store_coordinates_and_leaf(
+            coordinates, leaves, destination_count, index, value, leaf_seed, prefix_bytes
+        );
 }
 
 kernel void stwo_zig_blake2s_leaves(

--- a/src/backends/metal/shaders/core/commitments.metal
+++ b/src/backends/metal/shaders/core/commitments.metal
@@ -2,7 +2,72 @@
 #include "stwo_zig/base.metal"
 #include "stwo_zig/blake2s.metal"
 #include "stwo_zig/merkle.metal"
+#include "stwo_zig/extension_fields.metal"
 #endif
+
+inline Qm31Value fri_fused_fold_pair(
+    Qm31Value left, Qm31Value right, uint inverse, Qm31Value alpha
+) {
+    return qm_add(qm_add(left, right), qm_mul(alpha, qm_mul_m31(qm_sub(left, right), inverse)));
+}
+
+inline void fri_store_coordinates_and_leaf(
+    device uint *coordinates, device uint *leaves, uint value_count, uint index,
+    Qm31Value value, constant uint *leaf_seed, uint prefix_bytes
+) {
+    coordinates[index] = value.a;
+    coordinates[value_count + index] = value.b;
+    coordinates[2u * value_count + index] = value.c;
+    coordinates[3u * value_count + index] = value.d;
+
+    uint state[8], message[16];
+    if (prefix_bytes == 0u) blake2s_init_hash(state);
+    else blake2s_init_seeded(state, leaf_seed);
+    message[0] = value.a;
+    message[1] = value.b;
+    message[2] = value.c;
+    message[3] = value.d;
+    for (uint word = 4u; word < 16u; ++word) message[word] = 0u;
+    blake2s_compress(state, message, prefix_bytes + 16u, true);
+    for (uint word = 0u; word < 8u; ++word) leaves[index * 8u + word] = state[word];
+}
+
+kernel void stwo_zig_fri_coordinates_and_leaves(
+    device const Qm31Value *source [[buffer(0)]],
+    device uint *coordinates [[buffer(1)]],
+    device uint *leaves [[buffer(2)]],
+    constant uint &value_count [[buffer(3)]],
+    constant uint *leaf_seed [[buffer(4)]],
+    constant uint &prefix_bytes [[buffer(5)]],
+    uint index [[thread_position_in_grid]]
+) {
+    if (index >= value_count) return;
+    fri_store_coordinates_and_leaf(
+        coordinates, leaves, value_count, index, source[index], leaf_seed, prefix_bytes
+    );
+}
+
+kernel void stwo_zig_fri_fold_line_prepare_next(
+    device const Qm31Value *source [[buffer(0)]],
+    device const uint *inverse_x [[buffer(1)]],
+    constant Qm31Value &alpha [[buffer(2)]],
+    device Qm31Value *destination [[buffer(3)]],
+    device uint *coordinates [[buffer(4)]],
+    device uint *leaves [[buffer(5)]],
+    constant uint &destination_count [[buffer(6)]],
+    constant uint *leaf_seed [[buffer(7)]],
+    constant uint &prefix_bytes [[buffer(8)]],
+    uint index [[thread_position_in_grid]]
+) {
+    if (index >= destination_count) return;
+    Qm31Value value = fri_fused_fold_pair(
+        source[index << 1u], source[(index << 1u) + 1u], inverse_x[index], alpha
+    );
+    destination[index] = value;
+    fri_store_coordinates_and_leaf(
+        coordinates, leaves, destination_count, index, value, leaf_seed, prefix_bytes
+    );
+}
 
 kernel void stwo_zig_blake2s_leaves(
     device const uint *flat_columns [[buffer(0)]],

--- a/src/backends/metal/shaders/manifest.zig
+++ b/src/backends/metal/shaders/manifest.zig
@@ -108,8 +108,6 @@ pub const exports = [_]Export{
     .{ .name = "stwo_zig_compact_finalize", .owner = .compaction },
     .{ .name = "stwo_zig_fri_fold_circle", .owner = .fri },
     .{ .name = "stwo_zig_fri_fold_line", .owner = .fri },
-    .{ .name = "stwo_zig_fri_coordinates_and_leaves", .owner = .fri },
-    .{ .name = "stwo_zig_fri_fold_line_prepare_next", .owner = .fri },
     .{ .name = "stwo_zig_qm31_to_coordinates", .owner = .quotient },
     .{ .name = "stwo_zig_quotient_rows", .owner = .quotient },
     .{ .name = "stwo_zig_quotient_rows_raw", .owner = .quotient },
@@ -363,7 +361,7 @@ fn kernelDeclaration(source: []const u8, name: []const u8) ![]const u8 {
 }
 
 test "Native core source exactly covers its non-Cairo export ABI" {
-    try std.testing.expectEqual(@as(usize, 80), native_exports.len);
+    try std.testing.expectEqual(@as(usize, 78), native_exports.len);
     try std.testing.expectEqual(native_exports.len, std.mem.count(u8, native_amalgamated_source, "kernel void "));
     try std.testing.expect(std.mem.indexOf(u8, native_amalgamated_source, "shaders/cairo/") == null);
     for (native_support_headers) |unit| try std.testing.expect(std.mem.indexOf(u8, unit.path, "/cairo/") == null);
@@ -386,7 +384,7 @@ fn expectIsolated(source: []const u8, names: []const []const u8) !void {
 
 test "metal shader manifest exactly covers source and runtime exports" {
     const runtime_source = @embedFile("../runtime.m");
-    try std.testing.expectEqual(@as(usize, 92), exports.len);
+    try std.testing.expectEqual(@as(usize, 90), exports.len);
 
     var declaration_count: usize = 0;
     var remaining: []const u8 = amalgamated_source[0 .. amalgamated_source.len - 1];
@@ -421,8 +419,8 @@ test "commitment shader bindings match core ABI version 3" {
         .{ .kernel = "stwo_zig_blake2s_parents_sparse", .argument = "prefix_bytes [[buffer(5)]]" },
         .{ .kernel = "stwo_zig_blake2s_parent_tail_sparse", .argument = "prefix_bytes [[buffer(6)]]" },
         .{ .kernel = "stwo_zig_fri_packed_leaves_resident", .argument = "prefix_bytes [[buffer(7)]]" },
-        .{ .kernel = "stwo_zig_fri_coordinates_and_leaves", .argument = "prefix_bytes [[buffer(5)]]" },
-        .{ .kernel = "stwo_zig_fri_fold_line_prepare_next", .argument = "prefix_bytes [[buffer(8)]]" },
+        .{ .kernel = "stwo_zig_qm31_to_coordinates", .argument = "prefix_bytes [[buffer(5)]]" },
+        .{ .kernel = "stwo_zig_fri_fold_line", .argument = "prefix_bytes [[buffer(8)]]" },
     };
     for (bindings) |binding| {
         const declaration = try kernelDeclaration(amalgamated_source, binding.kernel);

--- a/src/backends/metal/shaders/manifest.zig
+++ b/src/backends/metal/shaders/manifest.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-pub const core_shader_abi: u32 = 2;
+pub const core_shader_abi: u32 = 3;
 pub const witness_codegen_support_version: u64 = 6;
 
 pub const CompileProfile = struct {
@@ -108,6 +108,8 @@ pub const exports = [_]Export{
     .{ .name = "stwo_zig_compact_finalize", .owner = .compaction },
     .{ .name = "stwo_zig_fri_fold_circle", .owner = .fri },
     .{ .name = "stwo_zig_fri_fold_line", .owner = .fri },
+    .{ .name = "stwo_zig_fri_coordinates_and_leaves", .owner = .fri },
+    .{ .name = "stwo_zig_fri_fold_line_prepare_next", .owner = .fri },
     .{ .name = "stwo_zig_qm31_to_coordinates", .owner = .quotient },
     .{ .name = "stwo_zig_quotient_rows", .owner = .quotient },
     .{ .name = "stwo_zig_quotient_rows_raw", .owner = .quotient },
@@ -361,7 +363,7 @@ fn kernelDeclaration(source: []const u8, name: []const u8) ![]const u8 {
 }
 
 test "Native core source exactly covers its non-Cairo export ABI" {
-    try std.testing.expectEqual(@as(usize, 78), native_exports.len);
+    try std.testing.expectEqual(@as(usize, 80), native_exports.len);
     try std.testing.expectEqual(native_exports.len, std.mem.count(u8, native_amalgamated_source, "kernel void "));
     try std.testing.expect(std.mem.indexOf(u8, native_amalgamated_source, "shaders/cairo/") == null);
     for (native_support_headers) |unit| try std.testing.expect(std.mem.indexOf(u8, unit.path, "/cairo/") == null);
@@ -384,7 +386,7 @@ fn expectIsolated(source: []const u8, names: []const []const u8) !void {
 
 test "metal shader manifest exactly covers source and runtime exports" {
     const runtime_source = @embedFile("../runtime.m");
-    try std.testing.expectEqual(@as(usize, 90), exports.len);
+    try std.testing.expectEqual(@as(usize, 92), exports.len);
 
     var declaration_count: usize = 0;
     var remaining: []const u8 = amalgamated_source[0 .. amalgamated_source.len - 1];
@@ -411,14 +413,16 @@ test "metal shader manifest exactly covers source and runtime exports" {
     }
 }
 
-test "commitment shader bindings match core ABI version 2" {
-    try std.testing.expectEqual(@as(u32, 2), core_shader_abi);
+test "commitment shader bindings match core ABI version 3" {
+    try std.testing.expectEqual(@as(u32, 3), core_shader_abi);
     const bindings = [_]struct { kernel: []const u8, argument: []const u8 }{
         .{ .kernel = "stwo_zig_blake2s_leaves", .argument = "prefix_bytes [[buffer(7)]]" },
         .{ .kernel = "stwo_zig_blake2s_parents", .argument = "prefix_bytes [[buffer(4)]]" },
         .{ .kernel = "stwo_zig_blake2s_parents_sparse", .argument = "prefix_bytes [[buffer(5)]]" },
         .{ .kernel = "stwo_zig_blake2s_parent_tail_sparse", .argument = "prefix_bytes [[buffer(6)]]" },
         .{ .kernel = "stwo_zig_fri_packed_leaves_resident", .argument = "prefix_bytes [[buffer(7)]]" },
+        .{ .kernel = "stwo_zig_fri_coordinates_and_leaves", .argument = "prefix_bytes [[buffer(5)]]" },
+        .{ .kernel = "stwo_zig_fri_fold_line_prepare_next", .argument = "prefix_bytes [[buffer(8)]]" },
     };
     for (bindings) |binding| {
         const declaration = try kernelDeclaration(amalgamated_source, binding.kernel);

--- a/src/backends/metal/tests/fri_fold_commit.zig
+++ b/src/backends/metal/tests/fri_fold_commit.zig
@@ -392,7 +392,7 @@ test "metal: line FRI cascade preserves every root, challenge, and final value" 
     try std.testing.expectEqual(@as(u64, 1), result.stats.command_buffers);
     try std.testing.expectEqual(@as(u64, 1), result.stats.wait_count);
     try std.testing.expectEqual(@as(u64, 1), result.stats.compute_encoders);
-    try std.testing.expectEqual(@as(u64, 30), result.stats.dispatches);
+    try std.testing.expectEqual(@as(u64, 21), result.stats.dispatches);
     for (result.trees, expected_roots) |tree, expected_root| {
         const actual_root = try tree.root();
         try std.testing.expectEqualSlices(u8, &expected_root, &actual_root.hash);

--- a/src/tools/metal_core_aot/probe.zig
+++ b/src/tools/metal_core_aot/probe.zig
@@ -112,7 +112,7 @@ fn parseTrustAnchor(encoded: []const u8) ![32]u8 {
 }
 
 test "probe authority is the exact Native ABI with no function constants" {
-    try std.testing.expectEqual(@as(usize, 80), kernel_abi.len);
+    try std.testing.expectEqual(@as(usize, 78), kernel_abi.len);
     for (kernel_abi) |entry|
         try std.testing.expectEqual(@as(usize, 0), entry.function_constants.len);
 }

--- a/src/tools/metal_core_aot/probe.zig
+++ b/src/tools/metal_core_aot/probe.zig
@@ -112,7 +112,7 @@ fn parseTrustAnchor(encoded: []const u8) ![32]u8 {
 }
 
 test "probe authority is the exact Native ABI with no function constants" {
-    try std.testing.expectEqual(@as(usize, 78), kernel_abi.len);
+    try std.testing.expectEqual(@as(usize, 80), kernel_abi.len);
     for (kernel_abi) |entry|
         try std.testing.expectEqual(@as(usize, 0), entry.function_constants.len);
 }


### PR DESCRIPTION
## Summary

- fuse each nonterminal Metal line-FRI fold with the next tree's coordinate scatter and leaf hash
- reuse the existing coordinate/fold entry points under explicit shader ABI 3 modes, preserving the 78-export AOT contract
- reduce line-cascade dispatches from 93 to 68 on wide/deep and from 55 to 38 on small without changing roots, challenges, coordinates, or proof bytes

## Native Metal evidence

Fifteen clean ABBA pairs per class, ten warmups and seven verified samples per process:

| class | B/A Hodges--Lehmann (95% CI) | wins |
| --- | ---: | ---: |
| small | 0.9855 [0.9713, 0.9981] | 11/15 |
| wide | 0.9921 [0.9812, 1.0039] | 9/15 |
| deep | 0.9942 [0.9911, 0.9979] | 12/15 |

Suite geometric mean: 0.9906 (0.94% lower proof latency). All 630 timed proofs verified, remained byte-identical, and used zero CPU fallback. Final paired profiles move FRI from 3.926 to 3.836 ms on wide and 3.705 to 3.672 ms on deep.

## Validation

- `zig build test -Doptimize=ReleaseFast`
- `zig build test-native-metal -Doptimize=ReleaseFast`
- `zig build metal-check -Doptimize=ReleaseFast`
- `zig build test-metal-core-aot test-metal-core-aot-probe -Doptimize=ReleaseFast`
- `zig build source-conformance`
- Metal API and GPU shader validation with an exact full proof
- S3 CPU controls for small/wide/deep: G1--G5 pass and confirmed neutral/no-credit

The broad Metal suite remains 80/83 with two expected skips and the same pre-existing resident-policy assertion as the predecessor. Full evidence and the sanitized reasoning transcript are in `autoresearch/submissions/2026-07-21-metal-fri-fold-leaf-fusion/`.
