### PR TITLE
Parallelize Metal FRI Merkle subtrees

### DIFF
--- a/autoresearch/submissions/2026-07-21-metal-fri-multiblock-merkle-tail/delta.json
+++ b/autoresearch/submissions/2026-07-21-metal-fri-multiblock-merkle-tail/delta.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "6c622c60297d",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/backends/metal/runtime/fri_fold_commit.m": "sha256:fe1e0bd6fe31368cbfb38ea37f5c5be65b4ec7f9b8db0bc7cee83965dcbfb364",
+    "src/backends/metal/shaders/core/commitments.metal": "sha256:3febc04ed90d20a9effb10c36a5bfa3f0f41e2bdd8b579b229cbd4a9a7a51def",
+    "src/backends/metal/tests/fri_fold_commit.zig": "sha256:f649d600387f687993fd796aa2e4383ac484c415ea846fb0eaca8251b176abcd"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "8a4f2f875315e371f8bf4137e5274481fd01cd9243d81fb7660f2771b9b25a4f",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-21-metal-fri-multiblock-merkle-tail/note.md
+++ b/autoresearch/submissions/2026-07-21-metal-fri-multiblock-merkle-tail/note.md
@@ -1,0 +1,68 @@
+# Parallelize Metal FRI Merkle tails across bottom subtrees
+
+## Model and harness
+
+Model: GPT-5 Codex.  The repo-resident autoresearch CLI was updated before this
+campaign.  Candidate `f01a645ad829` is measured against exact promoted
+predecessor `6c622c60297d` on an Apple M5 Max.  Native Metal measurements use
+the real ReleaseFast product, functional protocol, independent verification,
+and `--metal-runtime source-jit`; macOS compiles the embedded MSL through
+`newLibraryWithSource`, so no offline Metal compiler or full Xcode is involved.
+
+## Hypothesis
+
+The thirteen-tree wide/deep FRI cascade still launched separate global parent
+grids for the bottom levels of large Merkle trees.  The existing parent-tail
+kernel could reduce an entire shallow tree in one threadgroup, but was used
+only after the whole remaining level fit a single group.  Making its global
+addressing relative to `threadgroup_position_in_grid` lets one dispatch reduce
+many independent bottom subtrees concurrently, followed by the existing upper
+tail, without increasing register pressure in the fold/coordinate/leaf
+producers.
+
+## Changes
+
+Each selected 128-thread bottom group consumes 256 leaves, retains at most 128
+parent hashes in 4 KiB of threadgroup memory, and writes every logical parent
+level and block root.  The upper tail retains its 256-thread capacity so small
+trees do not gain an extra launch.  Wide/deep line-FRI topology moves from 68
+to 58 dispatches; small remains exactly 38.  Buffer bindings, shader export
+inventory, hash order, transcript order, proof data, source-JIT/AOT admission
+split, and the one-command-buffer/one-wait epoch are unchanged.
+
+## Results
+
+Fifteen clean process pairs per class alternated A-B / B-A order.  Every
+process used ten verified warmups and seven timed verified proofs.  Across all
+90 reports, 630/630 timed proofs independently verified, matched the fixed
+class digests, and remained byte-identical within each process.  Every sample
+classified accelerated-without-fallbacks, with zero CPU fallback and zero
+post-warmup direct compilation.
+
+| class | predecessor | candidate | B/A HL (95% CI) | wins |
+| --- | ---: | ---: | ---: | ---: |
+| small `wf_log10x8` | 2.660 ms | 2.632 ms | 0.9937 [0.9785, 1.0110] | 9/15 |
+| wide `wf_log14x32` | 11.725 ms | 11.629 ms | 0.9946 [0.9867, 1.0049] | 11/15 |
+| deep `plonk_log14` | 7.088 ms | 7.031 ms | 0.9915 [0.9856, 0.9959] | 13/15 |
+
+The robust three-class geometric-mean ratio is 0.99325, about 0.68% less proof
+latency.  Deep is confirmed; small and wide are favorable but neutral and are
+not overclaimed.
+
+## Validation
+
+A strengthened log-10 parity fixture forces four independent bottom
+threadgroups and checks every coordinate, Merkle root, transcript challenge,
+and terminal evaluation against the CPU reference.  Native Metal product and
+lifecycle, `metal-check`, source conformance, core-AOT contract, AOT probe
+contract, and a proof under both Metal API and GPU shader validation pass.  The
+broad Metal suite remains at the predecessor's 80/83 baseline: two expected
+skips and the same pre-existing resident-policy assertion.
+
+## Caveats
+
+The official autoresearch board is CPU-only.  Its S3 deep control passes G1--G5
+at 0.9929 [0.9830, 0.9992] but is correctly classified neutral against theta
+0.0183; no CPU-board credit is claimed for a Metal-only change.  The attached
+reasoning transcript also retains the rejected producer-microtree design and
+its occupancy regression rather than folding that dead end into the result.

--- a/autoresearch/submissions/2026-07-21-metal-fri-multiblock-merkle-tail/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-21-metal-fri-multiblock-merkle-tail/transcripts/session-01.md
@@ -1,0 +1,226 @@
+# Session 01 — sixth Metal-backend architecture campaign
+
+Date: 2026-07-21
+Model: GPT-5 Codex
+
+## Recorded frontier and fresh benchmark
+
+PR #29 merged fold/coordinate/leaf producer fusion and the recorder advanced
+canonical main to `6c622c60297d`.  The repo-resident CLI was updated to that
+exact commit, a fresh isolated workspace passed `stwo-perf setup`, and the real
+ReleaseFast Native Metal product was built before any source edit.
+
+The complete fixed three-class Metal suite then ran with ten warmups and seven
+timed verified samples per class on `--metal-runtime source-jit`:
+
+| class | prove median | request median | logical Metal dispatch telemetry |
+| --- | ---: | ---: | ---: |
+| small `wf_log10x8` | 6.713 ms | 7.025 ms | 306 |
+| wide `wf_log14x32` | 11.465 ms | 12.450 ms | 374 |
+| deep `plonk_log14` | 7.084 ms | 7.405 ms | 408 |
+
+Every report named clean complete commit `6c622c60297d`, used ReleaseFast,
+matched its fixed proof digest, independently verified all samples, classified
+accelerated-without-fallbacks, and reported zero CPU fallback.  The small
+absolute latency is frequency-state sensitive, so architecture selection uses
+the stage and device decomposition rather than that one process median.
+
+## Fresh profile and physical residual
+
+Seven-sample ReleaseFast profiles place the common residual as follows:
+
+| stage median (ms) | small | wide | deep |
+| --- | ---: | ---: | ---: |
+| main trace commit | 0.919 | 1.779 | 0.652 |
+| composition evaluation | 0.049 | 2.637 | 0.127 |
+| composition interpolate/split | 0.033 | 0.481 | 0.054 |
+| composition commit | 0.918 | 1.404 | 0.747 |
+| sampled values | 0.411 | 0.806 | 0.665 |
+| FRI quotient/build/commit | 3.188 | 3.865 | 3.656 |
+| proof of work | 0.376 | 0.345 | 0.351 |
+| all decommitment | 0.071 | 0.119 | 0.129 |
+
+FRI remains the dominant common stage.  A fresh Debug source-JIT device run of
+the merged wide cascade is stable at 3.138--3.177 ms, thirteen logical trees,
+68 physical dispatches, one command buffer, one compute encoder, and one wait.
+Small is 1.654--1.678 ms, nine trees, and 38 dispatches.  Device capabilities
+queried through the repository Metal profiler are Apple M5 Max, 1,024 maximum
+threads per threadgroup, 32,768 bytes threadgroup memory, unified memory, and a
+55.66 GB recommended working set.
+
+For wide/deep the 68-dispatch graph now consists of:
+
+```text
+14 producer/fold grids
+  = initial [coordinates + leaves] + 12 [fold + next coordinates + leaves]
+    + terminal fold
+28 Merkle parent/tail grids
+26 serialized transcript mix/draw grids
+------------------------------------------
+68 total
+```
+
+The thirteen trees have logs 14 down through 2.  The existing shallow-tail
+kernel fuses the top of each tree once parent cardinality reaches at most 256,
+but bottom parent levels still launch globally and reread just-written leaf or
+parent hashes.  Coordinates and leaves must remain globally materialized for
+decommitment; parent construction is the remaining legal locality boundary.
+
+## Candidate architectures
+
+| candidate | ceiling | risk / decision |
+| --- | --- | --- |
+| Remove intermediate AoS evaluations and fold from SoA coordinates | 12 buffers plus about 262 KiB read/write | useful but low byte ceiling; defer |
+| Fuse only the first parent into each producer | 13 dispatches and leaf reread | safe but leaves four more global bottom levels on the largest tree |
+| Full 256-leaf threadgroup-memory subtree | 22 dispatches and bottom-level traffic | 32 KiB scratch forces one resident group; reject occupancy risk |
+| SIMDgroup-register microtrees plus tiny cross-subgroup reduction | 22 dispatches without large scratch | select |
+
+The selected producer assigns one leaf to each lane.  A SIMDgroup retains its
+eight-word leaf hash in registers and repeatedly gathers adjacent child hashes
+with `simd_shuffle`, producing and globally storing every logical parent level
+through a 32-leaf subtree.  Up to eight SIMDgroup roots occupy only 256 bytes
+of threadgroup memory; the first subgroup reduces them to one 256-leaf block
+root.  Thus a 256-thread producer writes levels 0 through 8 in one dispatch
+while preserving the complete proof tree:
+
+```text
+folded QM31 lane value
+  |-> four global coordinate planes (proof data)
+  |-> global leaf hash            (proof data)
+  `-> lane hash state
+       -> shuffle-reduce levels 1..5 within each 32-lane SIMDgroup
+       -> 8 subgroup roots in 256 B shared scratch
+       -> first subgroup reduces levels 6..8
+       -> global nodes at every level (proof data)
+```
+
+For logs 14 through 9, one existing top-tail dispatch finishes from the block
+roots; logs 8 through 2 finish entirely inside their producer.  The predicted
+wide/deep cascade is therefore:
+
+| physical work | current | SIMD microtree |
+| --- | ---: | ---: |
+| producers/folds | 14 | 14 |
+| parent/tail grids | 28 | 6 |
+| transcript grids | 26 | 26 |
+| total | 68 | 46 |
+
+Small predicts 38 -> 30.  Compared with the pre-fusion 93-dispatch graph, this
+would remove 47 grids.  It also replaces global reads between the bottom eight
+Merkle levels with register shuffle or 256-byte shared-root traffic.
+
+The implementation will widen the same two authenticated entry points again,
+advance core shader ABI 3 -> 4, and keep the exact 78-export inventory.  Plain
+coordinate/fold modes must bind the wider ABI and return before collectives;
+tree mode dispatches full SIMDgroups.  The host derives a power-of-two block
+width no larger than 256 or the reflected pipeline limit, so smaller Apple GPUs
+remain valid.  Existing global-parent scheduling remains as a capability
+fallback before the top tail if a pipeline cannot produce enough local levels.
+
+Prediction: at least 0.15 ms less ReleaseFast FRI time and a significant
+end-to-end win on one production class.  Falsifiers are any missing logical
+layer node, root/challenge/final-evaluation mismatch, Metal validation error,
+pipeline limit below one SIMDgroup, authenticated-AOT failure, dispatch count
+above the capability-derived model, or clean paired regression.
+
+## Rejected producer microtree experiment
+
+The implementation widened the two existing producer kernels, retained a
+capability fallback, materialized every logical Merkle node, and passed the
+real source-JIT compiler plus the broad Metal suite at its unchanged 80/83
+baseline (two expected skips and the known resident-policy assertion).  The
+five-tree exact fixture moved from 21 to 16 dispatches and preserved every
+root, transcript challenge, coordinate, and terminal evaluation.  Production
+wide topology also matched the model at 46 dispatches with 256-thread blocks.
+
+Device timing falsified the performance hypothesis.  The 256-thread producer
+was about 3.36 ms versus a same-session frontier cascade around 2.88--2.94 ms.
+Sweeping the capability cap exposed an occupancy knee: 32, 64, 128, and 256
+thread choices produced 49, 48, 47, and 46 dispatches respectively, but even
+the best 128-thread version remained roughly 3.0--3.3 ms in a direct thermal
+countercheck.  Folding seven rounds of BLAKE parent work into the already
+register-heavy fold/leaf pipeline costs more occupancy than the removed global
+launches and traffic save.  The entire producer experiment is therefore
+reverted and none of its favorable topology counts are used as improvement
+evidence.
+
+The failed result sharpens the next boundary: keep the producer pipeline
+compact, and reuse the existing isolated parent-tail pipeline across multiple
+independent bottom subtrees.  That kernel already reduces a 512-leaf tree from
+global children through a 256-parent, 8 KiB threadgroup scratch without
+bloating fold or leaf register allocation.  Adding only a threadgroup-position
+base lets one dispatch process every 512-leaf block of a large tree; one final
+tail then joins the block roots.  This is the same validated reducer, applied
+at both the bottom and top of large trees rather than only once the whole level
+fits one group.
+
+## Selected multi-block parent-tail architecture
+
+The parent-tail shader now includes its threadgroup position when addressing
+the first global child level and every globally materialized destination
+level.  Existing one-group users retain group zero and identical semantics.
+The FRI cascade can therefore launch many independent bottom reductions with
+the already-authenticated pipeline.  Each 128-thread group consumes a
+256-leaf block, retains at most 128 parent hashes in 4 KiB of threadgroup
+memory, writes all eight logical parent levels, and leaves one block root.  A
+separate existing upper-tail dispatch joins all block roots.  Fold,
+coordinate, and leaf pipelines are unchanged, avoiding the occupancy failure
+above.
+
+Bottom width and upper-tail capacity are intentionally asymmetric.  A device
+profile sweep found 128 bottom threads better than 64 or 256; the upper tail
+keeps its proven 256-thread capacity so shallow trees do not gain an extra
+dispatch.  On this device, wide/deep line FRI moves 68 -> 58 dispatches while
+small stays exactly 38.  The new exact log-10 fixture forces four independent
+bottom groups, then checks every coordinate, layer root, transcript challenge,
+and final evaluation against the CPU reference.  It reports the modeled 38
+fixture dispatches and passes source-JIT execution.
+
+An initial dirty ReleaseFast ABBA screen used ten verified warmups and seven
+timed proofs per process.  Wide moved 11.695 -> 11.644 ms and 11.656 -> 11.438
+ms across the two counterbalanced pairs.  A first deep pair moved 7.574 ->
+7.374 ms (2.6%), while small was neutral at 6.023 versus 6.043 ms.  All 42
+timed samples in this screen independently verified, were byte-identical
+within each process, matched their fixed class digests, used source-JIT, and
+reported zero fallback.  These dirty-tree numbers are mechanism screening,
+not final verdict evidence.
+
+The broad Metal suite remains at the frontier's 80/83 result: two expected
+skips and the same pre-existing resident-policy assertion.  Native Metal
+product/lifecycle, `metal-check`, source conformance, core-AOT contract tests,
+and the AOT acceptance-probe contract all pass.  A complete proof also passes
+with both Metal API validation and GPU shader validation enabled.  The final
+change keeps the buffer ABI and exact export inventory unchanged; authenticated
+AOT identity changes through the embedded shader-source digest, so no ABI
+version or offline Metal compiler is required for this source-JIT run.
+
+## Final clean paired Metal evidence
+
+Final candidate `f01a645ad829` and exact predecessor `6c622c60297d` were built
+independently from clean ReleaseFast worktrees.  Fifteen process pairs per
+class alternated A-B / B-A order; every process used ten verified warmups and
+seven timed independently verified proofs.  The complete 90-report audit found
+the expected 45 reports per commit, clean complete provenance, source-JIT
+admission, no post-warmup direct compilation, accelerated-without-fallbacks
+classification, zero CPU fallbacks, and the fixed digest for each class.  All
+630 timed proofs verified and remained byte-identical within each process.
+
+| class | predecessor median | candidate median | B/A HL (95% CI) | wins |
+| --- | ---: | ---: | ---: | ---: |
+| small `wf_log10x8` | 2.660 ms | 2.632 ms | 0.9937 [0.9785, 1.0110] | 9/15 |
+| wide `wf_log14x32` | 11.725 ms | 11.629 ms | 0.9946 [0.9867, 1.0049] | 11/15 |
+| deep `plonk_log14` | 7.088 ms | 7.031 ms | 0.9915 [0.9856, 0.9959] | 13/15 |
+
+The repository Hodges--Lehmann/bootstrap estimator gives a three-class
+geometric-mean ratio of 0.99325, about 0.68% less proof latency.  Deep is the
+confirmed class; small and wide are favorable but neutral and are not
+overclaimed.  One small candidate-first round contains a large favorable
+frequency excursion (ratio 0.553); it is retained rather than pruned, and the
+robust estimator plus every bootstrap resample sees it.
+
+The official autoresearch board is CPU-only, so its S3 deep control measures no
+expected Metal credit.  Candidate `f01a645` versus predecessor `6c622c6`
+passes G1--G5, locked-path policy, pinned Rust oracle, and exact proof checks at
+0.9929 [0.9830, 0.9992] over seven rounds.  Its measured theta is 0.0183, so it
+is correctly classified confirmed-neutral.  The claimed Metal improvement is
+the clean device evidence above, not this CPU control.

--- a/autoresearch/submissions/2026-07-21-metal-fri-multiblock-merkle-tail/verdict.json
+++ b/autoresearch/submissions/2026-07-21-metal-fri-multiblock-merkle-tail/verdict.json
@@ -1,0 +1,137 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "35a0e0cfc689",
+  "repo_commit": "f01a645ad829",
+  "predecessor_commit": "6c622c60297d",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 2.03
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.4656 vs targeted budget x1.02; request ratio 0.9919 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "plonk_log14": {
+        "r": 0.992857,
+        "ci": [
+          0.983005,
+          0.999242
+        ],
+        "rounds": 7,
+        "a_median_ms": 6.752166,
+        "b_median_ms": 6.712792
+      }
+    },
+    "R_geomean": 0.992857,
+    "theta": 0.018278,
+    "aa_dispersion": 0.009139,
+    "significant": false,
+    "neutral": true
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "plonk_log14",
+      "verified": true,
+      "artifact_sha256": "ed64ff803f2e7ec8c5eeb81f520ee3cb228c6811795a53137092a8632f9e5e68"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "plonk_log14": {
+        "round_ratios": [
+          0.993666,
+          0.991631,
+          0.983005,
+          0.995358,
+          1.003126,
+          1.000427,
+          0.975218
+        ],
+        "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf",
+        "request_ratio": 0.991859,
+        "report_sha256s": [
+          "c20c4d58c204a0274c1652b566ca8cdfd581ab81649dc348c9fa1d9109df7a86",
+          "769c68336c2996fe41121d0ce410cb088f7965e3706f592a6217649195b417a9",
+          "b41b18fa9bc17824aac3cc3502feecd3492c4a80e8fdb947ed75eb9bfc8aa553",
+          "b1a90679f5bfe4cabcf3dc927d73e2d749dccd918bd6bf7acbc7ffaae2da0881",
+          "43d3615ba97e2e9a1b00de68d2fbc9ed2fc662ae3eb069d7a2093c97eae4a1e6",
+          "4ec294c89890ace06c4a1d0d06889262eb5f73905191c37ecbc10202e2802281",
+          "255e1bbeaae54b47f6169bfda002b59638189225be48ee4c1e28723d08e65fe7",
+          "1254b9baa359b2a471f1890bb3bdfe5b2a73025d803061a1533080243e9ed64e",
+          "b5d92a84140e98c0c8ea333455a9800eed54389b93095a60b21a9ff80a7181ff",
+          "58079d20fb48d11b9948ef0dff595cc366132081342e9264271340b07dd6d864",
+          "d5a36350ec78182457987868b0e14d8674a940ce6a635f57095fb657fcf38e98",
+          "0b84b8d412b6787dc7ae48bfefead957220f378a333d8308070459a2129e944a",
+          "e8aa944bf18911b1b2f9b1b663ddac425cdffb210315ddcdcb70cf750c03f1e0",
+          "657d5f9d444b6a1dddf983d7ba92cdace86a01aef02f29df39659bd5f27f96f3"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch6/autoresearch/.runs/latest/plonk_log14.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch6/autoresearch/.runs/latest/plonk_log14.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch6/autoresearch/.runs/latest/plonk_log14.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch6/autoresearch/.runs/latest/plonk_log14.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch6/autoresearch/.runs/latest/plonk_log14.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch6/autoresearch/.runs/latest/plonk_log14.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch6/autoresearch/.runs/latest/plonk_log14.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch6/autoresearch/.runs/latest/plonk_log14.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch6/autoresearch/.runs/latest/plonk_log14.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch6/autoresearch/.runs/latest/plonk_log14.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch6/autoresearch/.runs/latest/plonk_log14.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch6/autoresearch/.runs/latest/plonk_log14.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch6/autoresearch/.runs/latest/plonk_log14.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch6/autoresearch/.runs/latest/plonk_log14.b7.json"
+    ]
+  }
+}

--- a/src/backends/metal/runtime/fri_fold_commit.m
+++ b/src/backends/metal/runtime/fri_fold_commit.m
@@ -405,20 +405,60 @@ bool stwo_zig_metal_fri_line_cascade(
             uint32_t tree_log_size = tree.logSize;
 
             uint32_t child_offsets[31], destination_offsets[31], parent_counts[31];
-            uint32_t tail_level = tree_log_size + 1u;
             uint32_t parent_count = count >> 1u;
             for (uint32_t level = 1u; level <= tree_log_size; ++level) {
                 child_offsets[level - 1u] = tree_layer_word_offset(tree, level - 1u);
                 destination_offsets[level - 1u] = tree_layer_word_offset(tree, level);
                 parent_counts[level - 1u] = parent_count;
-                // Leave a one-level tail alone; fusing is useful only when a
-                // single threadgroup replaces at least two dispatches.
-                if (tail_level > tree_log_size && level < tree_log_size &&
-                    parent_count <= tail_capacity)
-                    tail_level = level;
                 parent_count >>= 1u;
             }
-            for (uint32_t level = 1u; level < tail_level; ++level) {
+
+            uint32_t first_parent_level = 1u;
+            if (tail_capacity >= 2u && parent_counts[0] > tail_capacity) {
+                // Reduce independent bottom subtrees concurrently with the
+                // existing tail kernel. 128 parent hashes need only 4 KiB of
+                // scratch and leave the 256-thread upper-tail policy intact.
+                uint32_t bottom_capacity = MIN(128u, tail_capacity);
+                uint32_t bottom_width = 1u;
+                while ((bottom_width << 1u) <= bottom_capacity) bottom_width <<= 1u;
+                uint32_t bottom_levels = 1u;
+                for (uint32_t width = bottom_width; width > 1u; width >>= 1u)
+                    bottom_levels += 1u;
+                uint32_t bottom_counts[31];
+                uint32_t local_count = bottom_width;
+                for (uint32_t level = 0u; level < bottom_levels; ++level) {
+                    bottom_counts[level] = local_count;
+                    local_count >>= 1u;
+                }
+
+                [encoder setComputePipelineState:runtime.parentTailSparse];
+                [encoder setBuffer:transcript_arena offset:0u atIndex:0];
+                [encoder setBytes:child_offsets
+                    length:(NSUInteger)bottom_levels * sizeof(uint32_t) atIndex:1];
+                [encoder setBytes:destination_offsets
+                    length:(NSUInteger)bottom_levels * sizeof(uint32_t) atIndex:2];
+                [encoder setBytes:bottom_counts
+                    length:(NSUInteger)bottom_levels * sizeof(uint32_t) atIndex:3];
+                [encoder setBytes:&bottom_levels length:sizeof(bottom_levels) atIndex:4];
+                [encoder setBuffer:node_seed_buffer offset:0u atIndex:5];
+                [encoder setBytes:&domain_prefix_bytes length:sizeof(domain_prefix_bytes) atIndex:6];
+                [encoder setThreadgroupMemoryLength:(NSUInteger)bottom_width * 8u * sizeof(uint32_t)
+                    atIndex:0];
+                [encoder dispatchThreadgroups:MTLSizeMake(parent_counts[0] / bottom_width, 1u, 1u)
+                     threadsPerThreadgroup:MTLSizeMake(bottom_width, 1u, 1u)];
+                [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+                dispatches += 1u;
+                first_parent_level = bottom_levels + 1u;
+            }
+
+            uint32_t tail_level = tree_log_size + 1u;
+            for (uint32_t level = first_parent_level; level < tree_log_size; ++level) {
+                if (parent_counts[level - 1u] <= tail_capacity) {
+                    tail_level = level;
+                    break;
+                }
+            }
+            for (uint32_t level = first_parent_level; level < tail_level; ++level) {
                 uint32_t level_index = level - 1u;
                 [encoder setComputePipelineState:runtime.parents];
                 [encoder setBuffer:transcript_arena

--- a/src/backends/metal/shaders/core/commitments.metal
+++ b/src/backends/metal/shaders/core/commitments.metal
@@ -209,14 +209,17 @@ kernel void stwo_zig_blake2s_parent_tail_sparse(
     constant uint *destination_offsets [[buffer(2)]], constant uint *parent_counts [[buffer(3)]],
     constant uint &level_count [[buffer(4)]], constant uint *node_seed [[buffer(5)]],
     constant uint &prefix_bytes [[buffer(6)]],
-    threadgroup uint *hashes [[threadgroup(0)]], uint thread_index [[thread_index_in_threadgroup]]
+    threadgroup uint *hashes [[threadgroup(0)]], uint thread_index [[thread_index_in_threadgroup]],
+    uint group [[threadgroup_position_in_grid]]
 ) {
     for (uint level = 0u; level < level_count; ++level) {
         uint parent_count = parent_counts[level];
         uint message[16];
         if (thread_index < parent_count) {
             if (level == 0u) {
-                uint source = child_offsets[0] + thread_index * 16u;
+                // Each threadgroup owns one contiguous bottom subtree.
+                uint source = child_offsets[0] +
+                    (group * parent_count + thread_index) * 16u;
                 for (uint i = 0u; i < 16u; ++i) message[i] = arena[source + i];
             } else {
                 uint source = thread_index * 16u;
@@ -229,7 +232,8 @@ kernel void stwo_zig_blake2s_parent_tail_sparse(
             if (prefix_bytes == 0u) blake2s_init_hash(state);
             else blake2s_init_seeded(state, node_seed);
             blake2s_compress(state, message, prefix_bytes + 64u, true);
-            uint destination = destination_offsets[level] + thread_index * 8u;
+            uint destination = destination_offsets[level] +
+                (group * parent_count + thread_index) * 8u;
             for (uint i = 0u; i < 8u; ++i) {
                 hashes[thread_index * 8u + i] = state[i];
                 arena[destination + i] = state[i];

--- a/src/backends/metal/tests/fri_fold_commit.zig
+++ b/src/backends/metal/tests/fri_fold_commit.zig
@@ -264,7 +264,7 @@ test "metal: line FRI cascade preserves every root, challenge, and final value" 
     var runtime = try runtime_mod.Runtime.init();
     defer runtime.deinit();
 
-    const source_log: u32 = 6;
+    const source_log: u32 = 10;
     const final_log: u32 = 1;
     const layer_count: usize = source_log - final_log;
     const source_count: usize = @as(usize, 1) << source_log;
@@ -392,7 +392,7 @@ test "metal: line FRI cascade preserves every root, challenge, and final value" 
     try std.testing.expectEqual(@as(u64, 1), result.stats.command_buffers);
     try std.testing.expectEqual(@as(u64, 1), result.stats.wait_count);
     try std.testing.expectEqual(@as(u64, 1), result.stats.compute_encoders);
-    try std.testing.expectEqual(@as(u64, 21), result.stats.dispatches);
+    try std.testing.expectEqual(@as(u64, 38), result.stats.dispatches);
     for (result.trees, expected_roots) |tree, expected_root| {
         const actual_root = try tree.root();
         try std.testing.expectEqualSlices(u8, &expected_root, &actual_root.hash);


### PR DESCRIPTION
This submission reuses the existing Metal parent-tail kernel across independent bottom Merkle subtrees, then joins block roots with the existing upper tail. The fold, coordinate, and leaf producers stay compact.

Metal mechanism:
- wide/deep line-FRI cascade: 68 to 58 physical dispatches
- small cascade: unchanged at 38 dispatches
- 128-thread bottom groups, 4 KiB threadgroup scratch; 256-thread upper-tail capacity retained
- exact log-10 parity fixture exercises four independent groups

Clean ReleaseFast source-JIT evidence, 15 alternating pairs per class and 630 verified timed proofs:
- small: 0.9937 [0.9785, 1.0110]
- wide: 0.9946 [0.9867, 1.0049]
- deep: 0.9915 [0.9856, 0.9959]
- three-class geomean: 0.99325

All proofs match fixed digests with zero CPU fallback and zero post-warmup compilation. Native Metal lifecycle, source conformance, metal-check, core-AOT contracts, and Metal API/GPU validation pass. The broad Metal suite remains at the predecessor baseline of 80/83 due to two expected skips and one pre-existing resident-policy assertion.

The enabled autoresearch judge board is CPU-only. Its S3 deep control passes G1-G5 but is correctly classified neutral; Metal credit is supported by the attached clean device evidence and transcript.