### PR TITLE
Parallelize generic Metal Merkle parent chains

### DIFF
--- a/autoresearch/submissions/2026-07-21-metal-generic-merkle-multiblock/delta.json
+++ b/autoresearch/submissions/2026-07-21-metal-generic-merkle-multiblock/delta.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "35819ff7920d",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/backends/metal/runtime.m": "sha256:a84642cc0a98a41fbe328fc05531604555ce5de09570a78c65d97541818c8eeb",
+    "src/backends/metal/runtime/lifecycle_and_tree.m": "sha256:453bf4b772ea82470f1b1578a69203027d416f72bdd0b32157e0e103a5c913ca",
+    "src/backends/metal/runtime/merkle_epochs.m": "sha256:c9073c5d06cca7720ba6edb1e005fb10f66e10d844c4b9be5e90ba45fb27f4af",
+    "src/backends/metal/tests/command_epoch.zig": "sha256:68ff44dd352d1c840a025a81d81d93acfcc373a72470f04bb97f1e48dc682f34"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "8b314464289a3a263180d67c3071a96decab542f4730f65d354d8c71c29d4c4b",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-21-metal-generic-merkle-multiblock/note.md
+++ b/autoresearch/submissions/2026-07-21-metal-generic-merkle-multiblock/note.md
@@ -1,0 +1,108 @@
+# Parallelize generic Metal Merkle parent chains
+
+## Model and harness
+
+GPT-5 Codex optimized clean candidate `03ec753d0232` from exact promoted
+predecessor `35819ff7920d` on an Apple M5 Max.  Before source changes, the
+repo-resident CLI was updated, the fixed three-class Metal suite was run
+locally, and fresh profiles identified generic main-trace and composition
+Merkle commitments as the next shared hot path.
+
+All production measurements use the real ReleaseFast
+`native-proof-bench-metal`, functional protocol, independent proof
+verification, and `--metal-runtime source-jit`.  Zig embeds the MSL and macOS
+compiles it through `newLibraryWithSource`; shader initialization is excluded
+from timed post-warmup samples.  No full Xcode installation or offline `metal`
+compiler is involved.
+
+## Hypothesis
+
+Large generic commitments still dispatched the lower Merkle levels one at a
+time.  A log-14 tree launched five global parent grids before its existing
+single-threadgroup top tail.  PR #30 had already proved that the isolated
+parent-tail kernel can reduce many independent bottom subtrees concurrently
+without the occupancy regression of fusing hash work into a leaf producer.
+
+The predicted architecture was one 128-parent threadgroup per 256 leaves,
+writing every required global layer through eight local reduction levels,
+followed by the existing upper tail.  A normal large parent chain would move
+from six dispatches to two.  Keeping leaf and parent grids in one compute
+encoder with explicit buffer barriers would also remove six encoder
+boundaries per direct commitment.
+
+## Changes
+
+Prepared generic parent chains now derive an optional multi-block bottom
+segment from reflected pipeline/threadgroup limits and arena geometry.  The
+fast schedule is enabled only when counts halve exactly, the first count is an
+exact multiple of the local width, every bottom destination is pairwise
+disjoint, and every destination is disjoint from the complete initial child
+range.  This last condition prevents a cross-threadgroup read/write race on
+ping-pong storage; aliased layouts retain their conservative schedule.
+
+Bottom, any global middle, and top-tail grids share one compute encoder with
+`MTLBarrierScopeBuffers` barriers.  The direct commitment's leaf grid joins
+that encoder and barriers before the first parent read.  Buffer layout, every
+materialized proof node, hash order, public C ABI, shader source, export
+inventory, source-JIT/AOT split, and fallback behavior are unchanged.
+
+## Results
+
+An isolated production `commitColumns` run discards five commits and measures
+the following 96, using exact stable roots:
+
+| log-14 commitment | predecessor GPU median | candidate GPU median | reduction |
+| --- | ---: | ---: | ---: |
+| 32 columns (wide main trace) | 0.091 ms | 0.077 ms | 15.4% |
+| 4 columns (composition) | 0.076 ms | 0.062 ms | 18.4% |
+
+Final end-to-end evidence uses fifteen clean process pairs per class,
+alternating A-B / B-A order.  Every process performs ten verified warmups and
+seven timed verified proofs.  Statistics are the repository Walsh-average
+Hodges--Lehmann estimator with deterministic bootstrap intervals.
+
+| class | predecessor | candidate | B/A (95% CI) | wins |
+| --- | ---: | ---: | ---: | ---: |
+| small `wf_log10x8` | 2.689 ms | 2.651 ms | 0.99005 [0.98088, 0.99723] | 12/15 |
+| wide `wf_log14x32` | 11.578 ms | 11.518 ms | 0.99574 [0.98490, 1.00467] | 9/15 |
+| deep `plonk_log14` | 7.026 ms | 6.997 ms | 0.99609 [0.99098, 0.99934] | 9/15 |
+
+The three-class geometric-mean ratio is `0.993954`: about 0.60% less proof
+latency / 1.006x throughput.  Small and deep are statistically favorable;
+wide is favorable but neutral.  One favorable small frequency-ramp outlier is
+retained and disclosed rather than pruned.
+
+Across 90 clean reports, all 630 timed proofs independently verify, remain
+byte-identical, and match the fixed digest for each class.  Every report has
+the exact expected commit, complete clean provenance, source-JIT admission,
+zero post-warmup direct compilation, `accelerated_without_fallbacks`
+classification, and zero CPU fallback.
+
+## Validation and official control
+
+A strengthened 2,048-leaf device fixture forces the new schedule, reports one
+compute encoder/two parent dispatches, and compares all eleven materialized
+levels with scalar Blake2s.  Its aliased ping-pong pass rejects the bottom
+schedule, uses barrier-separated globals plus the safe top tail, and produces
+the same root.
+
+Native Metal build/lifecycle, independent verification, `metal-check`, source
+conformance, core-AOT tooling, AOT acceptance-probe contracts, formatting, and
+diff checks pass.  A full Plonk proof passes with Metal API and GPU Validation
+enabled.  The broad Metal suite remains at the predecessor's 80/83 baseline:
+two expected skips and the same pre-existing resident-policy assertion.
+
+The required CPU S3 deep control passes G1--G5 and the pinned Rust oracle at
+1.0043 [0.9952, 1.0122], correctly confirmed-neutral against theta 0.0183.
+
+## Caveats
+
+- The manifest still has no enabled `core_metal` judge workload.  The CPU
+  verdict is a no-regression packaging control; the optimization claim comes
+  from the clean production Metal evidence and is not mislabeled as CPU gain.
+- Full Metal System Trace is unavailable on this Command-Line-Tools-only host.
+  Real source-JIT execution, GPU command timestamps, stage profiles, exact
+  topology counters, validation layers, and isolated production commitments
+  provide the attribution.
+- Devices unable to provide the reflected tail capacity, and chains with
+  overlapping storage, fail closed to the existing per-level path.

--- a/autoresearch/submissions/2026-07-21-metal-generic-merkle-multiblock/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-21-metal-generic-merkle-multiblock/transcripts/session-01.md
@@ -1,0 +1,186 @@
+# Session 01 — seventh Metal-backend architecture campaign
+
+Date: 2026-07-21
+Model: GPT-5 Codex
+
+## Frontier and fresh local grounding
+
+The recorder advanced canonical main to `35819ff7920d` after PR #30 merged the
+multi-block FRI Merkle tail.  Before editing source, the repository CLI was
+updated to that exact frontier, a fresh isolated workspace passed setup, and a
+real ReleaseFast Native Metal product was built with the macOS runtime
+source-JIT path.  Ten warmups and seven verified timed samples gave:
+
+| class | prove median | request median |
+| --- | ---: | ---: |
+| small `wf_log10x8` | 6.693 ms | 6.964 ms |
+| wide `wf_log14x32` | 11.737 ms | 12.670 ms |
+| deep `plonk_log14` | 7.038 ms | 7.368 ms |
+
+All samples were exact, independently verified, source-JIT admitted, and
+fallback-free.  Fresh profiled wide/deep runs locate the remaining commitment
+cost as follows:
+
+| stage median (ms) | wide | deep |
+| --- | ---: | ---: |
+| main trace commit | 1.838 | 0.652 |
+| main commit's Merkle child | 0.745 | 0.389 |
+| composition evaluation | 2.594 | 0.127 |
+| composition interpolate/split | 0.479 | 0.062 |
+| composition commit | 1.558 | 0.756 |
+| sampled values | 0.810 | 0.660 |
+| FRI | 3.794 | 3.638 |
+
+PR #30 demonstrated that the isolated `parentTailSparse` pipeline can reduce
+many independent bottom subtrees in one grid without the occupancy regression
+of producer fusion.  The generic main/composition commitment path still emits
+one encoder and grid for each bottom parent level, then one top-tail grid.
+
+## Selected generic multi-block architecture
+
+Extend the prepared generic `StwoZigMerkleParentChain` plan with a capability-
+and-layout-derived bottom segment.  On this device, each 128-threadgroup owns
+256 initial child hashes, writes eight complete logical parent levels to their
+existing global destinations, and leaves one block root.  The existing upper
+tail then joins the block roots:
+
+```text
+separate arena levels, large tree
+
+leaf hashes ──┬─ TG 0: 128 -> 64 -> ... -> 1 ─┐
+              ├─ TG 1: 128 -> 64 -> ... -> 1 ─┤
+              ├─ ...                           ├─ upper tail -> root
+              └─ TG N: 128 -> 64 -> ... -> 1 ─┘
+
+old:  global L0 -> global L1 -> ... -> global L7 -> top tail
+new:  one concurrent bottom grid                         -> top tail
+```
+
+For a normal log-14 direct commitment this predicts six physical Merkle
+parent grids becoming two.  Main trace and composition each use the same
+prepared chain, so a wide proof should remove about eight launch boundaries
+without changing the leaf pipeline, node layout, proof data, shader exports,
+or public ABI.
+
+The critical correctness constraint is cross-threadgroup aliasing.  Metal has
+no global barrier inside a grid: if a destination overlaps the initial child
+range, one group could overwrite leaves another group has not loaded.  The
+bottom segment is therefore enabled only when:
+
+1. the first parent count exceeds the ordinary top-tail capacity;
+2. at least eight exact halving levels exist for a 128-parent local cascade;
+3. every bottom output level has a pairwise-disjoint arena range;
+4. every bottom output range is disjoint from the complete initial child
+   range; and
+5. the first global count is an exact multiple of the local width.
+
+Direct main/composition commitments allocate a distinct range per level and
+qualify.  Ping-pong and overlapping recipe layouts fail closed to their
+current per-level schedule.  Shallow trees are deliberately unchanged.
+
+Prediction: exact roots and every materialized node remain unchanged; large
+direct chains report two parent dispatches, production proof telemetry drops,
+and at least one wide/deep class improves materially.  Falsifiers are a Metal
+validation error, any node/root/proof mismatch, changed shallow topology,
+activation on aliased storage, or same-session/counterbalanced latency loss.
+
+## Implemented schedule and first measurements
+
+Plan preparation now records a bottom level count, local width, group count,
+and scratch requirement only after the five geometry checks above pass.  The
+existing source-JIT shader needs no ABI or source change because PR #30 already
+made its first global read and every global write group-relative.  A stack
+array substitutes local counts `128, 64, ..., 1` while the plan retains global
+counts for validation and arena bounds.
+
+The generic chain was also brought into the same encoder model as the FRI
+cascade.  Bottom, any conservative global middle, and the top tail share one
+compute encoder with explicit `MTLBarrierScopeBuffers` barriers.  The direct
+commitment's leaf grid joins that encoder too, with a barrier before the first
+parent read.  Thus a normal large direct commitment changes from:
+
+```text
+leaf encoder | P0 encoder | P1 | P2 | P3 | P4 | top-tail encoder
+```
+
+to:
+
+```text
+leaf grid -> buffer barrier -> multi-group bottom grid -> barrier -> top tail
+<--------------------------- one compute encoder --------------------------->
+```
+
+The strengthened 2,048-leaf source-JIT fixture reports one compute encoder and
+two parent dispatches, and compares all eleven globally materialized layers
+against scalar Blake2s.  A second pass deliberately ping-pongs through the
+initial leaf range.  It rejects the concurrent bottom schedule, retains nine
+barrier-separated global grids plus its safe two-level top-tail grid, and
+matches the same root.  The broad Metal suite remains at its known 80/83
+frontier baseline: two expected skips and the pre-existing resident-policy
+assertion are unchanged.
+
+Full-proof A/B screening is frequency noisy in wide because composition
+evaluation and FRI dominate, but deep is favorable in every six-pair screen.
+An isolated production `commitColumns` measurement removes that confounder.
+Each process creates the real source-JIT runtime, discards five commits, and
+measures the next 96 log-14 commitments:
+
+| commitment | frontier GPU median | candidate GPU median | change |
+| --- | ---: | ---: | ---: |
+| 32 columns (wide main-trace geometry) | 0.091 ms | 0.077 ms | -15.4% |
+| 4 columns (composition geometry) | 0.076 ms | 0.062 ms | -18.4% |
+
+The corresponding candidate wall medians are 0.449 and 0.307 ms, versus 0.465
+and 0.345 ms in the counterbalanced frontier processes.  Earlier cold process
+outliers are retained rather than silently pruned; the table uses the second
+counterbalanced pair after both orders had warmed the device.  Exact roots are
+stable in every repetition.  This mechanism result and the consistently
+favorable deep proof class are sufficient to advance to clean validation and
+submission; wide end-to-end movement will not be overclaimed.
+
+## Clean end-to-end evidence and controls
+
+Candidate `03ec753d0232` and predecessor `35819ff7920d` were built in separate
+clean worktrees.  An initial 90-report attempt was discarded before use
+because both binaries were launched with the dirty research workspace as the
+process current directory; runtime provenance correctly marked the reports
+dirty even though the executable files came from clean builds.  The complete
+suite was rerun with each process rooted in its owning clean worktree.
+
+Fifteen process pairs per class alternated A-B / B-A order.  Every process used
+ten verified warmups and seven timed verified proofs.  The corrected audit has
+90 reports, exactly 45 per commit, and no provenance error.  All 630 timed
+proofs independently verified, remained byte-identical within each process,
+matched the fixed cross-arm class digest, used source-JIT admission, reported
+`accelerated_without_fallbacks`, had zero CPU fallback, and performed zero
+post-warmup direct compilation.
+
+| class | predecessor median | candidate median | B/A HL (95% CI) | wins |
+| --- | ---: | ---: | ---: | ---: |
+| small `wf_log10x8` | 2.689 ms | 2.651 ms | 0.99005 [0.98088, 0.99723] | 12/15 |
+| wide `wf_log14x32` | 11.578 ms | 11.518 ms | 0.99574 [0.98490, 1.00467] | 9/15 |
+| deep `plonk_log14` | 7.026 ms | 6.997 ms | 0.99609 [0.99098, 0.99934] | 9/15 |
+
+The repository Walsh-average Hodges--Lehmann estimator and deterministic
+bootstrap give a three-class geometric-mean ratio of `0.993954`, about 0.60%
+less end-to-end proof latency.  Small and deep are confirmed favorable; wide
+is favorable but neutral and is not overclaimed.  The first small pair has a
+large favorable ratio of 0.517, consistent with the known small-workload GPU
+frequency ramp.  It is retained, disclosed, and handled by the robust
+estimator rather than pruned.
+
+Validation passes the Native Metal ReleaseFast build and lifecycle, independent
+proof verification, `metal-check`, source conformance, core-AOT tooling tests,
+and the authenticated-AOT acceptance-probe contracts.  The broad device suite
+is unchanged at 80/83: two expected skips and the pre-existing resident-policy
+assertion.  A complete Plonk proof passes with both Metal API Validation and
+Metal GPU Validation explicitly enabled.  No shader source or export changed;
+the macOS runtime still compiles the embedded MSL through source-JIT, while the
+host-runtime identity correctly incorporates the Objective-C scheduler change.
+
+The required official `core_cpu` S3 deep control passes G1--G5 and the pinned
+Rust oracle over fifteen paired rounds.  It measures 1.0043 [0.9952, 1.0122]
+against theta 0.0183 and is correctly confirmed-neutral.  The current manifest
+still has no enabled `core_metal` workload, so the claimed improvement is the
+clean production Metal evidence above; no Metal verdict or locked benchmark
+change is fabricated.

--- a/autoresearch/submissions/2026-07-21-metal-generic-merkle-multiblock/verdict.json
+++ b/autoresearch/submissions/2026-07-21-metal-generic-merkle-multiblock/verdict.json
@@ -1,0 +1,177 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "9cd4618522e8",
+  "repo_commit": "03ec753d0232",
+  "predecessor_commit": "35819ff7920d",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 3.52
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.4676 vs targeted budget x1.02; request ratio 1.0066 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "plonk_log14": {
+        "r": 1.004291,
+        "ci": [
+          0.99518,
+          1.012168
+        ],
+        "rounds": 15,
+        "a_median_ms": 6.68225,
+        "b_median_ms": 6.740625
+      }
+    },
+    "R_geomean": 1.004291,
+    "theta": 0.018278,
+    "aa_dispersion": 0.009139,
+    "significant": false,
+    "neutral": true
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "plonk_log14",
+      "verified": true,
+      "artifact_sha256": "ed64ff803f2e7ec8c5eeb81f520ee3cb228c6811795a53137092a8632f9e5e68"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "plonk_log14": {
+        "round_ratios": [
+          1.024598,
+          1.005985,
+          1.015607,
+          0.978152,
+          1.020152,
+          0.971772,
+          0.996751,
+          1.01835,
+          0.987622,
+          1.007364,
+          0.992899,
+          1.01576,
+          1.007729,
+          0.99746,
+          1.008576
+        ],
+        "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf",
+        "request_ratio": 1.006601,
+        "report_sha256s": [
+          "8227d35e3cce03211f8b51d68bdf613984490fea3fb9b35a43e2763feb1e3dd8",
+          "52bce083bac0120988791caef46c06c47afcf47efe6f9095e8ad5c03460d9663",
+          "dc234e53da78d9a80cb17a383a1aae39733507874c8ffe4638007b7921af5cea",
+          "caa233e7ba1017857c5dd1de87cfb9e907ae6df33562212a5db32614af1e62a7",
+          "7348a6fc4eb54e28e210315ced695c6e1f60439dfa79eaa5c2694178906b9a7c",
+          "31e6f4b1fa4dbc7c06cf801a91e208b91d6aec9bbbd1153aa446ef9f62c14495",
+          "380855a8ad858bfbf9b85c1a5cf32f28370b541631355d949ccba55426661287",
+          "6ad7bf1827dcca243b8742d3d375c4a45e818b7599a3abd4d27a5da359d63338",
+          "4af32a9b7d867ec4095045272ba3ca0ec1dc74a99cdd56b81496bb38f478744e",
+          "4364663dcef3dda0d1fbc067c66e678e77ebde192f0bc94e3105b3cc6f05a8c9",
+          "967bfb795468620302e4a8917827fb0ead3cb91d3e9597f792eb0270731fac98",
+          "00d04949b5ed5e3a376d4770199ec2213b557039f16b4508af5c0fed94d8dff1",
+          "e53d335da9bbf61855859837825dcab19bbdcc51d1218b61589ecf02b48f3930",
+          "440a073188587fddb5408454b322e6b4c62ff0f639e94c2052795d868952d477",
+          "0a4cde6dd2226f7714d22d150a6287207578200ffbd8a0207b73753941816590",
+          "f7823864874371387e036b3baddd7e156c472efe0745ec2e5f1fe974936df393",
+          "8d625654ab254f9ac7cc9c103b35630d14dfa68b9165142d29718a0c6cc4434a",
+          "cd82bb472c4fc76e8f6b2198d1576ff9f8984040079ef0cf8a80736dd8aed00c",
+          "50aacd446a58a4e123bc64f15d331a631fee6ad56b4b55ab06c0d18d407846b3",
+          "4aff87d85eefab4831019d012293027560285bc0e4237d3ed2984179f87f60c2",
+          "fc33458a8a686834847e5c47ded94da427909c042f9814c0a9e7d50e26b04a80",
+          "463f9bb4f4056b4677d433e2fe35d8a53adc17a22c0698493be86383c348b917",
+          "6c5d863d1b15bd05d0f6afc686ee253cae83c40fc1a78653af7072c4791583a4",
+          "5dccbb3cb345887167c28ce067b2ffa99b4f713ddf9960da47940666130e645e",
+          "c76617dad98072a339c25ffe002945e38cacb316529f8b53bd9ac4b3935e68ec",
+          "a60c6dbb05d1a2c0a67c107e69d7d75c53ce467dd1fc7aeca341c5b11a1ec6f0",
+          "4a7e335b1e2922731eeb49f316a5fbedfc769ce37a8ec1a0084b3276d69f605b",
+          "02962984ba3441b4540b1ef8aec13c74364d64bef98fbf435098f25dfaf3156f",
+          "1afbeab8c2d2de3e4363c74cf0f382d47128be10e4bdb816e58fe54ed5dc2f12",
+          "9ded9c2f87e7ddedc7b3d9fea2e8390a9ac7e149480a728b566d52ee96fb43bf"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.b10.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.a11.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.b11.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.a12.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.b12.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.a13.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.b13.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.a14.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.b14.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.a15.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch7-clean/autoresearch/.runs/latest/plonk_log14.b15.json"
+    ]
+  }
+}

--- a/src/backends/metal/runtime.m
+++ b/src/backends/metal/runtime.m
@@ -214,6 +214,10 @@
 @property(nonatomic, strong) id<MTLBuffer> nodeSeed;
 @property(nonatomic) uint32_t levelCount;
 @property(nonatomic) uint32_t prefixBytes;
+@property(nonatomic) uint32_t bottomLevelCount;
+@property(nonatomic) uint32_t bottomThreadgroupWidth;
+@property(nonatomic) uint32_t bottomThreadgroupCount;
+@property(nonatomic) NSUInteger bottomScratchBytes;
 @property(nonatomic) uint32_t tailStart;
 @property(nonatomic) uint32_t tailThreadgroupWidth;
 @property(nonatomic) NSUInteger tailScratchBytes;

--- a/src/backends/metal/runtime/lifecycle_and_tree.m
+++ b/src/backends/metal/runtime/lifecycle_and_tree.m
@@ -192,16 +192,18 @@ void *stwo_zig_metal_merkle_commit(
                                     runtime.leaves.threadExecutionWidth * 8u);
         [leaf_encoder dispatchThreads:MTLSizeMake(leaf_count, 1, 1)
                 threadsPerThreadgroup:MTLSizeMake(leaf_width, 1, 1)];
-        [leaf_encoder endEncoding];
 
         if (parent_plan != nil) {
-            uint64_t parent_encoders = 0u, parent_dispatches = 0u;
-            if (!encode_merkle_parent_chain_prepared(runtime, hash_arena, parent_plan, command,
-                                                      &parent_encoders, &parent_dispatches)) {
+            [leaf_encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+            uint64_t parent_dispatches = 0u;
+            if (!encode_merkle_parent_chain_on_encoder(runtime, hash_arena, parent_plan,
+                                                        leaf_encoder, &parent_dispatches)) {
+                [leaf_encoder endEncoding];
                 write_error(error_message, error_message_len, @"Metal Merkle parent-chain encoding failed");
                 return NULL;
             }
         }
+        [leaf_encoder endEncoding];
         if (!runtime.device.hasUnifiedMemory) {
             id<MTLBlitCommandEncoder> root_copy = [command blitCommandEncoder];
             if (root_copy == nil) {

--- a/src/backends/metal/runtime/merkle_epochs.m
+++ b/src/backends/metal/runtime/merkle_epochs.m
@@ -433,6 +433,37 @@ static uint32_t merkle_parent_tail_start(
     return level_count;
 }
 
+static uint32_t merkle_floor_power_of_two(uint32_t value) {
+    if (value == 0u) return 0u;
+    return 1u << (31u - (uint32_t)__builtin_clz(value));
+}
+
+static uint32_t merkle_parent_bottom_level_count(
+    const uint32_t *children, const uint32_t *destinations, const uint32_t *counts,
+    uint32_t level_count, uint32_t width, uint32_t tail_capacity
+) {
+    if (width < 2u || counts[0] <= tail_capacity || counts[0] % width != 0u) return 0u;
+    uint32_t bottom_levels = 1u;
+    for (uint32_t count = width; count > 1u; count >>= 1u) bottom_levels += 1u;
+    if (level_count < bottom_levels) return 0u;
+
+    uint64_t initial_child_start = children[0];
+    uint64_t initial_child_words = (uint64_t)counts[0] * 16u;
+    for (uint32_t level = 0u; level < bottom_levels; ++level) {
+        uint32_t expected_count = counts[0] >> level;
+        if (counts[level] != expected_count ||
+            (level > 0u && children[level] != destinations[level - 1u])) return 0u;
+        uint64_t destination_words = (uint64_t)counts[level] * 8u;
+        if (merkle_ranges_overlap(destinations[level], destination_words,
+                                  initial_child_start, initial_child_words)) return 0u;
+        for (uint32_t prior = 0u; prior < level; ++prior) {
+            if (merkle_ranges_overlap(destinations[level], destination_words,
+                                      destinations[prior], (uint64_t)counts[prior] * 8u)) return 0u;
+        }
+    }
+    return bottom_levels;
+}
+
 void *stwo_zig_metal_merkle_parent_chain_prepare(
     void *runtime_ptr, const uint32_t *child_offsets, const uint32_t *destination_offsets,
     const uint32_t *parent_counts, uint32_t level_count, const uint32_t *node_seed,
@@ -459,8 +490,18 @@ void *stwo_zig_metal_merkle_parent_chain_prepare(
         NSUInteger capacity = MIN((NSUInteger)256u,
             MIN(runtime.parentTailSparse.maxTotalThreadsPerThreadgroup,
                 available_bytes / (8u * sizeof(uint32_t))));
-        plan.tailStart = merkle_parent_tail_start(child_offsets, destination_offsets,
-                                                  parent_counts, level_count, (uint32_t)capacity);
+        uint32_t bottom_width = merkle_floor_power_of_two((uint32_t)MIN((NSUInteger)128u, capacity));
+        plan.bottomLevelCount = merkle_parent_bottom_level_count(
+            child_offsets, destination_offsets, parent_counts, level_count,
+            bottom_width, (uint32_t)capacity);
+        if (plan.bottomLevelCount > 0u) {
+            plan.bottomThreadgroupWidth = bottom_width;
+            plan.bottomThreadgroupCount = parent_counts[0] / bottom_width;
+            plan.bottomScratchBytes = (NSUInteger)bottom_width * 8u * sizeof(uint32_t);
+        }
+        uint32_t tail_start = merkle_parent_tail_start(child_offsets, destination_offsets,
+                                                       parent_counts, level_count, (uint32_t)capacity);
+        plan.tailStart = MAX(tail_start, plan.bottomLevelCount);
         if (plan.tailStart < level_count) {
             plan.tailThreadgroupWidth = parent_counts[plan.tailStart];
             plan.tailScratchBytes = (NSUInteger)plan.tailThreadgroupWidth * 8u * sizeof(uint32_t);
@@ -473,11 +514,11 @@ void stwo_zig_metal_merkle_parent_chain_destroy(void *plan_ptr) {
     if (plan_ptr != NULL) CFRelease(plan_ptr);
 }
 
-static bool encode_merkle_parent_chain_prepared(
+static bool encode_merkle_parent_chain_on_encoder(
     StwoZigMetalRuntime *runtime, id<MTLBuffer> arena, StwoZigMerkleParentChain *plan,
-    id<MTLCommandBuffer> command, uint64_t *compute_encoders, uint64_t *dispatches
+    id<MTLComputeCommandEncoder> encoder, uint64_t *dispatches
 ) {
-    if (runtime == nil || arena == nil || plan == nil || command == nil) return false;
+    if (runtime == nil || arena == nil || plan == nil || encoder == nil) return false;
     const uint32_t *children = plan.childOffsets.bytes, *destinations = plan.destinationOffsets.bytes, *counts = plan.parentCounts.bytes;
     uint64_t arena_words = arena.length / sizeof(uint32_t);
     for (uint32_t level = 0u; level < plan.levelCount; ++level) {
@@ -487,22 +528,41 @@ static bool encode_merkle_parent_chain_prepared(
     }
     NSUInteger width = MIN((NSUInteger)256u, runtime.parentsSparse.maxTotalThreadsPerThreadgroup);
     uint32_t prefix_bytes = plan.prefixBytes;
-    for (uint32_t level = 0; level < plan.tailStart; ++level) {
+    if (plan.bottomLevelCount > 32u) return false;
+    uint64_t encoded_dispatches = 0u;
+    if (plan.bottomLevelCount > 0u) {
+        uint32_t local_counts[32];
+        for (uint32_t level = 0u; level < plan.bottomLevelCount; ++level)
+            local_counts[level] = plan.bottomThreadgroupWidth >> level;
+        uint32_t bottom_levels = plan.bottomLevelCount;
+        [encoder setComputePipelineState:runtime.parentTailSparse];
+        [encoder setBuffer:arena offset:0 atIndex:0];
+        [encoder setBytes:children length:(NSUInteger)bottom_levels * sizeof(uint32_t) atIndex:1];
+        [encoder setBytes:destinations length:(NSUInteger)bottom_levels * sizeof(uint32_t) atIndex:2];
+        [encoder setBytes:local_counts length:(NSUInteger)bottom_levels * sizeof(uint32_t) atIndex:3];
+        [encoder setBytes:&bottom_levels length:sizeof(bottom_levels) atIndex:4];
+        [encoder setBuffer:plan.nodeSeed offset:0 atIndex:5];
+        [encoder setBytes:&prefix_bytes length:sizeof(prefix_bytes) atIndex:6];
+        [encoder setThreadgroupMemoryLength:plan.bottomScratchBytes atIndex:0];
+        [encoder dispatchThreadgroups:MTLSizeMake(plan.bottomThreadgroupCount, 1u, 1u)
+                 threadsPerThreadgroup:MTLSizeMake(plan.bottomThreadgroupWidth, 1u, 1u)];
+        encoded_dispatches += 1u;
+        if (plan.bottomLevelCount < plan.levelCount)
+            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+    }
+    for (uint32_t level = plan.bottomLevelCount; level < plan.tailStart; ++level) {
         uint32_t child = children[level], destination = destinations[level], count = counts[level];
-        id<MTLComputeCommandEncoder> encoder = [command computeCommandEncoder];
-        if (encoder == nil) return false;
         [encoder setComputePipelineState:runtime.parentsSparse]; [encoder setBuffer:arena offset:0 atIndex:0];
         [encoder setBytes:&child length:sizeof(child) atIndex:1]; [encoder setBytes:&destination length:sizeof(destination) atIndex:2];
         [encoder setBytes:&count length:sizeof(count) atIndex:3]; [encoder setBuffer:plan.nodeSeed offset:0 atIndex:4];
         [encoder setBytes:&prefix_bytes length:sizeof(prefix_bytes) atIndex:5];
         [encoder dispatchThreads:MTLSizeMake(count, 1u, 1u) threadsPerThreadgroup:MTLSizeMake(width, 1u, 1u)];
-        [encoder endEncoding];
-        *compute_encoders += 1u; *dispatches += 1u;
+        encoded_dispatches += 1u;
+        if (level + 1u < plan.tailStart || plan.tailStart < plan.levelCount)
+            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
     }
     if (plan.tailStart < plan.levelCount) {
         uint32_t tail_levels = plan.levelCount - plan.tailStart;
-        id<MTLComputeCommandEncoder> encoder = [command computeCommandEncoder];
-        if (encoder == nil) return false;
         [encoder setComputePipelineState:runtime.parentTailSparse];
         [encoder setBuffer:arena offset:0 atIndex:0];
         [encoder setBytes:children + plan.tailStart length:(NSUInteger)tail_levels * sizeof(uint32_t) atIndex:1];
@@ -514,9 +574,23 @@ static bool encode_merkle_parent_chain_prepared(
         [encoder setThreadgroupMemoryLength:plan.tailScratchBytes atIndex:0];
         [encoder dispatchThreadgroups:MTLSizeMake(1u, 1u, 1u)
                  threadsPerThreadgroup:MTLSizeMake(plan.tailThreadgroupWidth, 1u, 1u)];
-        [encoder endEncoding];
-        *compute_encoders += 1u; *dispatches += 1u;
+        encoded_dispatches += 1u;
     }
+    *dispatches += encoded_dispatches;
+    return true;
+}
+
+static bool encode_merkle_parent_chain_prepared(
+    StwoZigMetalRuntime *runtime, id<MTLBuffer> arena, StwoZigMerkleParentChain *plan,
+    id<MTLCommandBuffer> command, uint64_t *compute_encoders, uint64_t *dispatches
+) {
+    if (command == nil) return false;
+    id<MTLComputeCommandEncoder> encoder = [command computeCommandEncoder];
+    if (encoder == nil) return false;
+    bool encoded = encode_merkle_parent_chain_on_encoder(runtime, arena, plan, encoder, dispatches);
+    [encoder endEncoding];
+    if (!encoded) return false;
+    *compute_encoders += 1u;
     return true;
 }
 

--- a/src/backends/metal/tests/command_epoch.zig
+++ b/src/backends/metal/tests/command_epoch.zig
@@ -462,35 +462,47 @@ test "metal: fused parent tail retains its plan and materializes every layer" {
     try std.testing.expectEqualSlices(u8, &root, std.mem.sliceAsBytes(words[root_offset .. root_offset + 8]));
 }
 
-test "metal: parent tail capacity preserves a per-level prefix" {
+test "metal: generic parent chain reduces independent bottom subtrees in one grid" {
+    const allocator = std.testing.allocator;
     var runtime = try runtime_mod.Runtime.init();
     defer runtime.deinit();
-    var arena = try runtime.allocateResidentBuffer(64 * 1024);
-    defer arena.deinit();
-    const words: [*]u32 = @ptrCast(@alignCast(arena.contents));
-    var children: [1024]Hasher.Hash = undefined;
-    for (&children, 0..) |*hash, child| {
+    const leaf_count = 2048;
+    const level_count = 11;
+    const children = try allocator.alloc(Hasher.Hash, leaf_count);
+    defer allocator.free(children);
+    for (children, 0..) |*hash, child| {
         for (hash, 0..) |*byte, index| byte.* = @intCast((child * 29 + index * 17 + 5) & 0xff);
     }
-    @memcpy(std.mem.sliceAsBytes(words[0 .. children.len * 8]), std.mem.sliceAsBytes(&children));
+    var expected: [level_count][]Hasher.Hash = undefined;
+    var expected_level_count: usize = 0;
+    defer for (expected[0..expected_level_count]) |level| allocator.free(level);
+    var previous: []const Hasher.Hash = children;
+    for (&expected) |*level| {
+        level.* = try allocator.alloc(Hasher.Hash, previous.len / 2);
+        expected_level_count += 1;
+        for (level.*, 0..) |*hash, index|
+            hash.* = Hasher.hashChildrenWithSeed(Hasher.nodeSeed(), .{ .left = previous[index * 2], .right = previous[index * 2 + 1] });
+        previous = level.*;
+    }
 
-    var level0: [512]Hasher.Hash = undefined;
-    for (&level0, 0..) |*hash, index|
-        hash.* = Hasher.hashChildrenWithSeed(Hasher.nodeSeed(), .{ .left = children[index * 2], .right = children[index * 2 + 1] });
-    var level1: [256]Hasher.Hash = undefined;
-    for (&level1, 0..) |*hash, index|
-        hash.* = Hasher.hashChildrenWithSeed(Hasher.nodeSeed(), .{ .left = level0[index * 2], .right = level0[index * 2 + 1] });
-    var level2: [128]Hasher.Hash = undefined;
-    for (&level2, 0..) |*hash, index|
-        hash.* = Hasher.hashChildrenWithSeed(Hasher.nodeSeed(), .{ .left = level1[index * 2], .right = level1[index * 2 + 1] });
-
-    const level0_offset: u32 = 8192;
-    const level1_offset: u32 = 12288;
-    const level2_offset: u32 = 14336;
+    var child_offsets: [level_count]u32 = undefined;
+    var destination_offsets: [level_count]u32 = undefined;
+    var parent_counts: [level_count]u32 = undefined;
+    var cursor: u32 = leaf_count * 8;
+    for (0..level_count) |level| {
+        child_offsets[level] = if (level == 0) 0 else destination_offsets[level - 1];
+        destination_offsets[level] = cursor;
+        parent_counts[level] = @intCast(expected[level].len);
+        cursor += parent_counts[level] * 8;
+    }
+    var arena = try runtime.allocateResidentBuffer(@as(usize, cursor) * @sizeOf(u32));
+    defer arena.deinit();
+    const words: [*]u32 = @ptrCast(@alignCast(arena.contents));
+    @memcpy(std.mem.sliceAsBytes(words[0 .. children.len * 8]), std.mem.sliceAsBytes(children));
     var plan = try runtime.prepareMerkleParentChain(
-        &.{ 0, level0_offset, level1_offset },
-        &.{ level0_offset, level1_offset, level2_offset },
-        &.{ 512, 256, 128 },
+        &child_offsets,
+        &destination_offsets,
+        &parent_counts,
         Hasher.nodeSeed(),
         Hasher.domainPrefixBytes(),
     );
@@ -501,11 +513,43 @@ test "metal: parent tail capacity preserves a per-level prefix" {
     try epoch.submit();
     const stats = try epoch.wait();
 
-    try std.testing.expectEqual(@as(u64, 2), stats.compute_encoders);
+    try std.testing.expectEqual(@as(u64, 1), stats.compute_encoders);
     try std.testing.expectEqual(@as(u64, 2), stats.dispatches);
-    try std.testing.expectEqualSlices(u8, std.mem.sliceAsBytes(&level0), std.mem.sliceAsBytes(words[level0_offset .. level0_offset + level0.len * 8]));
-    try std.testing.expectEqualSlices(u8, std.mem.sliceAsBytes(&level1), std.mem.sliceAsBytes(words[level1_offset .. level1_offset + level1.len * 8]));
-    try std.testing.expectEqualSlices(u8, std.mem.sliceAsBytes(&level2), std.mem.sliceAsBytes(words[level2_offset .. level2_offset + level2.len * 8]));
+    for (expected, destination_offsets) |level, offset|
+        try std.testing.expectEqualSlices(u8, std.mem.sliceAsBytes(level), std.mem.sliceAsBytes(words[offset .. offset + level.len * 8]));
+
+    // Reuse the leaf range as one half of a ping-pong chain.  The global
+    // dispatch barriers make this legal, but one multi-threadgroup grid
+    // would race a destination writer against another group's initial read.
+    // Preparation must therefore retain the conservative per-level schedule.
+    const alternate_offset: u32 = leaf_count * 8;
+    var aliased_children: [level_count]u32 = undefined;
+    var aliased_destinations: [level_count]u32 = undefined;
+    for (0..level_count) |level| {
+        aliased_children[level] = if (level == 0) 0 else aliased_destinations[level - 1];
+        aliased_destinations[level] = if (level & 1 == 0) alternate_offset else 0;
+    }
+    var aliased_plan = try runtime.prepareMerkleParentChain(
+        &aliased_children,
+        &aliased_destinations,
+        &parent_counts,
+        Hasher.nodeSeed(),
+        Hasher.domainPrefixBytes(),
+    );
+    defer aliased_plan.deinit();
+    var aliased_epoch = try runtime.beginCommandEpoch(arena);
+    defer aliased_epoch.deinit();
+    try aliased_epoch.encodeMerkleParentChain(aliased_plan);
+    try aliased_epoch.submit();
+    const aliased_stats = try aliased_epoch.wait();
+    // Nine global levels plus the existing two-level top tail.
+    try std.testing.expectEqual(@as(u64, 1), aliased_stats.compute_encoders);
+    try std.testing.expectEqual(@as(u64, level_count - 1), aliased_stats.dispatches);
+    try std.testing.expectEqualSlices(
+        u8,
+        std.mem.sliceAsBytes(expected[level_count - 1]),
+        std.mem.sliceAsBytes(words[alternate_offset .. alternate_offset + 8]),
+    );
 }
 
 test "metal: parent chain preparation and arena bounds fail closed" {


### PR DESCRIPTION
## Summary

- reduce independent 256-leaf subtrees concurrently with the existing Metal parent-tail kernel
- collapse large generic parent chains from six dispatches to two and keep leaf/parents in one barriered compute encoder
- fail closed for aliased or unsupported arena geometry

## Evidence

- isolated log-14 commitment GPU median: -15.4% (32 columns), -18.4% (4 columns)
- clean three-class Metal geomean: 0.993954 across 90 reports / 630 verified timed proofs
- exact 2,048-leaf all-layer parity plus aliased-layout fallback fixture
- Native Metal lifecycle, validation layers, static/AOT contracts, and source conformance pass
- official CPU S3 control is confirmed-neutral as expected for Metal-only code

Full methodology and caveats are in the packaged submission note and transcript.