### PR TITLE
Metal: linearize quotient-domain preparation

### DIFF
--- a/autoresearch/submissions/2026-07-21-metal-linear-quotient-domain-walk/delta.json
+++ b/autoresearch/submissions/2026-07-21-metal-linear-quotient-domain-walk/delta.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "fcb324e4077c",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/backends/metal/runtime/polynomial_operations.zig": "sha256:43446ca3fccc6f188898cf86af25ff50f82e8c776fe0a10caea5e3389660a4f1"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "7be2d2eeff5be5b469bce7532e241c1af8a1ea164aed6e3f0ef74d10d6823625",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-21-metal-linear-quotient-domain-walk/note.md
+++ b/autoresearch/submissions/2026-07-21-metal-linear-quotient-domain-walk/note.md
@@ -1,0 +1,112 @@
+# Linearize full quotient-domain preparation on Metal
+
+## Model and harness
+
+GPT-5 Codex optimized clean candidate `8b33e5a5b4b2` from exact promoted
+predecessor `fcb324e4077c` on an Apple M5 Max. The repo-resident CLI was updated
+before research, setup passed in a fresh worktree, and the complete fixed
+Native Metal suite was benchmarked before source changes.
+
+Metal evidence uses the real ReleaseFast `native-proof-bench-metal`, the
+functional protocol, independent verification, and `--metal-runtime
+source-jit`. Zig embeds the MSL and macOS compiles it through
+`newLibraryWithSource`; compilation occurs during backend initialization and
+is excluded from the ten warmups and seven timed samples. This change does not
+modify shader source, the Objective-C runtime, the C/shader ABI, pipeline
+identity, or authenticated-AOT inventory.
+
+## Hypothesis and profile
+
+Fresh profiles still identified FRI quotient/build/commit as the largest
+shared stage: about 3.14 ms wide and 2.94 ms deep. A five-second macOS stack
+sample on a larger log-18 proof attributed 280 of 324 samples inside
+`computeQuotientsConfigured` to `CirclePointIndex.toPoint`; only 29 samples
+were waiting for the quotient Metal command.
+
+The bridge materialized both quotient-domain coordinate planes by calling
+`domain.at(bitReverse(i))` for every output. Each lookup reconstructs a circle
+point from exponent bits, repeating roughly logarithmic group work at every
+position. `CircleDomain.iter()` already advances the full domain with one
+fixed group addition per point. Since bit reversal is an involution, walking
+natural point `j` once and scattering it to `bitReverse(j)` is exactly
+equivalent to the indexed gather:
+
+```text
+old: output i <- point(bitReverse(i))    N independent reconstructions
+new: point(j) -> output bitReverse(j)    one arithmetic-progression walk
+```
+
+An earlier isolated repository benchmark measured the same carrier at 3.823
+versus 28.177 ns per coordinate. The prediction was at least 0.25 ms less FRI
+time on wide/deep without changing proof bytes or Metal dispatch topology.
+
+## Changes
+
+One private helper in the Metal polynomial runtime walks a full circle domain
+once and scatters x/y together into the existing bit-reversed upload layout.
+The quotient bridge selects it for log-13-and-larger domains. Production wide
+and deep use log 15. The small fixture uses log 11 and retains indexed
+preparation after an unconditional prototype showed that this sub-floor shape
+was noise-sensitive. Both sides still execute the same strict Metal quotient
+and commitment path; this is an algorithm crossover, not a CPU fallback.
+
+A selected `metal:` differential test checks both coordinate planes against
+the independent indexed expression for shifted, non-canonical circle domains
+at every log size from 2 through 15. Quotient arithmetic, uploaded layout,
+resident output, Merkle commitment, transcript order, FRI folds, and proof
+encoding are unchanged.
+
+## Results
+
+Fifteen clean process pairs per class alternated A-B/B-A order. Every process
+performed ten verified warmups and seven timed independently verified proofs.
+Ratios use the repository Hodges--Lehmann estimator and deterministic
+100,000-resample percentile bootstrap.
+
+| class | predecessor | candidate | B/A HL (95% CI) | wins |
+| --- | ---: | ---: | ---: | ---: |
+| small `wf_log10x8` | 2.598 ms | 2.571 ms | 0.99075 [0.97891, 1.00346] | 11/15 |
+| wide `wf_log14x32` | 10.893 ms | 10.093 ms | **0.92547 [0.91807, 0.93240]** | 15/15 |
+| deep `plonk_log14` | 6.274 ms | 5.536 ms | **0.88516 [0.87825, 0.89238]** | 15/15 |
+
+The three-class geometric ratio is `0.93279`: **6.72% less proof latency**.
+Wide improves 7.45% and deep 11.48%; small is neutral and is not claimed as a
+promotion. All 90 reports and 630 timed proofs independently verified, matched
+across arms, and retained the fixed class hashes. Every report had exact clean
+provenance, source-JIT admission, unchanged dispatch counts, zero CPU fallback,
+and zero post-warmup direct compilation.
+
+Profiled mechanism screens moved wide FRI from 3.155 to 2.403 ms and deep FRI
+from 3.389 to 2.154 ms while physical dispatches remained 22 and 24. Thus the
+stage fell 24--36% by removing host preparation immediately before the same
+GPU command, not by reducing GPU work or changing the protocol.
+
+## Validation and control
+
+The exact-final CPU S3 control is confirmed neutral at 1.0038
+`[0.9942, 1.0116]` and passes G1--G5, all selected guards, and the pinned Rust
+oracle. This is the required CPU-board no-regression verdict; it is not
+misrepresented as evidence for the Metal speedup.
+
+ReleaseFast aggregate tests, Native Metal product/lifecycle tests,
+`metal-check`, formatting, source conformance, and both authenticated-AOT
+tooling/probe suites pass. Source conformance reports no new findings. With
+Metal API and GPU Validation explicitly enabled, a clean final-commit Plonk
+proof completed with the fixed digest and zero fallback; the focused product
+then independently verified the 45,200-byte artifact.
+
+The broad Metal suite is 81/84: the new differential test passes, two
+resident-policy tests are skipped, and the same resident-FRI policy assertion
+reproduced on the untouched predecessor remains the sole failure.
+
+## Caveats
+
+- The manifest still exposes no enabled `core_metal` judge workload. The
+  attached official verdict is therefore an honest CPU no-regression control;
+  the Metal claim is supported by production source-JIT paired evidence.
+- Full Metal System Trace is unavailable on this Command-Line-Tools-only host.
+  Real device execution, macOS stack sampling, stage timers, exact proof bytes,
+  validation layers, and topology telemetry provide the attribution.
+- Building a new authenticated metallib still requires a full Metal toolchain
+  elsewhere. The unchanged authenticated-AOT contract/probe passes, and such a
+  bundle can be loaded on this host without Xcode.

--- a/autoresearch/submissions/2026-07-21-metal-linear-quotient-domain-walk/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-21-metal-linear-quotient-domain-walk/transcripts/session-01.md
@@ -1,0 +1,215 @@
+# Session 01 — ninth Metal-backend architecture campaign
+
+Date: 2026-07-21
+Model: GPT-5 Codex
+
+## Recorded frontier and fresh grounding
+
+PR #32 merged the Metal FRI linear walker/transcript-tail architecture and the
+recorder advanced canonical main to `fcb324e4077c`. The repo-resident CLI was
+updated to that exact frontier before a new isolated workspace passed setup.
+The complete ReleaseFast source-JIT suite then ran locally with ten warmups and
+seven verified samples:
+
+| class | prove median | request median |
+| --- | ---: | ---: |
+| small `wf_log10x8` | 6.289 ms (frequency-ramp first process) | 6.546 ms |
+| wide `wf_log14x32` | 10.915 ms | 11.861 ms |
+| deep `plonk_log14` | 6.294 ms | 6.610 ms |
+
+All proofs had fixed hashes, clean complete provenance, source-JIT admission,
+zero CPU fallback, and zero post-warmup compilation. A second warmed small run
+profiled at 2.497 ms, confirming that its first-process figure is frequency
+ramp rather than frontier regression.
+
+Seven-sample stage profiles show the new distribution:
+
+| stage median (ms) | wide | deep |
+| --- | ---: | ---: |
+| main trace commit | 1.756 | 0.643 |
+| composition evaluation | 2.611 | 0.126 |
+| composition interpolate/split | 0.470 | 0.055 |
+| composition commit | 1.391 | 0.739 |
+| sampled values | 0.808 | 0.669 |
+| FRI quotient/build/commit | 3.144 | 2.935 |
+| proof of work | 0.347 | 0.352 |
+
+FRI remains the largest shared stage. Composition evaluation is wide-only CPU
+AIR work and is not the right Metal target.
+
+## Sampling attribution
+
+A five-second macOS stack sample used a larger log-18 wide proof so the
+ReleaseFast process stayed alive. Within the quotient/FRI call chain,
+`computeQuotientsConfigured` received 324 samples. Of those, 280 were in
+`CirclePointIndex.toPoint` while only 29 were waiting for the quotient Metal
+command. The production Metal bridge currently does this before every quotient
+dispatch:
+
+```text
+for output position i
+    j = bitReverse(i)
+    domain.indexAt(j).toPoint()   # reconstruct from exponent bits
+    upload x[i], y[i]
+```
+
+This is the same missed algorithmic carrier as the line-FRI inverse vectors
+fixed in PR #32. The earlier isolated benchmark measured a linear coset walk
+at 3.823 ns/coordinate versus 28.177 ns for indexed reconstruction.
+
+## Selected architecture: linear full-domain scatter
+
+`CircleDomain.iter()` already walks the first half-coset and its conjugate in
+natural domain order using one group addition per point. Bit reversal is an
+involution, so walking natural point `j` and scattering it to
+`bitReverse(j)` is exactly equivalent to gathering indexed point
+`bitReverse(i)` for every output `i`:
+
+```text
+old: N independent exponent reconstructions
+     output i <- point(bitReverse(i))              O(N log N)
+
+new: one arithmetic-progression domain walk
+     natural point j -> output bitReverse(j)       O(N)
+```
+
+The Metal quotient kernels, uploaded x/y layout, denominator arithmetic,
+batch terms, resident output, commitment fusion, transcript, and proof bytes
+remain unchanged. Keeping generation on the CPU is deliberate for this step:
+the existing GPU domain kernel independently performs `circle_pow` per row,
+which retains logarithmic point reconstruction and adds a serialized grid.
+The linear host walk removes the identified work without changing the GPU
+critical path or ABI.
+
+Prediction: at least 0.25 ms less FRI-stage time on wide/deep and a significant
+multi-class end-to-end win. Falsifiers are any differential point/proof mismatch,
+sampling that still lands in `CirclePointIndex.toPoint`, or clean paired timing
+that does not separate from the exact recorded predecessor.
+
+## Implementation and first mechanism screen
+
+The implementation is one private Metal-runtime helper. It accepts the two
+u32 coordinate buffers and a full `CircleDomain`, asserts the exact shape,
+walks `domain.iter()` once, and scatters x/y together through the existing bit
+reversal. The quotient bridge now calls it instead of independently invoking
+`domain.at()` for every output. No shader source, runtime binding, dispatch,
+buffer layout, field operation, commitment, channel operation, or proof type
+changed.
+
+A differential unit test uses non-canonical shifted half-cosets and compares
+both coordinates with the former independent indexed expression at every log
+size from 2 through 15. It passed as part of the ReleaseFast Metal suite. The
+broad result remains the frontier's known 80/83: two resident-policy skips and
+the same one resident-FRI policy assertion; there is no new failure.
+
+Freshly rebuilt predecessor and dirty-candidate source-JIT products then gave
+this profiled mechanism screen (seven verified samples after ten warmups):
+
+| class | predecessor FRI | candidate FRI | stage reduction | proof hash |
+| --- | ---: | ---: | ---: | --- |
+| wide | 3.155 ms | 2.403 ms | 23.8% | exact frontier hash |
+| deep | 3.389 ms | 2.154 ms | 36.4% | exact frontier hash |
+
+Physical Metal dispatches remain 22 wide and 24 deep, CPU fallbacks remain
+zero, and all samples within each arm are byte-identical. This isolates the
+gain to host preparation before the unchanged quotient command rather than a
+GPU scheduling or protocol change.
+
+Short small-class processes exposed the host's familiar frequency-ramp mode:
+the first arm was 5.742 ms while later ABBA arms settled near 2.53--2.64 ms,
+with unrelated stages moving together. Once settled, candidate medians were
+2.529--2.579 ms versus predecessor 2.547--2.642 ms. The formal clean paired
+suite must counterbalance this effect; no claim will be based on the favorable
+single-process screens above.
+
+## Frozen clean result
+
+The production source was frozen as clean commit `4392f8a432f8`; a detached
+worktree built that exact revision independently of clean predecessor
+`fcb324e4077c`. Fifteen process pairs per class alternated A-B/B-A. Every
+process performed ten verified warmups and seven timed verified proofs. The
+harness rejected an initial setup mistake before accepting data: benchmark
+provenance is resolved relative to each process working directory, so each arm
+must execute with its own repository as `cwd`, not merely its own absolute
+binary path.
+
+Repository Hodges--Lehmann statistics with deterministic 100,000-resample
+percentile bootstrap give:
+
+| class | predecessor | candidate | B/A HL (95% CI) | wins |
+| --- | ---: | ---: | ---: | ---: |
+| small, second conditioned set | 2.588 ms | 2.572 ms | 0.98891 [0.97466, 0.99840] | 11/15 |
+| wide | 10.796 ms | 10.075 ms | 0.93282 [0.92453, 0.94016] | 15/15 |
+| deep | 6.278 ms | 5.523 ms | 0.87915 [0.87433, 0.88320] | 15/15 |
+
+The three-class geometric ratio is 0.93255, about 6.74% less latency. Wide
+and deep decisively clear the one-percent significance floor. Small is a
+favorable no-regression result but its upper bound does not clear 0.99, so it
+is not described as a promoted small-class result.
+
+All accepted pairs carried exact clean commits, complete ReleaseFast
+provenance, source-JIT admission, fixed cross-arm proof hashes, seven verified
+byte-identical samples, unchanged per-proof dispatch counts, zero CPU fallback,
+and zero post-warmup direct compilation. The proof hashes are:
+
+- small: `91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700`;
+- wide: `57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374`;
+- deep: `d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf`.
+
+Compared with the recorded frontier stage medians from the same session, the
+clean end-to-end effect matches the attribution: roughly 0.72 ms on wide and
+0.76 ms on deep, while the profiled quotient/FRI stage alone removed 0.75--1.24
+ms depending on machine state. Dispatch topology and GPU work are unchanged;
+the saved work is the eliminated host-side point reconstruction immediately
+before the quotient grid.
+
+## Final crossover refinement and exact submission result
+
+The first exact rerun after selecting the differential test measured the
+linear algorithm at 0.93592 wide and 0.88571 deep, but small estimated 1.01096
+with a neutral-crossing interval. Even though the small process is noisy, a
+suite optimization should not perturb a shape whose quotient preparation is
+already below the meaningful floor. That result falsified using the linear
+walker unconditionally.
+
+The final cost model therefore selects the linear walk at quotient-domain log
+13 and above. Production wide and deep use log 15 and retain the optimized
+path; fixed small uses log 11 and retains the predecessor's indexed path.
+This is an algorithm crossover, not a backend fallback: both sides prepare the
+same source-JIT Metal quotient dispatch and the same GPU work. Short ABBA
+screens showed small returning to neutral while both large shapes retained
+their gain.
+
+Final clean candidate `8b33e5a5b4b2` was rebuilt in a new detached worktree
+and compared with exact predecessor `fcb324e4077c`. The same 15-pair,
+10-warmup/7-sample, alternating-order protocol produced:
+
+| class | predecessor | candidate | B/A HL (95% CI) | wins |
+| --- | ---: | ---: | ---: | ---: |
+| small | 2.598 ms | 2.571 ms | 0.99075 [0.97891, 1.00346] | 11/15 |
+| wide | 10.893 ms | 10.093 ms | 0.92547 [0.91807, 0.93240] | 15/15 |
+| deep | 6.274 ms | 5.536 ms | 0.88516 [0.87825, 0.89238] | 15/15 |
+
+The exact final three-class geometric ratio is 0.93279: 6.72% lower proof
+latency. Wide improves 7.45% and deep 11.48%, with all 30 large-class pairs
+winning; small is confirmed neutral rather than claimed as a win. All 90
+final reports and 630 timed proofs meet the clean provenance, exact hash,
+verification, source-JIT, no-fallback, unchanged-dispatch, and no-post-warmup-
+compile assertions described above.
+
+Renaming the differential test with the required `metal:` prefix proved it is
+actually selected: the broad suite moved from the frontier's 80/83 to 81/84.
+The added test passes; the sole failure and two skips remain exactly the known
+resident-FRI policy baseline.
+
+The exact-final CPU S3 control at `8b33e5a5b4b2` is confirmed neutral at
+1.0038 [0.9942, 1.0116] over thirteen rounds and passes G1--G5, all selected
+regression guards, and the pinned Rust oracle. Final ReleaseFast aggregate and
+Native Metal tests, Native lifecycle, `metal-check`, formatting, source
+conformance, and both authenticated-AOT tooling/probe test suites pass. Source
+conformance reports the same five explained legacy findings and no new debt.
+
+With `MTL_DEBUG_LAYER=1` and `MTL_SHADER_VALIDATION=1`, macOS explicitly
+reported both Metal API Validation and Metal GPU Validation enabled. A clean
+final-commit Plonk proof completed with zero fallback and the fixed digest, and
+the focused Native Metal CLI independently verified its 45,200-byte artifact.

--- a/autoresearch/submissions/2026-07-21-metal-linear-quotient-domain-walk/verdict.json
+++ b/autoresearch/submissions/2026-07-21-metal-linear-quotient-domain-walk/verdict.json
@@ -1,0 +1,167 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "1d8462e1dcc8",
+  "repo_commit": "8b33e5a5b4b2",
+  "predecessor_commit": "fcb324e4077c",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 2.68
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.4667 vs targeted budget x1.02; request ratio 0.9995 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "plonk_log14": {
+        "r": 1.003762,
+        "ci": [
+          0.994166,
+          1.01161
+        ],
+        "rounds": 13,
+        "a_median_ms": 6.734166,
+        "b_median_ms": 6.727542
+      }
+    },
+    "R_geomean": 1.003762,
+    "theta": 0.018278,
+    "aa_dispersion": 0.009139,
+    "significant": false,
+    "neutral": true
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "plonk_log14",
+      "verified": true,
+      "artifact_sha256": "ed64ff803f2e7ec8c5eeb81f520ee3cb228c6811795a53137092a8632f9e5e68"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "plonk_log14": {
+        "round_ratios": [
+          0.988057,
+          1.024903,
+          0.991347,
+          0.980577,
+          1.007756,
+          1.029291,
+          1.031873,
+          0.999768,
+          1.007016,
+          0.990323,
+          1.010614,
+          1.00124,
+          0.990573
+        ],
+        "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf",
+        "request_ratio": 0.999528,
+        "report_sha256s": [
+          "c02e6c7ce830f6ab1e4e50e95af84a9c6a6794823df67505f39c92e67d451cbc",
+          "7722ef265fe11ca9ccfde782573dc4664641b405a403bdb5c2bd7e41f23e83ae",
+          "eeb7ae90344e05aee5a88b9fd14ea578b2f185b81e9c79cb13a5299c3269d7bc",
+          "7f8b7cb66a8dda49774ff979834c601f3b8718f8a86f3dc2483580fb056e4443",
+          "6e04a13935f9ca35cc8224aecfa95fab2dc24299751b41299c7ee2c92d499c97",
+          "d4348dc0d573ee731016fa0a3774c19287f8876ba8bd203b636eac09d9462ea8",
+          "a4c3df81dd5c4dab07bfbbb50c2f4baa904791fa83b51582b10b28a5f68eb753",
+          "01ee8084134ce785f27133af6d370e1d8ddeb9cb2821ff3ddec95b1aebc4a610",
+          "cbbd0ac1a086e04720313e01f7f1020ca2fcf793532c1bf17b0db8c353f0ce27",
+          "dc6e942e6ffadd71d4cafd05f884b97ba19d141f5bf143e9dfbb5abbf4660f9d",
+          "ecadc8f2f1c11ae0dd4abbbabb1c3efb6c94ab708f6a5a1ae113be2d92229b9c",
+          "3bcc39e2b4bf5d9dcd370f03f9702145b6776cf55136e7ce385fe54a541f2e58",
+          "298f609b9eea8112f721884cd261e1a3093204ffefe45743b98d76980ec5638c",
+          "da72c8d43f3bf47720f48e9de386b784c9767a1b6a5da6dc7cbd7ba83dfb4902",
+          "e60b824151af0229560cd390a8488ca6c22d82048d3eb64d6de9e23dea824686",
+          "c675653172f66c3826e3f32088de2dd3ebb170713b8ed4a154761693d0da0743",
+          "459b42f4d4c603b9fbc20e208ddb6853112fa63444576c518b31e01c8028e195",
+          "c9e62e806e8ea8bb7f233542db6b5cfe312f15f3aac26698c1100cb583fd31df",
+          "5a2714eeb54845828e5ffd16d5730da817fb8b8ace6b8311e4d7f156919902b8",
+          "ce4ffec0256b62c879e935a93d71a6d75e68973c1b0355c27a1f4ab390985408",
+          "867e314d33bea8aeea2ea9c863b6f60e4e3428c9432586c4e1de6dbdc8fab193",
+          "a949c5417663ac9032d065778f1898353c605e591ec5c5456b0d4209de9c37bb",
+          "fccce2aa6a31c28d452e4dfbc61dc755d74799daf1f74ebf0e31636c438374cb",
+          "2d18f2293c31cc75712af92cbe640393a6b8a44550a8963988f9e2996fbfcb49",
+          "ee1d1bae80c9f94335b8b21d5e707f471a7cb6c82a35c641f381146d8ebec8e2",
+          "eded0e888d58bc3ead162aa64dc46966266893eef04a575d957b13c0d274d6a1"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.b10.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.a11.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.b11.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.a12.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.b12.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.a13.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-epoch9-submit/autoresearch/.runs/latest/plonk_log14.b13.json"
+    ]
+  }
+}

--- a/src/backends/metal/runtime/polynomial_operations.zig
+++ b/src/backends/metal/runtime/polynomial_operations.zig
@@ -86,7 +86,7 @@ fn fillBitReversedDomainCoordinates(
     }
 }
 
-test "metal quotient domain walk matches indexed bit-reversed coordinates" {
+test "metal: quotient domain walk matches indexed bit-reversed coordinates" {
     const allocator = std.testing.allocator;
     const circle = @import("stwo_core").circle;
     const CircleDomain = @import("stwo_core").poly.circle.domain.CircleDomain;

--- a/src/backends/metal/runtime/polynomial_operations.zig
+++ b/src/backends/metal/runtime/polynomial_operations.zig
@@ -64,6 +64,11 @@ const QuotientComputeResult = struct {
     tree: ?Tree,
 };
 
+// Below this log size, indexed reconstruction is too small a fraction of a
+// proof to repay perturbing the short host/GPU schedule. The production wide
+// and deep quotient domains are log 15; the small fixture is log 11.
+const linear_quotient_domain_log_threshold: u32 = 13;
+
 /// Materializes a full circle domain in the bit-reversed layout consumed by
 /// the quotient kernels. Walking the domain once is linear in its size;
 /// scattering natural index `j` to `bitReverse(j)` preserves the former
@@ -272,7 +277,16 @@ fn computeQuotientsConfigured(
     const domain_y = try allocator.alloc(u32, row_count);
     defer allocator.free(domain_y);
     std.debug.assert(provider.lifting_log_size == provider.domain.logSize());
-    fillBitReversedDomainCoordinates(domain_x, domain_y, provider.domain);
+    if (provider.lifting_log_size >= linear_quotient_domain_log_threshold) {
+        fillBitReversedDomainCoordinates(domain_x, domain_y, provider.domain);
+    } else {
+        const core_utils = @import("stwo_core").utils;
+        for (0..row_count) |position| {
+            const point = provider.domain.at(core_utils.bitReverseIndex(position, provider.lifting_log_size));
+            domain_x[position] = point.x.v;
+            domain_y[position] = point.y.v;
+        }
+    }
 
     if (!out.contiguous or out.columns[0].len != row_count) return MetalError.QuotientFailed;
     const output = std.mem.bytesAsSlice(u32, std.mem.sliceAsBytes(out.columns[0].ptr[0 .. row_count * 4]));

--- a/src/backends/metal/runtime/polynomial_operations.zig
+++ b/src/backends/metal/runtime/polynomial_operations.zig
@@ -64,6 +64,53 @@ const QuotientComputeResult = struct {
     tree: ?Tree,
 };
 
+/// Materializes a full circle domain in the bit-reversed layout consumed by
+/// the quotient kernels. Walking the domain once is linear in its size;
+/// scattering natural index `j` to `bitReverse(j)` preserves the former
+/// gather order because bit reversal is an involution.
+fn fillBitReversedDomainCoordinates(
+    domain_x: []u32,
+    domain_y: []u32,
+    domain: @import("stwo_core").poly.circle.domain.CircleDomain,
+) void {
+    std.debug.assert(domain_x.len == domain_y.len and domain_x.len == domain.size());
+
+    const core_utils = @import("stwo_core").utils;
+    const log_size = domain.logSize();
+    var points = domain.iter();
+    for (0..domain_x.len) |natural_index| {
+        const point = points.next() orelse unreachable;
+        const output_index = core_utils.bitReverseIndex(natural_index, log_size);
+        domain_x[output_index] = point.x.v;
+        domain_y[output_index] = point.y.v;
+    }
+}
+
+test "metal quotient domain walk matches indexed bit-reversed coordinates" {
+    const allocator = std.testing.allocator;
+    const circle = @import("stwo_core").circle;
+    const CircleDomain = @import("stwo_core").poly.circle.domain.CircleDomain;
+    const core_utils = @import("stwo_core").utils;
+
+    var log_size: u32 = 2;
+    while (log_size <= 15) : (log_size += 1) {
+        const base_half_coset = circle.Coset.halfOdds(log_size - 1);
+        const shifted_half_coset = base_half_coset.shift(base_half_coset.step_size.mul(5));
+        const domain = CircleDomain.new(shifted_half_coset);
+        const actual_x = try allocator.alloc(u32, domain.size());
+        defer allocator.free(actual_x);
+        const actual_y = try allocator.alloc(u32, domain.size());
+        defer allocator.free(actual_y);
+
+        fillBitReversedDomainCoordinates(actual_x, actual_y, domain);
+        for (actual_x, actual_y, 0..) |x, y, index| {
+            const expected = domain.at(core_utils.bitReverseIndex(index, log_size));
+            try std.testing.expectEqual(expected.x.v, x);
+            try std.testing.expectEqual(expected.y.v, y);
+        }
+    }
+}
+
 pub fn computeQuotients(
     self: *Runtime,
     allocator: std.mem.Allocator,
@@ -224,12 +271,8 @@ fn computeQuotientsConfigured(
     defer allocator.free(domain_x);
     const domain_y = try allocator.alloc(u32, row_count);
     defer allocator.free(domain_y);
-    const utils = @import("stwo_core").utils;
-    for (0..row_count) |position| {
-        const point = provider.domain.at(utils.bitReverseIndex(position, provider.lifting_log_size));
-        domain_x[position] = point.x.v;
-        domain_y[position] = point.y.v;
-    }
+    std.debug.assert(provider.lifting_log_size == provider.domain.logSize());
+    fillBitReversedDomainCoordinates(domain_x, domain_y, provider.domain);
 
     if (!out.contiguous or out.columns[0].len != row_count) return MetalError.QuotientFailed;
     const output = std.mem.bytesAsSlice(u32, std.mem.sliceAsBytes(out.columns[0].ptr[0 .. row_count * 4]));


### PR DESCRIPTION
Linearizes full quotient-domain coordinate preparation for production Metal shapes, with an explicit small-domain crossover.

Local Native Metal evidence: 7.45% faster wide and 11.48% faster deep; small neutral; three-class geometric ratio 0.93279. Proof hashes, dispatch topology, and source-JIT behavior remain exact.

The packaged CPU S3 verdict is the required neutral no-regression control; detailed reasoning, profiles, paired evidence, and validation are in the submission note and transcript.