### PR TITLE
Metal: keep FRI inverse domains resident

### DIFF
--- a/autoresearch/submissions/2026-07-21-metal-resident-fri-inverse-domains/delta.json
+++ b/autoresearch/submissions/2026-07-21-metal-resident-fri-inverse-domains/delta.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "91d18f7bdd44",
+  "declared_objective": {
+    "board": "core_metal",
+    "workload_class": "wide",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/backends/metal/commit_backend.zig": "sha256:13396cba20ec3fd3a7565ca3766763826db5cb0385df19007b77c03fdbe28114",
+    "src/backends/metal/core_aot.zig": "sha256:34f87d375903ec35a55230926d42db2da29589da8b868bd76121008dd5aab799",
+    "src/backends/metal/kernels.metal": "sha256:10440431eef012d2fc055dbf323c6890ac23313b713651d29b717cd2d51b6e87",
+    "src/backends/metal/runtime.m": "sha256:9d0ab15fecaa4547175482ccce9845b8239c1e5dfa8abe66596c6d58663a3a87",
+    "src/backends/metal/runtime.zig": "sha256:3abf01e95fe63d416994738439f5d3c6fb75cc04622a2489f82c70c5ed29740d",
+    "src/backends/metal/runtime/fri_fold_commit.m": "sha256:3fd3a00a457e06c36e4af7747c4294aa07147d6470bd66a306171403be5cf213",
+    "src/backends/metal/runtime/fri_plans.m": "sha256:f5e7ae83d1c0df5ed72462c6d52217bf75f481409911024dd6a71e196fea99e9",
+    "src/backends/metal/runtime/opening_bindings.zig": "sha256:b8c1c8465b286a403415e58bc4c59545180722ce6747f0679e58885a7299ad71",
+    "src/backends/metal/runtime/opening_operations.zig": "sha256:2110ae6bfb32758098f2108cb63d6bc49f8356361cf2aa8646a6902ff99267cc",
+    "src/backends/metal/runtime/quotients.m": "sha256:59d9a0325385241733aef0fdb7b8d4fb985ba1703ef1da676cf31c3a0db57f70",
+    "src/backends/metal/runtime/runtime_queries.m": "sha256:60524fee4787698f7813752d3a6afe03d124b2a9efb427ea8e8d53a702510866",
+    "src/backends/metal/shaders/manifest.zig": "sha256:029b54797cfc4a1e7f3c21df319cdc4a566a864f90452e6e8018abced494a36b",
+    "src/backends/metal/tests/fri_fold_commit.zig": "sha256:c6d6b5bb8131773a73664681717584a310e56bd90d4e7c90df425a9234642265",
+    "src/prover/fri.zig": "sha256:07f4875d109bfa88066fdb8caf3b7147d253d3e909acd1dbedae58d9d5335f55"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "29dedad7487b5c1fe5d0c6d0891937409d5f52bcf899edcf358117b591dfbb40",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-21-metal-resident-fri-inverse-domains/note.md
+++ b/autoresearch/submissions/2026-07-21-metal-resident-fri-inverse-domains/note.md
@@ -1,0 +1,107 @@
+# Keep FRI inverse domains resident on Metal
+
+## Model and harness
+
+GPT-5 Codex optimized clean candidate `7a28519b5968` from exact current
+predecessor `91d18f7bdd44` on an Apple M5 Max. The repository CLI was updated
+before research, setup passed in a fresh workspace, and the fixed Native Metal
+suite was benchmarked locally before source changes.
+
+Metal evidence uses the real ReleaseFast `native-proof-bench-metal`, functional
+protocol, independent verification, and `--metal-runtime source-jit`. Zig
+embeds the MSL and macOS compiles it through `newLibraryWithSource`; runtime
+initialization is outside the ten warmups and seven measured samples. No full
+Xcode installation or offline `metal` compiler is assumed.
+
+## Hypothesis
+
+After quotient domains became resident, a new log-18 stack sample attributed
+about 60 samples to FRI coset iteration and 11 to batch inversion, versus about
+50 samples waiting for the line cascade. Every proof rebuilt the same
+bit-reversed inverse-y circle domain and the same concatenated inverse-x line
+domains, allocated scratch arrays, and uploaded them to Metal.
+
+These values depend only on fixed domain shape and indices, not witness or
+transcript. Generating them once during excluded warmup and retaining two
+bounded device buffers should eliminate recurring host walks, batch inversions,
+allocations, and uploads without changing the measured GPU schedule or proofs.
+
+## Changes
+
+The existing authenticated `stwo_zig_quotient_domain_points_resident` kernel
+now has three ABI-5 modes: unchanged quotient x/y output, bit-reversed inverse
+x, and bit-reversed inverse y. Existing quotient callers bind mode zero.
+
+`StwoZigMetalRuntime` owns independent one-entry circle and line inverse caches
+with complete `(shape, layers, initial, step)` keys. On a miss, a private
+candidate is generated before its consumer in the same command and published
+under synchronization only after successful completion. Hits bind the retained
+buffer directly. Local strong references protect in-flight commands; concurrent
+misses may duplicate bounded work but cannot observe partial data. The fixed
+shape retains roughly 128 KiB total.
+
+Large Metal FRI paths omit host inverses and initialize generic inverse
+workspaces lazily. Small and standalone paths retain the previous host route.
+CPU backends are compile-time unchanged. The Native export inventory is
+unchanged; core shader ABI advances 4 to 5 so prior AOT bundles fail closed.
+
+## Results
+
+Fifteen clean process pairs per class alternated A-B/B-A. Each process used ten
+verified warmups and seven timed verified proofs. Ratios use the repository
+Hodges--Lehmann estimator and deterministic 100,000-resample bootstrap.
+
+| class | predecessor | candidate | B/A HL (95% CI) | wins |
+| --- | ---: | ---: | ---: | ---: |
+| small `mwf_log10x8` | 2.608750 ms | 2.572584 ms | 0.98593 [0.96763, 1.00156] | 10/15 |
+| wide `mwf_log14x32` | 9.798583 ms | 9.465792 ms | **0.97348 [0.96103, 0.98404]** | 14/15 |
+| deep `mplonk_log14` | 5.301875 ms | 5.006417 ms | **0.94698 [0.94064, 0.95376]** | 15/15 |
+
+The three-class geometric ratio is `0.96866`: **3.13% lower Metal proof
+latency**. Wide improves 2.65% and deep 5.30%; small is neutral and is not
+overclaimed. All 630 measured proofs verified, matched hashes across arms,
+used clean source-JIT provenance, and had zero CPU fallback or post-warmup
+compilation.
+
+The newly enabled official `core_metal` S3 harness independently produced
+significant claimed verdicts on both moved classes:
+
+| official workload | R | 95% CI | rounds | result |
+| --- | ---: | ---: | ---: | --- |
+| `mwf_log14x32` | **0.960611** | **[0.951332, 0.970111]** | 15 | significant |
+| `mplonk_log14` | **0.9437** | **[0.9319, 0.9534]** | 15 | significant |
+
+Matched profiles moved FRI from 2.096 to 1.858 ms wide and 1.908 to 1.617 ms
+deep. A strict runtime-event capture shows exactly one untimed line-cache miss
+with 45 grids; the next twelve cascades retain the established 32 grids. The
+circle fill is likewise warmup-only. A fresh log-18 stack sample contains no
+FRI coset iterator or batch inversion.
+
+## Validation and control
+
+A device differential compares host and shader-generated inverse-y values on
+two shifted cosets, on both cache miss and hit, through the real fold output.
+ReleaseFast aggregate and Native Metal lifecycle tests, `metal-check`, source
+conformance, formatting, and both deterministic authenticated-AOT tool/probe
+suites pass. Fixed hashes remain:
+
+- small: `91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700`
+- wide: `57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374`
+- deep: `d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf`
+
+Both exact-candidate Metal S3 verdicts pass G1--G5, the pinned Rust oracle, all
+twelve impact-mapped guards, and request/RSS budgets. A source-identical
+pre-rebase CPU S3 control was additionally neutral at `1.0033
+[0.9914, 1.0146]`.
+
+## Caveats
+
+- The `core_metal` board was enabled during the final frontier sync. Its local
+  verdicts are still claimed/advisory until the locked judge re-run records
+  them.
+- Full Metal System Trace is unavailable on this Command-Line-Tools-only host.
+  Real device execution, strict encoder counters, stack sampling, exact proofs,
+  and topology telemetry provide the mechanism evidence.
+- Creating a new authenticated metallib still requires a full Metal toolchain
+  elsewhere. ABI-5 AOT tool/probe contracts pass, and such a bundle remains
+  loadable on this Mac without Xcode.

--- a/autoresearch/submissions/2026-07-21-metal-resident-fri-inverse-domains/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-21-metal-resident-fri-inverse-domains/transcripts/session-01.md
@@ -1,0 +1,216 @@
+# Session 01 — device-resident FRI inverse domains
+
+Date: 2026-07-21
+Model: GPT-5 Codex
+
+## Recorded frontier and fresh grounding
+
+PR #34 removed recurring quotient-domain construction with a bounded resident
+Metal buffer, and the autoresearch recorder advanced the exact frontier to
+`c14ef9789118`. A fresh worktree passed setup and rebuilt the real ReleaseFast
+Native Metal product in source-JIT mode. The previous frozen paired result was
+3.00% lower end-to-end geometric mean, with the fixed proof hashes, no fallback,
+and a neutral scalar control.
+
+Fresh strict runtime-event profiles of the current frontier show that the line
+FRI cascade is now the largest shared Metal command. Encoder counters attribute
+37.9% of wide GPU time and 37.5% of deep GPU time to that command; polynomial
+evaluation follows at roughly 26%. Without encoder counters, line-cascade
+medians are approximately 0.865 ms wide and 0.518 ms deep. The cascade has one
+command buffer and wait but still contains 32 physical grids at production
+sizes: one initial coordinate/leaf grid, eighteen bottom/tail Merkle grids, and
+thirteen fold/coordinate/leaf grids.
+
+A separate log-18 macOS stack sample localizes a different recurring cost on
+the host. After the quotient-domain cache removed its iterator, FRI inverse
+preparation still accounts for about 60 `CosetPointIterator.next` samples and
+11 `batchInverseInPlace` samples, compared with roughly 50 samples waiting for
+the line cascade. The circle-to-line fold builds inverse y coordinates; the
+line cascade builds concatenated inverse x coordinates for every layer. Both
+domains and all values are invariant across proofs of a fixed shape.
+
+## Residual dependency graph
+
+```text
+every proof today
+
+circle half-coset walk -> bit-reversed y[] -> batch inverse -> host buffer upload
+                                                               |
+resident FRI column --------------------------------------------+-> circle fold
+                                                                    |
+                                                                    v
+line coset walk #0 -> bit-reversed x[] -> batch inverse -----------+
+line coset walk #1 -> bit-reversed x[] -> batch inverse -----------+-> concatenate
+...                                                                |      |
+line coset walk #L -> bit-reversed x[] -> batch inverse -----------+      v
+                                                               host buffer upload
+                                                                      |
+resident line evaluation --------------------------------------------+-> 32-grid cascade
+
+selected steady state
+
+fixed circle-domain key ---> [resident inverse-y buffer] ------------> circle fold
+fixed line-domain key -----> [resident concatenated inverse-x buffer] -> cascade
+                                  ^
+                                  |
+                         one warmup-only JIT Metal fill
+```
+
+The prior researchers already tested the tempting dispatch-reduction branch:
+folding Merkle microtrees into the FRI producer reduced topology from 68 grids
+to 46, but increased device time from about 2.9 ms to 3.36 ms because the
+register-heavy producer lost occupancy. That measured rejection rules out
+repeating producer fusion here. Later isolated parent tails and transcript-tail
+fusion preserved occupancy and established the current 32-grid schedule.
+
+## Selected architecture
+
+Extend the already authenticated
+`stwo_zig_quotient_domain_points_resident` pipeline with a mode binding:
+
+- mode 0 retains its exact full-circle x/y quotient-domain ABI;
+- mode 1 emits bit-reversed inverse x values for one coset;
+- mode 2 emits bit-reversed inverse y values for one coset.
+
+For inverse modes, output row `r` maps to
+`natural = bit_reverse_logN(r)`. The point exponent is
+`initial_index + step_size * natural (mod 2^31)`, after which the shader writes
+`m31_inv(point.x)` or `m31_inv(point.y)`. This is the GPU equivalent of the
+current linear host walk, bit-reversed scatter, and batch inverse. Differential
+tests over shifted cosets must prove that equivalence; fixed proof bytes are the
+end-to-end oracle.
+
+The Objective-C runtime owns two independent one-entry caches so the circle
+and line phases cannot evict each other:
+
+```text
+circle key = (destination_count, initial_index, step_size)
+circle value = inverse_y[destination_count]
+
+line key = (source_count, layer_count, initial_index, step_size)
+line value = inverse_x[N/2] || inverse_x[N/4] || ... || inverse_x[last+1]
+```
+
+On a miss, a private candidate buffer is filled by one inverse-domain dispatch
+for the circle or one per line layer. The existing fold command consumes that
+same candidate, waits, checks command success, and only then publishes it under
+`@synchronized(runtime)`. On a hit there is no fill grid, host domain walk,
+batch inversion, scratch vector, buffer allocation, or upload. A local strong
+reference protects an in-flight hit from replacement. Concurrent misses may
+compute equivalent private candidates but can never observe partial contents.
+
+Large production domains use the cache; small domains retain the established
+host route because their schedule is too short to amortize cache machinery.
+Generic FRI code initializes inverse workspaces lazily only for a backend that
+declares this capability, while Metal fallback paths continue to call
+`ensureCapacity`. The cache is bounded to about 128 KiB for the fixed scored
+shape and replaces on a shape change.
+
+The embedded MSL remains compiled through macOS
+`newLibraryWithSource:options:error:`. Adding one binding to an existing export
+requires a core shader ABI bump and authenticated-AOT manifest validation, but
+does not require Xcode's offline `metal` tool. Source compilation remains in
+runtime initialization and outside the ten post-warmup samples.
+
+## Prediction and falsifiers
+
+Prediction: cache-hit samples remove the FRI coset iterators and batch inverse
+from host stacks; measured proof topology remains 22/24 because fills occur in
+excluded warmup; FRI and end-to-end medians improve on wide and deep while the
+small class and scalar control remain neutral. The expected fixed-shape gain is
+roughly 0.15--0.40 ms, potentially larger when allocator and upload work are
+included.
+
+Falsifiers are any shifted-coset differential mismatch, proof digest change,
+Metal validation error, cache-key collision across mixed shapes, publication
+before command success, measured cache-fill grids after warmup, residual host
+inverse stacks, material small-shape regression, or paired confidence intervals
+that fail to separate from the exact predecessor. Any such result triggers a
+fix or complete revert rather than a submission.
+
+## Implementation and direct parity
+
+The production patch widens the existing domain-point pipeline rather than
+adding an export. Core shader ABI 4 advances to 5, and every existing quotient
+caller binds mode 0 explicitly. Modes 1 and 2 use the same circle exponent,
+safe M31 multiplication, inversion, and bit reversal compiled by the macOS
+runtime. The authenticated-AOT manifest and probe therefore reject ABI-4
+bundles before use while preserving the exact Native export inventory.
+
+`StwoZigMetalRuntime` owns separate strong circle and line cache buffers and
+their complete keys. Both caches use private storage. A circle miss encodes one
+inverse-y grid in the fold command before its ordinary fold encoder. A line
+miss encodes one inverse-x grid per doubled domain at disjoint offsets in the
+existing cascade encoder, then inserts a buffer memory barrier before the
+32-grid proof dependency chain. Publication happens only after command success
+and transcript validation. Hits bind the retained buffer directly.
+
+The generic FRI prover observes one Metal-only compile-time capability and
+starts inverse workspaces at capacity zero. Metal's small and standalone paths
+still call `ensureCapacity`; large cached paths never allocate those four host
+scratch arrays. CPU backends retain their prior capacities and generated code.
+
+A new device differential uses two shifted, non-canonical cosets. For each it
+compares a host batch-inverted y domain with shader generation on both a cache
+miss and subsequent hit, then compares every output word of the real circle
+fold. The test passes. Complete wide and Plonk proofs independently retain
+their fixed hashes, providing line inverse-x and end-to-end arithmetic parity.
+
+## Mechanism evidence
+
+A strict encoder-counter capture covered ten warmups and three measured wide
+proofs: 104 command buffers, 470 encoders, zero errors, zero untimed encoders,
+zero counter overflows, and only 0.322 ms unattributed GPU time. Exactly one
+line-cascade encoder contained 45 dispatches—the established 32 plus thirteen
+inverse-domain fills. The other twelve line cascades contained exactly 32
+dispatches. The one circle inverse fill and one quotient-domain fill likewise
+occurred in the first untimed warmup. Thus all measured cache hits preserve the
+22/24 high-level proof topology and add no physical work.
+
+The same report still places the line cascade first at 36.6% of GPU command
+time and polynomial evaluation second at 26.2%, so the optimization did not
+hide a device regression behind host savings. A fresh three-second log-18 stack
+sample contains no `CosetPointIterator` or `batchInverseInPlace` under either
+FRI path. Circle and line calls are overwhelmingly in `waitUntilCompleted`, as
+predicted.
+
+Matched stage screens tie the movement to FRI:
+
+| class | predecessor FRI | candidate FRI | reduction |
+| --- | ---: | ---: | ---: |
+| wide | 2.096 ms | 1.858 ms | 11.4% |
+| deep | 1.908 ms | 1.617 ms | 15.3% |
+
+## Frozen exact-final result
+
+During the required final sync, frontier commit `ef33f70` enabled the real
+`core_metal` board. The production tree had not changed, and the source patch
+rebased without conflict. Source was therefore re-frozen as `7a28519b5968`
+against exact current frontier `91d18f7bdd44`, then rebuilt and measured again.
+Fifteen clean process pairs per class alternated A-B/B-A order. Every process
+used its own detached clean checkout, the ReleaseFast Native Metal product,
+source-JIT admission, ten excluded verified warmups, and seven timed verified
+proofs. Repository Hodges--Lehmann statistics with a deterministic 100,000-
+resample percentile bootstrap give:
+
+| class | predecessor | candidate | B/A HL (95% CI) | wins |
+| --- | ---: | ---: | ---: | ---: |
+| small | 2.608750 ms | 2.572584 ms | 0.98593 [0.96763, 1.00156] | 10/15 |
+| wide | 9.798583 ms | 9.465792 ms | 0.97348 [0.96103, 0.98404] | 14/15 |
+| deep | 5.301875 ms | 5.006417 ms | 0.94698 [0.94064, 0.95376] | 15/15 |
+
+The suite geometric ratio is `0.96866`: 3.13% less end-to-end proof latency.
+Small is neutral and is not overclaimed. All 630 timed proofs independently
+verified, were byte-identical within process and across arms, used zero CPU
+fallback, and retained the three fixed proof digests.
+
+The newly enabled official Metal S3 harness independently confirms both moved
+classes with fifteen paired rounds each: wide `0.960611 [0.951332, 0.970111]`
+and deep `0.9437 [0.9319, 0.9534]`. Both clear the 1% promotion threshold and
+pass G1--G5, the pinned Rust oracle, request/RSS budgets, and all twelve
+impact-mapped guards. A source-identical pre-rebase CPU control was also neutral
+at `1.0033 [0.9914, 1.0146]`.
+
+ReleaseFast aggregate tests, Native Metal product/lifecycle tests, Metal
+compile/link, formatting, source conformance, and deterministic core-AOT tool
+and probe tests pass on the rebased candidate.

--- a/autoresearch/submissions/2026-07-21-metal-resident-fri-inverse-domains/verdict-deep.json
+++ b/autoresearch/submissions/2026-07-21-metal-resident-fri-inverse-domains/verdict-deep.json
@@ -1,0 +1,310 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "db6b3dc9fcad",
+  "repo_commit": "7a28519b5968",
+  "predecessor_commit": "91d18f7bdd44",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_metal",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 1.49
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "anchor not frozen; drift budget inactive; regression guards 12/12 within budget; request ratio 0.9512 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "mplonk_log14": {
+        "r": 0.94369,
+        "ci": [
+          0.931932,
+          0.953413
+        ],
+        "rounds": 15,
+        "a_median_ms": 5.256666,
+        "b_median_ms": 4.963375
+      }
+    },
+    "R_geomean": 0.94369,
+    "theta": 0.01,
+    "aa_dispersion": null,
+    "significant": true,
+    "neutral": false
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {
+    "guard_blake_10x10": {
+      "r": 0.998157,
+      "ci": [
+        0.996212,
+        1.003968
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "4153acd6e32a98b9d240730062f7fa35e2e31eca915f01c179337f04d409cbd2"
+    },
+    "guard_blake_12x16": {
+      "r": 0.997797,
+      "ci": [
+        0.97508,
+        1.015797
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "70e516957d2d38ed78214bfda5b0b2bdfe41f1c93439fb68e124bfef096fbc9f"
+    },
+    "guard_plonk_14": {
+      "r": 0.940926,
+      "ci": [
+        0.835296,
+        0.957637
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf"
+    },
+    "guard_plonk_16": {
+      "r": 0.908854,
+      "ci": [
+        0.89379,
+        0.932337
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "cfb36bf17fb3526bf1bdd9401fb885fd91ca46b9982fee1ca5fad33a1d574b72"
+    },
+    "guard_poseidon_10": {
+      "r": 0.944317,
+      "ci": [
+        0.914945,
+        0.980896
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "af33240da8e7947362fdf7e78d306f2e11cb2e3df7e1b6f498a6e86ac3ae7b1b"
+    },
+    "guard_poseidon_13": {
+      "r": 0.969221,
+      "ci": [
+        0.941935,
+        0.989992
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "f196835da5d4a155c6311bafb44335c2863cc028879d69a7ae53b802321200f1"
+    },
+    "guard_sm_14": {
+      "r": 0.949871,
+      "ci": [
+        0.942856,
+        0.958566
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "488fadeeb4e5d76b6fc0a9c10ab258bab6673de8e912ae5de927561650920b37"
+    },
+    "guard_sm_16": {
+      "r": 0.89426,
+      "ci": [
+        0.868431,
+        0.905297
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "88ec35ee88a05ce0a5db4b6cb063f4cf7824ee65284db0908a62a9362879af73"
+    },
+    "guard_wf_14x32": {
+      "r": 0.979131,
+      "ci": [
+        0.971229,
+        1.006053
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374"
+    },
+    "guard_wf_16x64": {
+      "r": 0.982898,
+      "ci": [
+        0.974555,
+        0.987083
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "42086545b7a170c5868afcc390f83d964e06d528e2d1039420fc6bfd7a6aac74"
+    },
+    "guard_xor_14": {
+      "r": 0.928887,
+      "ci": [
+        0.914583,
+        0.95479
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "35bb35714e10888c786a71ccdfe31d2b9b4651c567fac5ba4c9543bc247cad80"
+    },
+    "guard_xor_16": {
+      "r": 0.90782,
+      "ci": [
+        0.898988,
+        0.914743
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "56163b8ea3d877b3b9bf15753b7c0175d4a6ead493640eef8210c59ba7e5215c"
+    }
+  },
+  "rust_oracle": [
+    {
+      "workload": "mplonk_log14",
+      "verified": true,
+      "artifact_sha256": "ed64ff803f2e7ec8c5eeb81f520ee3cb228c6811795a53137092a8632f9e5e68"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "mplonk_log14": {
+        "round_ratios": [
+          0.627511,
+          0.974302,
+          0.94587,
+          0.92859,
+          0.9201,
+          0.955312,
+          0.974027,
+          0.940011,
+          0.959108,
+          0.954365,
+          0.942612,
+          0.925005,
+          0.94705,
+          0.95246,
+          0.930956
+        ],
+        "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf",
+        "request_ratio": 0.951241,
+        "report_sha256s": [
+          "a6d505834ddd90e44ecc714b727e9d54cf9519aa05ba12b579bd7ebed728c585",
+          "effb2501fb94ec03752fd73e6cb1435434ad7793b6f1f6b24e6e3f68bd3e95ba",
+          "c152f544fb260ca169f8cf03d2a8551476ac0cc7a0a29759f67919dfc6d2ec01",
+          "69d82af12624484dd579b14a5949734ba9686ffa759c7eb99ca0666aa5126d50",
+          "ab258de732e2e8a5006b75bc889bc911ec368bd287dff3e59cf7c97584c2150b",
+          "e23c48f8706bee6abfdf02bef54ee1420ab329b20bfd6d879b8613b2bc064b26",
+          "ad4dda1aaa4b5f15748243b9f1fea9e9246b256d7b07e8422bd197a53165b4c6",
+          "918a361363e3cda9f49d8cc608abe2777a57967f9bdd20f38e160d359f4203f0",
+          "5ab0032e53688b4e05986253e26cb8a62f21832ddf5970d8dfac369f90a2d0c3",
+          "90acfc6766bd92fa578660f726692a366c58946f8c30754ed09a6951f75acd95",
+          "0b6b807f06e76213a9f1af0fe17e2566d5a82f8863d630f37624d973b43bb721",
+          "5cdaaf99a92391908b958bad7a5a82340811cac9ac483c8691e9025ae88bddd9",
+          "4281381c5dac14507b52337774527477c0e90de8050943b729585b34c3c32b58",
+          "51297b819d3c291f43b0d6a1d58491c05761beec8ded9c374386975935b910b0",
+          "874f6d8bd8632846e2129459c040fd6a47d778742195422f79e92d6bd4d6acb4",
+          "26a6d00832f9d107cd9c60660ecc52ac3764865df056c190b7c1ca037f8c7243",
+          "026792e36c1d85ad488bb25255fefad08d40d0b5669ce25d2d3b2e8e3024e1ce",
+          "3f76874784601cc01e772879c732690626707869c4acfbf44961f124b8472ef5",
+          "76d3c13d7d2882a70665cda2cb22152ff46024d65fa53ebfa4731bdb44bed23a",
+          "092859b4ae3a0deb76a0aecc012e58371909e2290fb13be7b10676b0efdb60fc",
+          "7c373d2d7442cc862775d195707fac2afe9d4da59ff410322cb1ff40b5786d69",
+          "b17ba11164c1ea9f1d193eee1fd7ded41111e20252559fe5780063ca0136e213",
+          "4a09a05ec908edbb1e1edace802a8323b3c56efc05dbb9c5bb07a3faef2fd1e2",
+          "bb9f793cdbff61dd39555f0dbf2c82c27a2362dd63267fa20b5debe3ca36dc1f",
+          "fa77523a64179965e7dd6b890cd6fb5e5def7d2d5a715f91cb21a7d5624d0fdd",
+          "2814672d53b71a3c507a72f76c87be85a3194ed4b3a733e79c0a127ddf0a0b88",
+          "53df516f4fab5753be551f40b0adfd0e6d9250885c7be437e430b4a3e1cd415e",
+          "2e7d36dddcc26fafbd0d189c414e94bd49950b40e9c3ed2126efb2aba5370618",
+          "749d5ee4863680b7e86b327f8f66b2fe0bc2e2ee57b9975240dffec2fb9a77fa",
+          "c57e87f0e6668a2f1c982551309d0ee09f54730ee864965ccdfb8a3a2d867e9e"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.b10.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.a11.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.b11.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.a12.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.b12.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.a13.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.b13.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.a14.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.b14.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.a15.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mplonk_log14.b15.json"
+    ]
+  }
+}

--- a/autoresearch/submissions/2026-07-21-metal-resident-fri-inverse-domains/verdict.json
+++ b/autoresearch/submissions/2026-07-21-metal-resident-fri-inverse-domains/verdict.json
@@ -1,0 +1,310 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "db6b3dc9fcad",
+  "repo_commit": "7a28519b5968",
+  "predecessor_commit": "91d18f7bdd44",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_metal",
+    "workload_class": "wide",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 1.86
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "anchor not frozen; drift budget inactive; regression guards 12/12 within budget; request ratio 0.9655 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "mwf_log14x32": {
+        "r": 0.960611,
+        "ci": [
+          0.951332,
+          0.970111
+        ],
+        "rounds": 15,
+        "a_median_ms": 9.773583,
+        "b_median_ms": 9.459542
+      }
+    },
+    "R_geomean": 0.960611,
+    "theta": 0.01,
+    "aa_dispersion": null,
+    "significant": true,
+    "neutral": false
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {
+    "guard_blake_10x10": {
+      "r": 1.020737,
+      "ci": [
+        1.009729,
+        1.035983
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "4153acd6e32a98b9d240730062f7fa35e2e31eca915f01c179337f04d409cbd2"
+    },
+    "guard_blake_12x16": {
+      "r": 0.988459,
+      "ci": [
+        0.956971,
+        1.032086
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "70e516957d2d38ed78214bfda5b0b2bdfe41f1c93439fb68e124bfef096fbc9f"
+    },
+    "guard_plonk_14": {
+      "r": 0.939769,
+      "ci": [
+        0.922284,
+        0.9535
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf"
+    },
+    "guard_plonk_16": {
+      "r": 0.91337,
+      "ci": [
+        0.90902,
+        0.919689
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "cfb36bf17fb3526bf1bdd9401fb885fd91ca46b9982fee1ca5fad33a1d574b72"
+    },
+    "guard_poseidon_10": {
+      "r": 0.924016,
+      "ci": [
+        0.910199,
+        0.947201
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "af33240da8e7947362fdf7e78d306f2e11cb2e3df7e1b6f498a6e86ac3ae7b1b"
+    },
+    "guard_poseidon_13": {
+      "r": 1.023779,
+      "ci": [
+        1.013195,
+        1.042231
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "f196835da5d4a155c6311bafb44335c2863cc028879d69a7ae53b802321200f1"
+    },
+    "guard_sm_14": {
+      "r": 0.94222,
+      "ci": [
+        0.92106,
+        0.956805
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "488fadeeb4e5d76b6fc0a9c10ab258bab6673de8e912ae5de927561650920b37"
+    },
+    "guard_sm_16": {
+      "r": 0.901003,
+      "ci": [
+        0.888194,
+        0.916582
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "88ec35ee88a05ce0a5db4b6cb063f4cf7824ee65284db0908a62a9362879af73"
+    },
+    "guard_wf_14x32": {
+      "r": 0.964642,
+      "ci": [
+        0.940217,
+        0.990097
+      ],
+      "rounds": 6,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374"
+    },
+    "guard_wf_16x64": {
+      "r": 1.00511,
+      "ci": [
+        0.997046,
+        1.008266
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "42086545b7a170c5868afcc390f83d964e06d528e2d1039420fc6bfd7a6aac74"
+    },
+    "guard_xor_14": {
+      "r": 0.930925,
+      "ci": [
+        0.917955,
+        0.945154
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "35bb35714e10888c786a71ccdfe31d2b9b4651c567fac5ba4c9543bc247cad80"
+    },
+    "guard_xor_16": {
+      "r": 0.9007,
+      "ci": [
+        0.891726,
+        0.905317
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "56163b8ea3d877b3b9bf15753b7c0175d4a6ead493640eef8210c59ba7e5215c"
+    }
+  },
+  "rust_oracle": [
+    {
+      "workload": "mwf_log14x32",
+      "verified": true,
+      "artifact_sha256": "d32393fe3b1f9abbc4795d87c3b3316e06111f014ec30f0635f13ec0ff0587f9"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "mwf_log14x32": {
+        "round_ratios": [
+          0.96409,
+          0.951332,
+          0.982145,
+          0.97696,
+          0.955361,
+          0.931381,
+          0.960404,
+          0.972808,
+          0.98889,
+          0.942288,
+          0.96775,
+          0.953935,
+          0.955756,
+          0.970304,
+          0.928831
+        ],
+        "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374",
+        "request_ratio": 0.965548,
+        "report_sha256s": [
+          "fab22a9543e9be3d2d0dedc53e9e80469129a765fe4d4816058a6a784534a13b",
+          "c57c2e44fc923f5d6d1f611a980037860fed9803c4219fe4cc3ee25487e0afd3",
+          "5a5749e7aebdedcce003c7977f3e6c017b910d0601922859372d1744c732eec9",
+          "8f2522d274b53dd2423b4ce1cd772eadc520c5abc5883e5307ac7c95853b9d40",
+          "99ba46fec2fb55b77d230f935b9fd1609421b16b5c418b7edde522d5716b143d",
+          "2fef40893f3acd643671d874f3f62a9e0a36d07e782f5a30e58662ac02966b1e",
+          "0606b0f3d3baa5881e9b7688c3017eeeb1fc6976e6b298174faa0ccd3cef5756",
+          "844f0017ae59d05313977da875c0e347f3a9f2bee1c7cb5ed0cc5a5cfb15559d",
+          "8fe525bd7b9d9b21c12a0db26ab54815a95a53cd563c86d7bb4b44ed05995747",
+          "22e83af230225f8c4e7c240d59e82750a74119ac6dd11edc559f0332d99f6be6",
+          "6a31f263a0f288553fcca550b58cb5631d81863bdb3daaa6819ff62bfdc88d21",
+          "ea49fb8d7fd754ee3d61b5b770d6093f54de77f19970dc42f07385ad35271017",
+          "757324a70f1dc25dd51858f8492dfa5579291b6ea10342c537cbb0b7e765f57c",
+          "1f57335993ef67a93d92c0c57c3e8ebb3e6af22cd7f7eeb76acabffb480830f8",
+          "817dae07e387cc71bfa814500cd77c923688e0f1516d6be4a94aed6e9eeb3cb2",
+          "8a9f6986479741ae19403aa1615bf5066a5d022766fd4925278bf281294ef41f",
+          "d0afaee64457fedcf6e0238c972063d2f284e687abcfde86d67c726cb6379fec",
+          "4d7a6f2af40d68f68cc7bff61a0c7d37e3e6a028f5db22f02e58173ea64b398a",
+          "8265bc98a93543fb4a6f70ae9ca92e6ee4decfce19e9327c18371721cb7ce48f",
+          "a0b54842a3c109c42d594a62b93aa83d713163f0d028809e4c97c951079eba48",
+          "d562d4d17e052ee4d8c46405ddaee40266b6b1ccbd52eb6c36146e112833b81b",
+          "d04a367e615ee0e5c1efa7491282b7abf7d169823ea6d998685a62871fec4b55",
+          "c934bb7596597f2f0a375bbb09e7328edfc79c8b9997ab5ac178ef14c7ec318b",
+          "d466a026828cbc42cc7cafdf9b214a9878b4a20cbcd5acb488fa02a8552de6dc",
+          "3930baeb1b0c581daef0a0d6ecb6a912d49d462c098b5235dedc6baf5213f847",
+          "33e2106c3480d3e0cf7f0fd99bbdbfd229554fe45378243fc4c05e5bd4e2e8ef",
+          "9e640353d5c866c2592ef4dc8c0fbfe7088b049b71d3a8ae54d4a1f41a129132",
+          "357f5330f45ce697c7f7a3ac9a7fcd37c32eac5416aed2e4d285d24683a38477",
+          "32639dd3c68793a11069de774cf23767206e369846ab18de48a52fb6c9bc5315",
+          "9c166dbccd2d066f4835ecbe2cd18e0b66356229d3ce005d6447e7917a68a690"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.b10.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.a11.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.b11.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.a12.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.b12.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.a13.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.b13.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.a14.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.b14.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.a15.json",
+      "/Users/theodorepender/code/auto-researching/ws-metal-e11-candidate/autoresearch/.runs/latest/mwf_log14x32.b15.json"
+    ]
+  }
+}

--- a/src/backends/metal/commit_backend.zig
+++ b/src/backends/metal/commit_backend.zig
@@ -7,7 +7,7 @@ const shared_runtime = @import("shared_runtime.zig");
 const telemetry = @import("telemetry.zig");
 
 const FoldCoordinate = enum { x, y };
-
+const fri_inverse_cache_min_values: usize = 1 << 13;
 /// Builds the inverse-coordinate vector for a Metal FRI fold with one linear
 /// coset walk. Scattering natural point j to bitReverse(j) is equivalent to
 /// the former per-output indexed reconstruction because bit reversal is an
@@ -77,6 +77,7 @@ pub const MetalCommitBackend = struct {
     /// Materialize the prepared LDE columns once so Metal can consume the
     /// complete tree in a single command buffer.
     pub const preferMonolithicCommit = true;
+    pub const lazyFriFoldInverseWorkspace = true;
 
     pub fn warmup() !void {
         var lease = try shared_runtime.acquire();
@@ -443,21 +444,28 @@ pub const MetalCommitBackend = struct {
         alpha: @import("stwo_core").fields.qm31.QM31,
         workspace: *@import("stwo_core").fri.FoldCircleWorkspace,
     ) !void {
-        try workspace.ensureCapacity(allocator, dst.len);
-        const py = workspace.py_values[0..dst.len];
-        const inverse_y = workspace.inv_py_values[0..dst.len];
-        try prepareBitReversedFoldInverses(py, inverse_y, src_domain.half_coset, .y);
+        const use_resident_inverse = dst.len >= fri_inverse_cache_min_values;
+        var inverse_words: ?[]const u32 = null;
+        if (!use_resident_inverse) {
+            try workspace.ensureCapacity(allocator, dst.len);
+            const py = workspace.py_values[0..dst.len];
+            const inverse_y = workspace.inv_py_values[0..dst.len];
+            try prepareBitReversedFoldInverses(py, inverse_y, src_domain.half_coset, .y);
+            inverse_words = std.mem.bytesAsSlice(u32, std.mem.sliceAsBytes(inverse_y));
+        }
         const alpha_coords = alpha.toM31Array();
         const alpha_words = [4]u32{ alpha_coords[0].v, alpha_coords[1].v, alpha_coords[2].v, alpha_coords[3].v };
         const source_words = std.mem.bytesAsSlice(u32, std.mem.sliceAsBytes(src_columns[0].ptr[0 .. src_columns[0].len * 4]));
         const destination_words = std.mem.bytesAsSlice(u32, std.mem.sliceAsBytes(dst));
-        const inverse_words = std.mem.bytesAsSlice(u32, std.mem.sliceAsBytes(inverse_y));
+        const fold_coset = src_domain.half_coset;
         var lease = try shared_runtime.acquire();
         defer lease.deinit();
         const gpu_ms = try lease.runtime.foldFriCircle(
             source_words.ptr,
             @intCast(src_columns[0].len),
             inverse_words,
+            @intCast(fold_coset.initial_index.v),
+            @intCast(fold_coset.step_size.v),
             alpha_words,
             destination_words.ptr,
         );
@@ -649,20 +657,23 @@ pub const MetalCommitBackend = struct {
         }
         const layer_count: usize = std.math.log2_int(usize, evaluation.len() / last_layer_size);
         if (layer_count == 0 or layer_count >= 31) return null;
-
         const inverse_count = evaluation.len() - last_layer_size;
-        const inverse_values = try allocator.alloc(M31, inverse_count);
-        defer allocator.free(inverse_values);
+        const use_resident_inverse = evaluation.len() >= fri_inverse_cache_min_values;
+        var inverse_values: ?[]M31 = null;
+        if (!use_resident_inverse) inverse_values = try allocator.alloc(M31, inverse_count);
+        defer if (inverse_values) |values| allocator.free(values);
         var current_domain = evaluation.domain();
         var current_count = evaluation.len();
         var inverse_cursor: usize = 0;
         for (0..layer_count) |_| {
             const destination_count = current_count >> 1;
-            try workspace.ensureCapacity(allocator, destination_count);
-            const x = workspace.x_values[0..destination_count];
-            const inverse_x = workspace.inv_x_values[0..destination_count];
-            try prepareBitReversedFoldInverses(x, inverse_x, current_domain.coset(), .x);
-            @memcpy(inverse_values[inverse_cursor .. inverse_cursor + destination_count], inverse_x);
+            if (inverse_values) |values| {
+                try workspace.ensureCapacity(allocator, destination_count);
+                const x = workspace.x_values[0..destination_count];
+                const inverse_x = workspace.inv_x_values[0..destination_count];
+                try prepareBitReversedFoldInverses(x, inverse_x, current_domain.coset(), .x);
+                @memcpy(values[inverse_cursor .. inverse_cursor + destination_count], inverse_x);
+            }
             inverse_cursor += destination_count;
             current_count = destination_count;
             current_domain = current_domain.double();
@@ -699,7 +710,11 @@ pub const MetalCommitBackend = struct {
             );
         }
         channel_state[8] = channel.n_draws;
-        const inverse_words = std.mem.bytesAsSlice(u32, std.mem.sliceAsBytes(inverse_values));
+        const inverse_words: ?[]const u32 = if (inverse_values) |values|
+            std.mem.bytesAsSlice(u32, std.mem.sliceAsBytes(values))
+        else
+            null;
+        const initial_coset = evaluation.domain().coset();
 
         var lease = try shared_runtime.acquire();
         defer lease.deinit();
@@ -708,6 +723,8 @@ pub const MetalCommitBackend = struct {
             source_storage.handle,
             @intCast(evaluation.len()),
             inverse_words,
+            @intCast(initial_coset.initial_index.v),
+            @intCast(initial_coset.step_size.v),
             coordinate_handles,
             terminal_storage.handle,
             H.leafSeed(),

--- a/src/backends/metal/core_aot.zig
+++ b/src/backends/metal/core_aot.zig
@@ -455,7 +455,7 @@ test "Native AOT admission rejects authority drift" {
     );
 
     @memcpy(candidate, valid);
-    try replaceManifestOnce(temporary.dir, candidate, "\"core_shader_abi\": 4", "\"core_shader_abi\": 5");
+    try replaceManifestOnce(temporary.dir, candidate, "\"core_shader_abi\": 5", "\"core_shader_abi\": 6");
     try std.testing.expectError(
         error.CoreShaderAbiMismatch,
         admit(std.testing.allocator, bundle_path, manifestDigest(candidate)),

--- a/src/backends/metal/kernels.metal
+++ b/src/backends/metal/kernels.metal
@@ -530,9 +530,18 @@ kernel void stwo_zig_quotient_domain_points_resident(
     constant uint &log_size [[buffer(3)]],
     constant uint &initial_index [[buffer(4)]],
     constant uint &step_size [[buffer(5)]],
+    constant uint &mode [[buffer(6)]],
     uint row [[thread_position_in_grid]]
 ) {
     if (row >= row_count) return;
+    if (mode != 0u) {
+        uint natural = reverse_bits(row) >> (32u - log_size);
+        ulong global = (ulong)initial_index + (ulong)step_size * natural;
+        CircleM31Value point = circle_pow((uint)(global & 0x7ffffffful));
+        uint coordinate = mode == 1u ? point.x : point.y;
+        arena[destination_offset + row] = m31_inv(coordinate);
+        return;
+    }
     CircleM31Value point = quotient_domain_point(initial_index, step_size, row, row_count, log_size);
     arena[destination_offset + row] = point.x;
     arena[destination_offset + row_count + row] = point.y;

--- a/src/backends/metal/runtime.m
+++ b/src/backends/metal/runtime.m
@@ -44,6 +44,15 @@
 @property(nonatomic) uint32_t quotientDomainCacheLogSize;
 @property(nonatomic) uint32_t quotientDomainCacheInitialIndex;
 @property(nonatomic) uint32_t quotientDomainCacheStepSize;
+@property(nonatomic, strong) id<MTLBuffer> friCircleInverseCache;
+@property(nonatomic) uint32_t friCircleInverseCacheCount;
+@property(nonatomic) uint32_t friCircleInverseCacheInitialIndex;
+@property(nonatomic) uint32_t friCircleInverseCacheStepSize;
+@property(nonatomic, strong) id<MTLBuffer> friLineInverseCache;
+@property(nonatomic) uint32_t friLineInverseCacheSourceCount;
+@property(nonatomic) uint32_t friLineInverseCacheLayerCount;
+@property(nonatomic) uint32_t friLineInverseCacheInitialIndex;
+@property(nonatomic) uint32_t friLineInverseCacheStepSize;
 @property(nonatomic, strong) id<MTLComputePipelineState> quotientDenominatorsResident;
 @property(nonatomic, strong) id<MTLComputePipelineState> quotientCombineResident;
 @property(nonatomic, strong) id<MTLComputePipelineState> quotientCoefficientsResident;
@@ -692,6 +701,29 @@ static void bind_fri_line_kernel(
     [encoder setBuffer:leaf_seed offset:0u atIndex:7];
     [encoder setBytes:&prefix_bytes length:sizeof(prefix_bytes) atIndex:8];
     [encoder setBytes:&prepare_next length:sizeof(prepare_next) atIndex:9];
+}
+
+static void encode_fri_inverse_domain(
+    StwoZigMetalRuntime *runtime, id<MTLComputeCommandEncoder> encoder,
+    id<MTLBuffer> destination, NSUInteger destination_offset,
+    uint32_t value_count, uint32_t initial_index, uint32_t step_size,
+    uint32_t mode
+) {
+    uint32_t log_size = 0u;
+    for (uint32_t count = value_count; count > 1u; count >>= 1u) log_size += 1u;
+    uint32_t destination_words = (uint32_t)(destination_offset / sizeof(uint32_t));
+    [encoder setComputePipelineState:runtime.quotientDomainPointsResident];
+    [encoder setBuffer:destination offset:0u atIndex:0];
+    [encoder setBytes:&destination_words length:sizeof(destination_words) atIndex:1];
+    [encoder setBytes:&value_count length:sizeof(value_count) atIndex:2];
+    [encoder setBytes:&log_size length:sizeof(log_size) atIndex:3];
+    [encoder setBytes:&initial_index length:sizeof(initial_index) atIndex:4];
+    [encoder setBytes:&step_size length:sizeof(step_size) atIndex:5];
+    [encoder setBytes:&mode length:sizeof(mode) atIndex:6];
+    NSUInteger width = MIN(runtime.quotientDomainPointsResident.maxTotalThreadsPerThreadgroup,
+                           runtime.quotientDomainPointsResident.threadExecutionWidth * 8u);
+    [encoder dispatchThreads:MTLSizeMake(value_count, 1u, 1u)
+         threadsPerThreadgroup:MTLSizeMake(width, 1u, 1u)];
 }
 
 #import "runtime/initialization.m"

--- a/src/backends/metal/runtime.zig
+++ b/src/backends/metal/runtime.zig
@@ -8,7 +8,7 @@ const command_epoch = @import("command_epoch.zig");
 const shader_manifest = @import("shaders/manifest.zig");
 
 comptime {
-    if (shader_manifest.core_shader_abi != 4) @compileError("Metal core shader ABI drift");
+    if (shader_manifest.core_shader_abi != 5) @compileError("Metal core shader ABI drift");
 }
 
 pub const CommandEpoch = command_epoch.CommandEpoch;

--- a/src/backends/metal/runtime/fri_fold_commit.m
+++ b/src/backends/metal/runtime/fri_fold_commit.m
@@ -216,6 +216,7 @@ void *stwo_zig_metal_fri_fold_line_and_commit(
 bool stwo_zig_metal_fri_line_cascade(
     void *runtime_ptr, void *source_ptr, uint32_t source_count,
     const uint32_t *inverse_x, uint32_t inverse_x_count,
+    uint32_t domain_initial_index, uint32_t domain_step_size,
     void *const *coordinate_ptrs, void *final_destination_ptr,
     uint32_t fri_layer_count,
     const uint32_t *leaf_seed, const uint32_t *node_seed,
@@ -223,7 +224,7 @@ bool stwo_zig_metal_fri_line_cascade(
     void **tree_outputs, StwoZigCommandEpochStats *stats,
     char *error_message, size_t error_message_len
 ) {
-    if (runtime_ptr == NULL || source_ptr == NULL || inverse_x == NULL ||
+    if (runtime_ptr == NULL || source_ptr == NULL ||
         coordinate_ptrs == NULL || final_destination_ptr == NULL ||
         leaf_seed == NULL || node_seed == NULL || channel_state == NULL ||
         tree_outputs == NULL || stats == NULL || source_count < 2u ||
@@ -256,9 +257,29 @@ bool stwo_zig_metal_fri_line_cascade(
             return false;
         }
 
-        id<MTLBuffer> inverse_buffer = [runtime.device newBufferWithBytes:inverse_x
-            length:(NSUInteger)inverse_x_count * sizeof(uint32_t)
-            options:MTLResourceStorageModeShared];
+        id<MTLBuffer> inverse_buffer = nil;
+        bool build_inverse_cache = false;
+        if (inverse_x == NULL) {
+            @synchronized(runtime) {
+                if (runtime.friLineInverseCache != nil &&
+                    runtime.friLineInverseCacheSourceCount == source_count &&
+                    runtime.friLineInverseCacheLayerCount == fri_layer_count &&
+                    runtime.friLineInverseCacheInitialIndex == domain_initial_index &&
+                    runtime.friLineInverseCacheStepSize == domain_step_size) {
+                    inverse_buffer = runtime.friLineInverseCache;
+                }
+            }
+            if (inverse_buffer == nil) {
+                inverse_buffer = [runtime.device newBufferWithLength:
+                    (NSUInteger)inverse_x_count * sizeof(uint32_t)
+                    options:MTLResourceStorageModePrivate];
+                build_inverse_cache = true;
+            }
+        } else {
+            inverse_buffer = [runtime.device newBufferWithBytes:inverse_x
+                length:(NSUInteger)inverse_x_count * sizeof(uint32_t)
+                options:MTLResourceStorageModeShared];
+        }
         const uint32_t transcript_state_base = 0u;
         const uint32_t transcript_root_base = 16u;
         const uint32_t transcript_alpha_base = transcript_root_base + fri_layer_count * 8u;
@@ -371,6 +392,27 @@ bool stwo_zig_metal_fri_line_cascade(
             return false;
         }
         const uint32_t disabled_transcript_config[3] = {0u, 0u, 0u};
+        uint64_t compute_encoders = 1u, dispatches = 0u;
+
+        if (build_inverse_cache) {
+            uint32_t domain_count = source_count;
+            uint32_t current_initial = domain_initial_index;
+            uint32_t current_step = domain_step_size;
+            NSUInteger domain_offset = 0u;
+            for (uint32_t stage = 0u; stage < fri_layer_count; ++stage) {
+                uint32_t value_count = domain_count >> 1u;
+                encode_fri_inverse_domain(
+                    runtime, encoder, inverse_buffer, domain_offset, value_count,
+                    current_initial, current_step, 1u
+                );
+                dispatches += 1u;
+                domain_offset += (NSUInteger)value_count * sizeof(uint32_t);
+                domain_count = value_count;
+                current_initial = (current_initial << 1u) & 0x7fffffffu;
+                current_step = (current_step << 1u) & 0x7fffffffu;
+            }
+            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+        }
 
         id<MTLBuffer> initial_coordinates = (__bridge id<MTLBuffer>)coordinate_ptrs[0];
         StwoZigMetalTree *initial_tree = trees[0];
@@ -390,11 +432,11 @@ bool stwo_zig_metal_fri_line_cascade(
         [encoder dispatchThreads:MTLSizeMake(source_count, 1u, 1u)
              threadsPerThreadgroup:MTLSizeMake(initial_width, 1u, 1u)];
         [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+        dispatches += 1u;
 
         id<MTLBuffer> evaluation = initial_source;
         count = source_count;
         NSUInteger inverse_offset = 0u;
-        uint64_t compute_encoders = 1u, dispatches = 1u;
         NSUInteger tail_static_bytes = runtime.parentTailSparse.staticThreadgroupMemoryLength;
         NSUInteger tail_available_bytes = runtime.device.maxThreadgroupMemoryLength > tail_static_bytes
             ? runtime.device.maxThreadgroupMemoryLength - tail_static_bytes : 0u;
@@ -588,6 +630,15 @@ bool stwo_zig_metal_fri_line_cascade(
             return false;
         }
         memcpy(channel_state, completed_state, 10u * sizeof(uint32_t));
+        if (build_inverse_cache) {
+            @synchronized(runtime) {
+                runtime.friLineInverseCache = inverse_buffer;
+                runtime.friLineInverseCacheSourceCount = source_count;
+                runtime.friLineInverseCacheLayerCount = fri_layer_count;
+                runtime.friLineInverseCacheInitialIndex = domain_initial_index;
+                runtime.friLineInverseCacheStepSize = domain_step_size;
+            }
+        }
 
         double gpu_milliseconds = (command.GPUEndTime - command.GPUStartTime) * 1000.0;
         *stats = (StwoZigCommandEpochStats){

--- a/src/backends/metal/runtime/fri_plans.m
+++ b/src/backends/metal/runtime/fri_plans.m
@@ -200,6 +200,7 @@ bool stwo_zig_metal_quotient_combine_prepared(
         [domain setBytes:&output length:sizeof(output) atIndex:1]; [domain setBytes:&rows length:sizeof(rows) atIndex:2];
         [domain setBytes:&log_size length:sizeof(log_size) atIndex:3]; [domain setBytes:&initial length:sizeof(initial) atIndex:4];
         [domain setBytes:&step length:sizeof(step) atIndex:5];
+        uint32_t domain_mode = 0u; [domain setBytes:&domain_mode length:sizeof(domain_mode) atIndex:6];
         NSUInteger domain_width = MIN(runtime.quotientDomainPointsResident.maxTotalThreadsPerThreadgroup, runtime.quotientDomainPointsResident.threadExecutionWidth * 8u);
         [domain dispatchThreads:MTLSizeMake(rows, 1u, 1u) threadsPerThreadgroup:MTLSizeMake(domain_width, 1u, 1u)];
         [domain endEncoding];

--- a/src/backends/metal/runtime/opening_bindings.zig
+++ b/src/backends/metal/runtime/opening_bindings.zig
@@ -14,7 +14,9 @@ pub extern fn stwo_zig_metal_fri_fold_circle(
     runtime: *anyopaque,
     source: [*]const u32,
     source_count: u32,
-    inverse_y: [*]const u32,
+    inverse_y: ?[*]const u32,
+    domain_initial_index: u32,
+    domain_step_size: u32,
     alpha: *const [4]u32,
     destination: [*]u32,
     gpu_milliseconds: *f64,
@@ -53,8 +55,10 @@ pub extern fn stwo_zig_metal_fri_line_cascade(
     runtime: *anyopaque,
     source: *anyopaque,
     source_count: u32,
-    inverse_x: [*]const u32,
+    inverse_x: ?[*]const u32,
     inverse_x_count: u32,
+    domain_initial_index: u32,
+    domain_step_size: u32,
     coordinates: [*]const *anyopaque,
     final_destination: *anyopaque,
     layer_count: u32,
@@ -431,8 +435,8 @@ test "opening bindings retain canonical shared ABI parameter types" {
     try std.testing.expect(fold_commit.return_type.? == ?*anyopaque);
 
     const cascade = @typeInfo(@TypeOf(stwo_zig_metal_fri_line_cascade)).@"fn";
-    try std.testing.expectEqual(@as(usize, 16), cascade.params.len);
-    try std.testing.expect(cascade.params[13].type.? == *CommandEpochStats);
+    try std.testing.expectEqual(@as(usize, 18), cascade.params.len);
+    try std.testing.expect(cascade.params[15].type.? == *CommandEpochStats);
     try std.testing.expect(cascade.return_type.? == bool);
 
     const quotient = @typeInfo(@TypeOf(stwo_zig_metal_quotient_coefficients_resident)).@"fn";

--- a/src/backends/metal/runtime/opening_operations.zig
+++ b/src/backends/metal/runtime/opening_operations.zig
@@ -53,19 +53,35 @@ const Tree = runtime.Tree;
 const validDomainPrefixBytes = protocol_mode.validDomainPrefixBytes;
 const resource_plans = @import("resource_plans.zig").ResourcePlans(MetalError);
 const evalArguments = resource_plans.evalArguments;
-
 pub fn foldFriCircle(
     self: *Runtime,
     source: [*]const u32,
     source_count: u32,
-    inverse_y: []const u32,
+    inverse_y: ?[]const u32,
+    domain_initial_index: u32,
+    domain_step_size: u32,
     alpha: [4]u32,
     destination: [*]u32,
 ) MetalError!f64 {
-    if (inverse_y.len != source_count / 2) return MetalError.InvalidColumns;
+    if (inverse_y) |values| {
+        if (values.len != source_count / 2) return MetalError.InvalidColumns;
+    }
     var gpu_ms: f64 = 0;
     var message: [1024]u8 = [_]u8{0} ** 1024;
-    if (!ffi.stwo_zig_metal_fri_fold_circle(self.handle, source, source_count, inverse_y.ptr, &alpha, destination, &gpu_ms, &message, message.len)) {
+    const inverse_ptr = if (inverse_y) |values| values.ptr else null;
+    if (!ffi.stwo_zig_metal_fri_fold_circle(
+        self.handle,
+        source,
+        source_count,
+        inverse_ptr,
+        domain_initial_index,
+        domain_step_size,
+        &alpha,
+        destination,
+        &gpu_ms,
+        &message,
+        message.len,
+    )) {
         std.log.err("Metal FRI circle fold failed: {s}", .{std.mem.sliceTo(&message, 0)});
         return MetalError.CircleTransformFailed;
     }
@@ -154,14 +170,14 @@ pub fn foldFriLineAndCommit(
     };
 }
 
-/// Commits every single-fold line-FRI layer, advances the Blake2s transcript,
-/// and folds to the terminal evaluation in one ordered Metal command buffer.
 pub fn foldFriLineCascade(
     self: *Runtime,
     allocator: std.mem.Allocator,
     source: *anyopaque,
     source_count: u32,
-    inverse_x: []const u32,
+    inverse_x: ?[]const u32,
+    domain_initial_index: u32,
+    domain_step_size: u32,
     coordinates: []const *anyopaque,
     final_destination: *anyopaque,
     leaf_seed: [8]u32,
@@ -177,30 +193,31 @@ pub fn foldFriLineCascade(
     }
     const layer_count = std.math.cast(u32, coordinates.len) orelse return MetalError.InvalidColumns;
     if (source_count >> @intCast(layer_count) == 0) return MetalError.InvalidColumns;
-
     var expected_inverse_count: u64 = 0;
     var count = source_count;
     for (coordinates) |_| {
         count >>= 1;
         expected_inverse_count += count;
     }
-    if (inverse_x.len != expected_inverse_count or inverse_x.len > std.math.maxInt(u32))
-        return MetalError.InvalidColumns;
-
+    if (inverse_x) |values| {
+        if (values.len != expected_inverse_count or values.len > std.math.maxInt(u32))
+            return MetalError.InvalidColumns;
+    }
     const trees = try allocator.alloc(Tree, coordinates.len);
     errdefer allocator.free(trees);
     const handles = try allocator.alloc(?*anyopaque, coordinates.len);
     defer allocator.free(handles);
     @memset(handles, null);
-
     var stats: CommandEpochStats = undefined;
     var message: [1024]u8 = [_]u8{0} ** 1024;
     if (!ffi.stwo_zig_metal_fri_line_cascade(
         self.handle,
         source,
         source_count,
-        inverse_x.ptr,
-        @intCast(inverse_x.len),
+        if (inverse_x) |values| values.ptr else null,
+        @intCast(expected_inverse_count),
+        domain_initial_index,
+        domain_step_size,
         coordinates.ptr,
         final_destination,
         layer_count,

--- a/src/backends/metal/runtime/quotients.m
+++ b/src/backends/metal/runtime/quotients.m
@@ -216,6 +216,8 @@ bool stwo_zig_metal_compute_quotients(
             [domain_encoder setBytes:&domain_log_size length:sizeof(domain_log_size) atIndex:3];
             [domain_encoder setBytes:&domain_initial_index length:sizeof(domain_initial_index) atIndex:4];
             [domain_encoder setBytes:&domain_step_size length:sizeof(domain_step_size) atIndex:5];
+            uint32_t domain_mode = 0u;
+            [domain_encoder setBytes:&domain_mode length:sizeof(domain_mode) atIndex:6];
             NSUInteger domain_width = MIN(runtime.quotientDomainPointsResident.maxTotalThreadsPerThreadgroup,
                                           runtime.quotientDomainPointsResident.threadExecutionWidth * 8u);
             [domain_encoder dispatchThreads:MTLSizeMake(row_count, 1u, 1u)

--- a/src/backends/metal/runtime/runtime_queries.m
+++ b/src/backends/metal/runtime/runtime_queries.m
@@ -123,10 +123,12 @@ static id<MTLBuffer> alias_shared_buffer(id<MTLDevice> device, void *bytes, size
 
 bool stwo_zig_metal_fri_fold_circle(
     void *runtime_ptr, const uint32_t *source, uint32_t source_count,
-    const uint32_t *inverse_y, const uint32_t *alpha, uint32_t *destination,
+    const uint32_t *inverse_y, uint32_t domain_initial_index,
+    uint32_t domain_step_size, const uint32_t *alpha, uint32_t *destination,
     double *gpu_milliseconds, char *error_message, size_t error_message_len
 ) {
-    if (runtime_ptr == NULL || source == NULL || inverse_y == NULL || alpha == NULL || destination == NULL || source_count < 2u) return false;
+    if (runtime_ptr == NULL || source == NULL || alpha == NULL || destination == NULL ||
+        source_count < 2u || (source_count & (source_count - 1u)) != 0u) return false;
     @autoreleasepool {
         StwoZigMetalRuntime *runtime = (__bridge StwoZigMetalRuntime *)runtime_ptr;
         uint32_t destination_count = source_count >> 1u;
@@ -137,12 +139,41 @@ bool stwo_zig_metal_fri_fold_circle(
         id<MTLBuffer> destination_buffer = alias_shared_buffer(runtime.device, destination, destination_bytes);
         bool direct_destination = destination_buffer != nil;
         if (destination_buffer == nil) destination_buffer = [runtime.device newBufferWithLength:destination_bytes options:MTLResourceStorageModeShared];
-        id<MTLBuffer> inverse_buffer = [runtime.device newBufferWithBytes:inverse_y length:(size_t)destination_count * sizeof(uint32_t) options:MTLResourceStorageModeShared];
+        id<MTLBuffer> inverse_buffer = nil;
+        bool build_inverse_cache = false;
+        if (inverse_y == NULL) {
+            @synchronized(runtime) {
+                if (runtime.friCircleInverseCache != nil &&
+                    runtime.friCircleInverseCacheCount == destination_count &&
+                    runtime.friCircleInverseCacheInitialIndex == domain_initial_index &&
+                    runtime.friCircleInverseCacheStepSize == domain_step_size) {
+                    inverse_buffer = runtime.friCircleInverseCache;
+                }
+            }
+            if (inverse_buffer == nil) {
+                inverse_buffer = [runtime.device newBufferWithLength:
+                    (NSUInteger)destination_count * sizeof(uint32_t)
+                    options:MTLResourceStorageModePrivate];
+                build_inverse_cache = true;
+            }
+        } else {
+            inverse_buffer = [runtime.device newBufferWithBytes:inverse_y
+                length:(size_t)destination_count * sizeof(uint32_t)
+                options:MTLResourceStorageModeShared];
+        }
         if (source_buffer == nil || destination_buffer == nil || inverse_buffer == nil) {
             write_error(error_message, error_message_len, @"FRI circle fold buffer allocation failed");
             return false;
         }
         id<MTLCommandBuffer> command = [runtime.queue commandBuffer];
+        if (build_inverse_cache) {
+            id<MTLComputeCommandEncoder> domain = [command computeCommandEncoder];
+            encode_fri_inverse_domain(
+                runtime, domain, inverse_buffer, 0u, destination_count,
+                domain_initial_index, domain_step_size, 2u
+            );
+            [domain endEncoding];
+        }
         id<MTLComputeCommandEncoder> encoder = [command computeCommandEncoder];
         [encoder setComputePipelineState:runtime.friFoldCircle];
         [encoder setBuffer:source_buffer offset:0 atIndex:0];
@@ -156,6 +187,14 @@ bool stwo_zig_metal_fri_fold_circle(
         [command commit]; [command waitUntilCompleted];
         if (command.status == MTLCommandBufferStatusError) {
             write_error(error_message, error_message_len, command.error.localizedDescription); return false;
+        }
+        if (build_inverse_cache) {
+            @synchronized(runtime) {
+                runtime.friCircleInverseCache = inverse_buffer;
+                runtime.friCircleInverseCacheCount = destination_count;
+                runtime.friCircleInverseCacheInitialIndex = domain_initial_index;
+                runtime.friCircleInverseCacheStepSize = domain_step_size;
+            }
         }
         if (!direct_destination) memcpy(destination, destination_buffer.contents, destination_bytes);
         if (gpu_milliseconds) *gpu_milliseconds = (command.GPUEndTime - command.GPUStartTime) * 1000.0;

--- a/src/backends/metal/shaders/manifest.zig
+++ b/src/backends/metal/shaders/manifest.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-pub const core_shader_abi: u32 = 4;
+pub const core_shader_abi: u32 = 5;
 pub const witness_codegen_support_version: u64 = 6;
 
 pub const CompileProfile = struct {
@@ -411,8 +411,8 @@ test "metal shader manifest exactly covers source and runtime exports" {
     }
 }
 
-test "commitment shader bindings match core ABI version 4" {
-    try std.testing.expectEqual(@as(u32, 4), core_shader_abi);
+test "commitment shader bindings match core ABI version 5" {
+    try std.testing.expectEqual(@as(u32, 5), core_shader_abi);
     const bindings = [_]struct { kernel: []const u8, argument: []const u8 }{
         .{ .kernel = "stwo_zig_blake2s_leaves", .argument = "prefix_bytes [[buffer(7)]]" },
         .{ .kernel = "stwo_zig_blake2s_parents", .argument = "prefix_bytes [[buffer(4)]]" },
@@ -421,6 +421,7 @@ test "commitment shader bindings match core ABI version 4" {
         .{ .kernel = "stwo_zig_fri_packed_leaves_resident", .argument = "prefix_bytes [[buffer(7)]]" },
         .{ .kernel = "stwo_zig_qm31_to_coordinates", .argument = "prefix_bytes [[buffer(5)]]" },
         .{ .kernel = "stwo_zig_fri_fold_line", .argument = "prefix_bytes [[buffer(8)]]" },
+        .{ .kernel = "stwo_zig_quotient_domain_points_resident", .argument = "mode [[buffer(6)]]" },
     };
     for (bindings) |binding| {
         const declaration = try kernelDeclaration(amalgamated_source, binding.kernel);

--- a/src/backends/metal/tests/fri_fold_commit.zig
+++ b/src/backends/metal/tests/fri_fold_commit.zig
@@ -21,6 +21,75 @@ const QM31 = qm31.QM31;
 const Hasher = blake2_merkle.Blake2sMerkleHasher;
 const MerkleChannel = blake2_merkle.Blake2sMerkleChannel;
 
+test "metal: resident FRI inverse-y cache matches shifted host domains" {
+    const allocator = std.testing.allocator;
+    var runtime = try runtime_mod.Runtime.init();
+    defer runtime.deinit();
+
+    const destination_log: u32 = 8;
+    const destination_count: usize = @as(usize, 1) << destination_log;
+    const source_count = destination_count << 1;
+    const source = try allocator.alloc(u32, source_count * 4);
+    defer allocator.free(source);
+    for (source, 0..) |*value, index| {
+        value.* = @intCast((index * 97 + 19) % m31.Modulus);
+    }
+    const alpha = [_]u32{ 7, 11, 13, 17 };
+
+    const host_destination = try allocator.alloc(u32, destination_count * 4);
+    defer allocator.free(host_destination);
+    const miss_destination = try allocator.alloc(u32, destination_count * 4);
+    defer allocator.free(miss_destination);
+    const hit_destination = try allocator.alloc(u32, destination_count * 4);
+    defer allocator.free(hit_destination);
+    const coordinates = try allocator.alloc(M31, destination_count);
+    defer allocator.free(coordinates);
+    const inverses = try allocator.alloc(M31, destination_count);
+    defer allocator.free(inverses);
+
+    for ([_]usize{ 12_345, 456_789 }) |initial_index| {
+        const fold_coset = circle.Coset.new(.{ .v = initial_index }, destination_log);
+        for (coordinates, 0..) |*coordinate, index| {
+            const natural = core_utils.bitReverseIndex(index, destination_log);
+            coordinate.* = fold_coset.at(natural).y;
+        }
+        try fields.batchInverseInPlace(M31, coordinates, inverses);
+        const inverse_words = std.mem.bytesAsSlice(u32, std.mem.sliceAsBytes(inverses));
+        const initial: u32 = @intCast(fold_coset.initial_index.v);
+        const step: u32 = @intCast(fold_coset.step_size.v);
+
+        _ = try runtime.foldFriCircle(
+            source.ptr,
+            source_count,
+            inverse_words,
+            initial,
+            step,
+            alpha,
+            host_destination.ptr,
+        );
+        _ = try runtime.foldFriCircle(
+            source.ptr,
+            source_count,
+            null,
+            initial,
+            step,
+            alpha,
+            miss_destination.ptr,
+        );
+        _ = try runtime.foldFriCircle(
+            source.ptr,
+            source_count,
+            null,
+            initial,
+            step,
+            alpha,
+            hit_destination.ptr,
+        );
+        try std.testing.expectEqualSlices(u32, host_destination, miss_destination);
+        try std.testing.expectEqualSlices(u32, host_destination, hit_destination);
+    }
+}
+
 test "metal: FRI fold and next tree use one submission with CPU parity" {
     const allocator = std.testing.allocator;
     var runtime = try runtime_mod.Runtime.init();
@@ -377,6 +446,8 @@ test "metal: line FRI cascade preserves every root, challenge, and final value" 
         source.handle,
         source_count,
         inverse_words,
+        0,
+        0,
         coordinate_handles,
         final_destination.handle,
         Hasher.leafSeed(),

--- a/src/prover/fri.zig
+++ b/src/prover/fri.zig
@@ -73,6 +73,7 @@ pub fn FriProver(comptime B: type, comptime H: type, comptime MC: type) type {
         last_layer_poly: line.LinePoly,
 
         const Self = @This();
+        const lazy_inverse_workspace = if (@hasDecl(B, "lazyFriFoldInverseWorkspace")) B.lazyFriFoldInverseWorkspace else false;
 
         const FirstLayerProver = struct {
             domain: circle_domain.CircleDomain,
@@ -394,7 +395,7 @@ pub fn FriProver(comptime B: type, comptime H: type, comptime MC: type) type {
 
             var fold_circle_workspace = try core_fri.FoldCircleWorkspace.init(
                 allocator,
-                layer_evaluation.len(),
+                if (lazy_inverse_workspace) 0 else layer_evaluation.len(),
             );
             defer fold_circle_workspace.deinit(allocator);
             const folding_alpha = channel.drawSecureFelt();
@@ -427,7 +428,7 @@ pub fn FriProver(comptime B: type, comptime H: type, comptime MC: type) type {
             if (config.fold_step > 1) {
                 var first_line_workspace = try core_fri.FoldLineWorkspace.init(
                     allocator,
-                    layer_evaluation.len() / 2,
+                    if (lazy_inverse_workspace) 0 else layer_evaluation.len() / 2,
                 );
                 defer first_line_workspace.deinit(allocator);
                 if (comptime @hasDecl(B, "foldLineEvaluationN")) {
@@ -472,7 +473,7 @@ pub fn FriProver(comptime B: type, comptime H: type, comptime MC: type) type {
             }
             var fold_workspace = try core_fri.FoldLineWorkspace.init(
                 allocator,
-                layer_evaluation.len() / 2,
+                if (lazy_inverse_workspace) 0 else layer_evaluation.len() / 2,
             );
             defer fold_workspace.deinit(allocator);
             const last_layer_log_size = std.math.log2_int(usize, config.lastLayerDomainSize());


### PR DESCRIPTION
Caches fixed circle inverse-y and line inverse-x FRI domains in bounded private Metal buffers after one warmup-only generation. Cache hits remove recurring CPU coset walks, batch inversions, scratch allocation, and uploads while preserving the established 32-grid line cascade.

Official core_metal S3 claimed verdicts:
- wide: R 0.960611, 95% CI [0.951332, 0.970111], 15 rounds
- deep: R 0.943690, 95% CI [0.931932, 0.953413], 15 rounds

Both pass G1-G5, the pinned Rust oracle, all 12 guards, and request/RSS budgets. Full three-class clean paired evidence is a 0.96866 geometric ratio with fixed proofs and zero fallback. Validation includes shifted-coset cache miss/hit device parity, Native Metal lifecycle, aggregate tests, metal-check, source conformance, formatting, and AOT tool/probe contracts.