### PR TITLE
Validate paired CPU and Metal verdicts by board

### DIFF
--- a/autoresearch/bots/validate_action.py
+++ b/autoresearch/bots/validate_action.py
@@ -87,7 +87,8 @@ def main() -> int:
             if not (sub / required).exists():
                 findings.append(f"{name}: missing {required}")
         verdict_paths = [sub / "verdict.json", *sorted(sub.glob("verdict-*.json"))]
-        seen_classes: set[str] = set()
+        verdicts = []
+        verdict_sources = []
         for verdict_path in verdict_paths:
             if not verdict_path.exists():
                 continue
@@ -96,12 +97,12 @@ def main() -> int:
             except json.JSONDecodeError:
                 findings.append(f"{name}: {verdict_path.name} is not valid JSON")
                 continue
-            if verdict.get("kind") == "judged":
-                findings.append(f"{name}: submissions must carry claimed verdicts")
-            cls = str((verdict.get("declared_objective") or {}).get("workload_class"))
-            if cls in seen_classes:
-                findings.append(f"{name}: duplicate verdict for class {cls}")
-            seen_classes.add(cls)
+            verdicts.append(verdict)
+            verdict_sources.append(verdict_path.name)
+        try:
+            submitter.check_claimed_verdicts(verdicts, verdict_sources)
+        except submitter.SubmitError as exc:
+            findings.append(f"{name}: {exc}")
         secrets = submitter.scan_transcripts(sub / "transcripts")
         findings.extend(f"{name}: transcript secret scan: {s}" for s in secrets)
         transcripts_dir = sub / "transcripts"

--- a/autoresearch/cli/stwo_perf/__main__.py
+++ b/autoresearch/cli/stwo_perf/__main__.py
@@ -546,8 +546,8 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--note-file", required=True)
     p.add_argument(
         "--verdict", required=True, action="append",
-        help="claimed verdict.json from `run`; repeat once per workload class "
-             "the change moves — every moved class earns its suite credit",
+        help="claimed verdict.json from `run`; repeat once per board/class pair "
+             "the change moves — every moved pair earns its suite credit",
     )
     p.add_argument(
         "--transcripts",

--- a/autoresearch/cli/stwo_perf/promotion.py
+++ b/autoresearch/cli/stwo_perf/promotion.py
@@ -140,7 +140,8 @@ def landing_commit(repo: Path, submission_id: str) -> str:
 
 def claimed_verdict_files(sub_dir: Path) -> list[Path]:
     """A submission's verdicts: the primary verdict.json plus one
-    verdict-<class>.json per additional workload class the change moved."""
+    verdict-<class>.json or verdict-<board>-<class>.json per additional
+    board/class pair the change moved."""
     primary = sub_dir / "verdict.json"
     extras = sorted(sub_dir.glob("verdict-*.json"))
     return [p for p in [primary, *extras] if p.is_file()]

--- a/autoresearch/schema/submission.md
+++ b/autoresearch/schema/submission.md
@@ -10,11 +10,10 @@ A submission is one directory under `autoresearch/submissions/`, added by one PR
 autoresearch/submissions/<utc-date>-<slug>/
   note.md          public note; required sections below, <= 10 KiB
   verdict.json     the submitter's claimed acceptance-rung verdict (schema/verdict.md)
-  verdict-<class>.json  OPTIONAL, one per additional workload class the same
-                   change moves (same mechanism, same diff, distinct declared
-                   class). Every moved class earns its own ledger row and its
-                   own suite-score credit — cross-class gains must never
-                   vanish into future predecessors uncredited
+  verdict-<class>.json  OPTIONAL CPU verdict, or verdict-<board>-<class>.json
+                   for another board; one per additional board/class pair the
+                   same change moves (same mechanism, same diff). Every moved
+                   pair earns its own ledger row and suite-score credit
   delta.json       predecessor binding + content digests (schema below)
   transcripts/     sanitized agent session transcripts — the submission-flow
                    default (skills/submission-transcripts): at least one file,


### PR DESCRIPTION
The submitter already permits one claimed verdict per (board, workload class) and emits board-qualified filenames, but PR validation still deduplicates by workload class alone. This makes every CPU+Metal paired package fail after packaging.

This change routes PR validation through the submitter's tested policy helper so the two paths cannot drift again, and updates CLI/schema wording to describe board/class pairs.

Validation:
- 26 focused submitter/promotion/transcript tests pass
- Python compilation and diff checks pass
- The pending real package with CPU+Metal wide/deep verdict pairs passes the corrected validator