### PR TITLE
Specialize bounded M31 reduction on CPU and Metal

### DIFF
--- a/autoresearch/submissions/2026-07-21-bounded-m31-reduction-cpu-metal/delta.json
+++ b/autoresearch/submissions/2026-07-21-bounded-m31-reduction-cpu-metal/delta.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "9efa1dba0714",
+  "declared_objective": {
+    "board": "core_metal",
+    "workload_class": "wide",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/backends/metal/shaders/include/m31.metal": "sha256:a544f6c8cc4a97daa4edbf1d97708cf0d26b0d369a0d2308d909a0cd3b2aecba",
+    "src/core/fields/m31.zig": "sha256:f18272840e60941430b13f20a19a645d3a68ab2fb3aa8093e0c09d3d454627bc"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "85ada7ef4055230e0457cca0a1631cc4eff99531d42a7a923e22fd83b0295c14",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-21-bounded-m31-reduction-cpu-metal/note.md
+++ b/autoresearch/submissions/2026-07-21-bounded-m31-reduction-cpu-metal/note.md
@@ -1,0 +1,64 @@
+# Specialize bounded M31 reduction on CPU and Metal
+
+## Model and harness
+
+GPT-5 Codex developed and measured this change with the repository's pinned
+`stwo-perf` harness at harness commit `becd88e4944a`. The candidate is
+`a16249f27872` against promoted predecessor `9efa1dba0714`. All reported S3
+verdicts use paired ABBA rounds, verified proof digests, and the pinned Rust
+oracle on an Apple M5 Max. Native CPU and Metal source-JIT products were built
+in ReleaseFast mode; Metal runs reported no CPU fallback.
+
+## Hypothesis
+
+M31 multiplication was using a generic reducer designed for arbitrary 64-bit
+inputs even though multiplication receives canonical field elements. With
+`p = 2^31 - 1` and `0 <= a,b < p`, the product satisfies `a*b < p^2 < 2^62`.
+One Mersenne fold therefore lands below `2p`, so one conditional subtraction is
+sufficient. Canonical addition also lands below `2p` and needs only one
+conditional subtraction. Removing redundant folds should reduce integer work
+in both host field arithmetic and Metal shaders without changing proofs,
+dispatches, resources, or ownership.
+
+## Changes
+
+The CPU scalar, four-lane vector, and native-packed multiplication paths now use
+a bounded product reducer. The generic arbitrary-`u64` reducer remains intact
+for constructors and boundary normalization. Edge cases, 4,096 randomized
+canonical products, Vec4 results, and native-packed results are checked against
+the generic reducer.
+
+The Metal M31 header now implements canonical addition with a 32-bit
+sum/subtract and canonical multiplication with one 64-bit fold/subtract. The
+generic Metal reducer remains available for wider arena values. No public ABI,
+buffer layout, resource lifetime, encoder, synchronization, pipeline, or
+dispatch behavior changes.
+
+## Results
+
+All six S3 CPU+Metal time verdicts are significant:
+
+| board / class | A median | B median | ratio | 95% CI | request ratio |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| CPU / small | 1.511209 ms | 1.417666 ms | 0.936051 | [0.907390, 0.959173] | 0.947688 |
+| Metal / small | 2.505917 ms | 2.436791 ms | 0.965743 | [0.944044, 0.987941] | 0.967833 |
+| CPU / wide | 10.344041 ms | 9.660250 ms | 0.923793 | [0.909715, 0.947753] | 0.915524 |
+| Metal / wide | 8.911667 ms | 7.814709 ms | 0.866114 | [0.844814, 0.883687] | 0.856497 |
+| CPU / deep | 6.691500 ms | 6.292166 ms | 0.943371 | [0.923037, 0.955130] | 0.945990 |
+| Metal / deep | 4.777625 ms | 4.627625 ms | 0.960649 | [0.919915, 0.980512] | 0.960284 |
+
+All claimed verdicts pass G1-G5, cross-arm proof digests are byte-identical,
+and the pinned Rust oracle verifies every workload. An isolated live-code CPU
+profile measured ratio 0.7722 with 95% CI [0.7632, 0.7796], while instructions
+fell to ratio 0.7384. A warmed real-device Metal arithmetic kernel stabilized
+near 0.184 ms before versus 0.0865 ms after, supporting the same mechanism.
+
+## Caveats
+
+Metal-small was noisy in an earlier process-level diagnostic, but its final
+15-round paired verdict is significant and is included above. One broad
+resident-FRI Metal test fails on this machine at both the candidate and
+untouched predecessor; focused device-only proof and independent-verifier tests
+pass, as do core, prover, native CPU, Metal AOT compile/probe, formatting, and
+source-conformance checks. These are submitter measurements; only the judge
+rerun determines promotion.

--- a/autoresearch/submissions/2026-07-21-bounded-m31-reduction-cpu-metal/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-21-bounded-m31-reduction-cpu-metal/transcripts/session-01.md
@@ -1,0 +1,237 @@
+# Session 01 — bounded M31 reduction across CPU and Metal
+
+## Objective and frontier
+
+The continuing autoresearch goal requires every new source submission to move
+CPU and Metal together. PR #37 landed the shared circle-basis optimization;
+because validation permits only one verdict per workload class in a package,
+PR #38 immediately recorded its already-measured CPU-wide verdict separately.
+Both are promoted. The canonical repository-resident CLI was then updated to
+recorded main `81712fa`, preserving two pre-existing untracked notes, and a
+clean `dual-02` workspace was created from that exact frontier.
+
+All repository skills remain binding: transcript capture, problem matching,
+CPU live-code profiling, real-device Metal profiling, and the Metal
+performance-design resource/ownership/dispatch framework. This session targets
+one mathematical mechanism implemented in both backends rather than combining
+unrelated wins.
+
+## Fresh benchmark and stage attribution
+
+`stwo-perf setup` rebuilt the enabled Native CPU and Native Metal ReleaseFast
+products; RISC-V remains explicitly disabled by policy. Ten verified timed
+samples after ten warmups produced representative medians:
+
+| board/class | prove ms | request ms | proof / telemetry |
+| --- | ---: | ---: | --- |
+| CPU small | 1.534 | 1.699 | `91741aec...bea5700` |
+| CPU wide | 10.228 | 11.227 | `57a7d291...0f3374` |
+| CPU deep | 6.598 | 6.920 | `d63a2c92...b69dbaf` |
+| Metal wide | 9.110 | 10.072 | 22 dispatches, zero fallback |
+| Metal deep | 4.773 | 5.101 | 24 dispatches, zero fallback |
+
+Metal-small varied strongly between repeated processes and is diagnostic only
+until paired. Profiled wide/deep medians show the remaining shared host ceiling:
+
+| stage | CPU wide | Metal wide | CPU deep | Metal deep |
+| --- | ---: | ---: | ---: | ---: |
+| composition evaluation | 2.627 | 2.484 | 0.123 | 0.135 |
+| FRI build + commit | 3.375 | 1.986 | 3.217 | 1.638 |
+| main trace commit | 1.941 | 1.877 | 0.976 | 0.657 |
+| composition commit | 1.068 | 1.453 | 0.434 | 0.745 |
+
+Intra-component row parallelism was considered first: wide Fibonacci is one AIR
+component, so the existing component-level pool cannot fan it out. The row loop
+lives in locked example code and its type-erased prover callback exposes only a
+whole-domain operation. Retrofitting a row-range vtable would touch locked core
+AIR/derive and example files; guessing the component from trace shape would be
+semantically unsound. That architecture is therefore rejected under the
+editable-surface contract, not merely deferred for implementation difficulty.
+
+## Problem match — bounded Mersenne reduction
+
+The next candidate is exact bounded modular reduction, not a new field
+algorithm. Let `p = 2^31 - 1` and canonical operands satisfy `0 <= a,b < p`.
+For `x = a*b`, `x < p^2 < 2^62`. One Mersenne fold
+`t = (x & p) + (x >> 31)` therefore satisfies `0 <= t < 2p`; a single
+conditional subtraction maps it canonically into `[0,p)`. The same `<2p`
+bound holds directly for `a+b`.
+
+Current CPU scalar, fixed-Vec4, and native-packed multiplication perform a
+second fold. Current Metal sends both addition and multiplication through a
+generic two-fold 64-bit reducer. The intended dataflow is:
+
+```text
+canonical a,b
+     |
+     +-- add --------------------------> s in [0,2p)
+     |                                  |
+     |                                  +--> subtract p iff s >= p
+     |
+     +-- 64-bit product --> one fold --> t in [0,2p)
+                                        |
+                                        +--> subtract p iff t >= p
+```
+
+The generic `M31.fromU64` reducer retains two folds because it accepts arbitrary
+`u64`; only operations with the proven operand bound use the specialized path.
+Aliasing, storage layout, canonical representation, operation order, public
+ABI, command buffers, dispatch counts, and pipeline identities are unchanged.
+Counterexamples considered: noncanonical operands would violate the proof, so
+all constructors and shader call sites must retain canonical invariants; the
+generic reducer remains available at arena boundaries that may contain wider
+values.
+
+## Baseline isolated evidence and Metal design
+
+A live-module `stwo-prof zig` harness performs four scalar M31 products plus one
+four-coordinate QM31-by-M31 product per iteration. Fifteen rounds measured
+0.8612 ns, 10.51 instructions, and 3.906 cycles per base-field product, IPC
+2.692. Assembly for `_workload.run` contains the expected second `and` plus
+shift/add fold in each scalar and vector path; the hot symbol is 161
+instructions with 29.2% NEON.
+
+A real Apple M5 Max Metal isolation runs 32 dependent multiply-add pairs per
+thread over a 1,048,576-element grid, 256 threads per group, with no threadgroup
+memory and PSO width 32 / maximum 1024 threads. GPU frequency ramping displaced
+early runs (0.877 ms then 0.373 ms median), so final attribution will use
+interleaved repeated baseline/candidate runs, not the first absolute number.
+
+Metal design classification: compute-bound integer field arithmetic; no new
+resources, allocations, transfers, waits, encoders, or dispatches. Lifetime and
+ownership are unchanged. The mechanism removes one 64-bit fold per multiply and
+all 64-bit reduction work from canonical addition. The falsifier is unchanged
+GPU/stage time, any proof mismatch, a canonicality failure at boundary tests, or
+an end-to-end regression on either board.
+
+## Implementation and first integrated result
+
+The CPU keeps its generic arbitrary-`u64` reducer and adds bounded scalar,
+fixed-Vec4, and native-packed product reducers. `M31.mul`, `mulVec4`, and
+`mulPacked` route only canonical products through them. Edge products and 4,096
+random canonical pairs match the generic reducer. The Metal header leaves
+`m31_reduce` unchanged for arena/boundary normalization, implements canonical
+addition with a 32-bit sum/subtract, and implements canonical multiplication
+with one fold/subtract.
+
+Live-code CPU ABBA against the untouched canonical module measured 0.864 ->
+0.673 ns/product, ratio 0.7722 with 95% CI [0.7632, 0.7796]. Instructions fell
+to ratio 0.7384 and cycles to 0.7734; the hot symbol shrank from 161 to 138
+instructions. Interleaved real-device Metal isolation, after frequency warmup,
+stabilized near 0.184 ms baseline versus 0.0865 ms candidate for the same grid
+and PSO, about a 53% kernel reduction.
+
+Core tests and both ReleaseFast products compile. Ten-sample diagnostic proof
+medians, still unpaired, moved as follows while retaining exact proof hashes:
+
+| board/class | frontier ms | candidate ms | diagnostic change |
+| --- | ---: | ---: | ---: |
+| CPU wide | 10.228 | 9.408 | -8.0% |
+| Metal wide | 9.110 | 8.753 | -3.9% |
+| CPU deep | 6.598 | 6.281 | -4.8% |
+| Metal deep | 4.773 | 4.683 | -1.9% |
+
+Candidate CPU-wide profiling attributes composition evaluation at 1.812 ms
+versus 2.627 ms before the change, and FRI build/commit at 3.006 versus 3.375
+ms. Metal profiling is heavily perturbed by instrumentation and GPU frequency,
+but its shared host composition stage moved from 2.484 to about 1.88 ms. The
+uninstrumented Metal result and isolated GPU timer are the reliable device
+signals. Dispatches remain 22/24 for wide/deep with zero CPU fallbacks.
+
+During this work the user reported that a fresh `stwo-perf update` restores
+CPU+Metal verdicts for the same class in one package. Canonical update advanced
+to `1b9a455`; the packager accepts board-qualified pairs, though that checkout's
+validator still visibly contains the previous class-only duplicate check. A
+second update will be run before packaging so the next result stays paired if
+the central fix has finished propagating.
+
+## Correctness closure and official wide verdicts
+
+The bounded reducers passed the 70-source core suite, the 152-source prover
+suite, the 190-source native CPU product suite, device-only Metal prove plus an
+independent verifier, Metal AOT compile/probe checks, formatting, and source
+conformance. The broad Metal suite passed 81/84 cases with two documented skips
+and one resident-FRI coordinate-conversion failure. Repeating that exact case
+on untouched canonical `1b9a455` produced the same failure on this M5 Max, so it
+is a pre-existing platform result rather than a candidate regression. Native
+Metal source-JIT proofs retain exact hashes, expected dispatch counts, and zero
+fallbacks.
+
+The first official CPU-wide attempt is discarded as contaminated evidence. It
+reported R=0.945575 with CI [0.852412, 1.043388], while round ratios ranged from
+roughly 0.40 to 1.19. Immediately afterward a separate RISC-V compiler process
+was observed consuming over 1,300% CPU, consistent with the pathological
+pairing noise. No process was interrupted; the CPU verdict was repeated only
+after that load ended.
+
+Stable S3 ABBA verdicts from candidate `edc13e90191d`, predecessor
+`1b9a45598e43`, and harness `f97aa4a99086` are:
+
+| board/class | A median ms | B median ms | R | 95% CI | request ratio | result |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| CPU wide | 10.256875 | 9.459292 | 0.918152 | [0.905943, 0.934447] | 0.912003 | significant |
+| Metal wide | 9.184417 | 8.251084 | 0.892766 | [0.870556, 0.913055] | 0.880346 | significant |
+
+Both use 15 paired rounds; all G1-G5 gates pass, the pinned Rust oracle passes,
+and the cross-arm proof digest is exactly
+`57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374`.
+This is an 8.18% CPU proof-time reduction and a 10.72% Metal proof-time
+reduction from one shared mathematical specialization.
+
+The remaining classes were then measured rather than inferred:
+
+| board/class | A median ms | B median ms | R | 95% CI | request ratio | result |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| CPU deep | 6.609500 | 6.321750 | 0.952484 | [0.944310, 0.960579] | 0.960753 | significant |
+| Metal deep | 4.812417 | 4.707875 | 0.970098 | [0.955852, 0.984097] | 0.977829 | significant |
+| CPU small | 1.536500 | 1.430458 | 0.934054 | [0.917693, 0.951611] | 0.950118 | significant |
+| Metal small | 2.564042 | 2.544500 | 0.988809 | [0.964024, 1.011500] | 0.995217 | neutral evidence |
+
+All runs pass G1-G5 and the pinned oracle. Deep shares proof digest
+`d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf`;
+small shares proof digest
+`91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700`.
+The submission should claim five significant rows: CPU small, CPU+Metal wide,
+and CPU+Metal deep. Metal small remains in the transcript as a measured neutral
+result and must not be promoted as a significant claim.
+
+## Paired-verdict policy closure
+
+The first five-verdict package proved that the refreshed submitter already
+deduplicated by `(board, workload class)` and emitted board-qualified Metal
+filenames. The repository PR validator nevertheless still deduplicated only by
+class, rejecting the real package with exactly two findings: duplicate `wide`
+and duplicate `deep`. This was a policy implementation split, not a benchmark
+or package-content failure; all focused submission tests passed.
+
+The missing half was isolated in governance PR #39. PR validation now calls the
+submitter's already-tested `check_claimed_verdicts` helper, making packaging and
+PR validation share one policy source. CLI and schema wording now describe
+board/class pairs. The pending real five-verdict package passed the corrected
+validator. After validation and focused CI were green, PR #39 merged as
+`9efa1dba071440ab41820e1c04216ec6b422117f`.
+
+To keep formal bindings exact, the optimization was not submitted with its old
+identities. A fresh branch from `9efa1dba` cherry-picked only the two editable
+source files, producing candidate `a16249f`. Both predecessor and candidate
+native CPU/Metal products were rebuilt successfully. The source diff and its
+mathematics are byte-for-byte unchanged; official paired verdicts are rerun
+below against the corrected frontier before repackaging.
+
+The corrected-frontier rerun uses candidate `a16249f27872`, predecessor
+`9efa1dba0714`, and harness `becd88e4944a`. Every run passes G1-G5, exact
+cross-arm proof comparison, and the pinned oracle:
+
+| board/class | A median ms | B median ms | R | 95% CI | request ratio | result |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| CPU small | 1.511209 | 1.417666 | 0.936051 | [0.907390, 0.959173] | 0.947688 | significant |
+| Metal small | 2.505917 | 2.436791 | 0.965743 | [0.944044, 0.987941] | 0.967833 | significant |
+| CPU wide | 10.344041 | 9.660250 | 0.923793 | [0.909715, 0.947753] | 0.915524 | significant |
+| Metal wide | 8.911667 | 7.814709 | 0.866114 | [0.844814, 0.883687] | 0.856497 | significant |
+| CPU deep | 6.691500 | 6.292166 | 0.943371 | [0.923037, 0.955130] | 0.945990 | significant |
+| Metal deep | 4.777625 | 4.627625 | 0.960649 | [0.919915, 0.980512] | 0.960284 | significant |
+
+Unlike the earlier Metal-small process result, the final 15-round paired
+Metal-small CI is wholly below one. The final package can therefore claim all
+six board/class rows, exactly matching the shared CPU+Metal mechanism and the
+new validator policy.

--- a/autoresearch/submissions/2026-07-21-bounded-m31-reduction-cpu-metal/verdict-core_metal-deep.json
+++ b/autoresearch/submissions/2026-07-21-bounded-m31-reduction-cpu-metal/verdict-core_metal-deep.json
@@ -1,0 +1,177 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "becd88e4944a",
+  "repo_commit": "a16249f27872",
+  "predecessor_commit": "9efa1dba0714",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_metal",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 4.71
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "anchor not frozen; drift budget inactive; request ratio 0.9603 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "mplonk_log14": {
+        "r": 0.960649,
+        "ci": [
+          0.919915,
+          0.980512
+        ],
+        "rounds": 15,
+        "a_median_ms": 4.777625,
+        "b_median_ms": 4.627625
+      }
+    },
+    "R_geomean": 0.960649,
+    "theta": 0.01,
+    "aa_dispersion": null,
+    "significant": true,
+    "neutral": false
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "mplonk_log14",
+      "verified": true,
+      "artifact_sha256": "ed64ff803f2e7ec8c5eeb81f520ee3cb228c6811795a53137092a8632f9e5e68"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "mplonk_log14": {
+        "round_ratios": [
+          0.614978,
+          0.969338,
+          0.952175,
+          1.00392,
+          0.968507,
+          0.951746,
+          0.980512,
+          1.030096,
+          0.964728,
+          0.859318,
+          0.927012,
+          0.957341,
+          0.905227,
+          1.020823,
+          0.971219
+        ],
+        "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf",
+        "request_ratio": 0.960284,
+        "report_sha256s": [
+          "b54b6b5a8a5e17b02cca47be487ca9a1631a3d92177643a86c28debc1e2aa3ae",
+          "49e38544fe30639770899c89248290b03ef6730205216a2f5c61b10c6eff4dab",
+          "a06a81fc58f78666436679ecc74627e1dc358c2c74bcc6cd7d4154df501f9b31",
+          "fb1f3d1cae15a0206319f821a46c0e7111d074ae8d016e14efd4ca0ef9908937",
+          "878806318cf9f995d6587e17469403f06ba0e21e36181aafff18adca71f4e0ee",
+          "49ff624e4a58f3de8097a03f165096be9c9b3703407f2b5fafffac8c08ae4869",
+          "eaba535fc36e369dbd0d99032bacceb09f2c856d562237b378d92c997037f9ee",
+          "4d1e53826d40514a454f623deb766a8dfe731940124469194d9eeb15d698bd19",
+          "a315d74313a6132485b04dd205b30f950d9310a727bfc36408ae003e5c23159d",
+          "1ae21a61515f3e77ece24f68e99a1e848ee53020ce89a01352e49eec41f9208c",
+          "12eca9c094938488bb0132cbb186ed8754ea521f9f0d724dbc20d6e691e1d64c",
+          "d2d051e50f7865d25970324b300178ca54ebf0efa8efe45afd6109b9ea3fd397",
+          "4093f2a999cf5e5db5f78f8531ace8fbe0ade7d334aca3ad719f2ab1e7b2b326",
+          "82e2914b1a5d1dd433dad0adace1c5ea7a091a2f1fb4a57faf73e5bac089d1c9",
+          "8c2b8fddd98a7c5950970fe481021cf109cd03107116d1db59df8f95632ef775",
+          "7b0a42f9b0e8a8765c15a4dfb1106229879b494b446a9e087eea9037feb22a8b",
+          "e514b8d43501e02081ae007421ff2a8a191761a9b6343cb294768d15c3172aea",
+          "95770f395414ce58a2be0282df78ae8f9037ff53037d1ab8631777faed928afa",
+          "3642f7da77ab4c2c871a2bd3a57cbeda5b168fa8f28724ff348d6ca2b71f4049",
+          "98db5e30fda1dd18e757ffc5685319cc62f9cb5fb00b7a13cf6c0c185f8bff67",
+          "d472ffb64ebc91b3289211415576f195ce1f348fb116e398ebde9d0a3a68f98e",
+          "4b5cb1476402202bb25e59426707208a95b458b6d214c48389275a6310f6dd2d",
+          "9ddbb28728af2b186ffd3191d5df5e305d5c8efbd250400efcea034c55b27edd",
+          "bedf5b46b947b00fc02a5fc5fd2ae67414912b821f5b4fa326a7e9e5aeef83bd",
+          "41f4a054911ce313ced10548de564ef6e11ecc175eb678c97735847887568c5c",
+          "2cdcc52d46ccb932c9691fc95104d447d9ff5aaa88d5982e49ffd7c08c2b6105",
+          "a1407727dbc3593199a6fd046d901a84802e9b6f56dc442849ec7c8425b0884a",
+          "f5d07b79cc5e9298eb336c85d57017e05c0288d4018aaa7693a242f284d892fa",
+          "58dc848798cf4d2ca64a9d7b1468e5f0febd9f9c0e3681d8a8c51c7846ffd234",
+          "8555196e178ce427cf86ef92fce6bf42807ac7c3319a6cbe25bb35d2451abb4f"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.b10.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.a11.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.b11.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.a12.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.b12.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.a13.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.b13.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.a14.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.b14.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.a15.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mplonk_log14.b15.json"
+    ]
+  }
+}

--- a/autoresearch/submissions/2026-07-21-bounded-m31-reduction-cpu-metal/verdict-core_metal-small.json
+++ b/autoresearch/submissions/2026-07-21-bounded-m31-reduction-cpu-metal/verdict-core_metal-small.json
@@ -1,0 +1,177 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "becd88e4944a",
+  "repo_commit": "a16249f27872",
+  "predecessor_commit": "9efa1dba0714",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_metal",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 4.61
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "anchor not frozen; drift budget inactive; request ratio 0.9678 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "mwf_log10x8": {
+        "r": 0.965743,
+        "ci": [
+          0.944044,
+          0.987941
+        ],
+        "rounds": 15,
+        "a_median_ms": 2.505917,
+        "b_median_ms": 2.436791
+      }
+    },
+    "R_geomean": 0.965743,
+    "theta": 0.01,
+    "aa_dispersion": null,
+    "significant": true,
+    "neutral": false
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "mwf_log10x8",
+      "verified": true,
+      "artifact_sha256": "6a2250b56d5e10b6385e3a0f617ef4cee001b5279fd3bbef404a5ccb58ccd7ce"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "mwf_log10x8": {
+        "round_ratios": [
+          0.75515,
+          1.06038,
+          0.943461,
+          1.001248,
+          0.966317,
+          1.013356,
+          1.01033,
+          0.97164,
+          0.965551,
+          0.9564,
+          0.956385,
+          0.923704,
+          0.978396,
+          0.923549,
+          0.958881
+        ],
+        "proof_digest": "91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700",
+        "request_ratio": 0.967833,
+        "report_sha256s": [
+          "ccec61a66ad27320f7524edb66ed864093a1113f8a77fa55b279bfb51d932085",
+          "46aa3bafbc5aeb2a77b2340f22f34d65072739e64792ab297364a93a02344e4d",
+          "376b49ad35a74e13caec82d9277aa86ffb5a3b3938f57f6278299b2dc8720d84",
+          "952bb9643f09b60ef624aaa5ff82e705bdc1853b563c66cd6b127c376821282f",
+          "fb4f8380e0e83776621ba18fbc2bc2215dd3cf2128146ba75e50b873713dae0d",
+          "5e89234a92f0bc53454202c6c3e1d7f13946ee5e697f9f06ad91d346e30bb3c2",
+          "bb9802dadfdd3c697be8015c2fc2d885290d8e0b863d308630de29210da29322",
+          "3a31503d646d7844e12ae3750bbf8c3f852b1e12ef956159271b338d0987d701",
+          "7e772c4b1f5ee97b519aa533346632499bea6c2eb869e70e2ec2cc5908edc1cc",
+          "111d04ef2169eb5fb32b489619551b4f3a95f3b965d7d01bd818a796a2faaa5f",
+          "f79d7c091ccc0e30d434680fd171daa0ef1ae4443bff95816c8b4f85f7ad2db1",
+          "c0ebb35c5698135d1cf1ba6d68e7095e6005a5b9f74bbdf85bde34c48b7142c0",
+          "d29794473b71258a92aaa3ef3f0e70afb87c4d887b713a4146d5f8458a975fee",
+          "b9bc54bff15986c61544ac6212f31c11997b38dc2e8f36527fb54641b7fc0408",
+          "5dc0fe6dc716f7c519b0bdee3f05a18b59211d861829480343d275cb8d85228f",
+          "af9dfd459935a555173d982ad856fd00a598b74e4f3836bf3bae85cedbedfb26",
+          "c4a21f76591c9792d11cd7785a9cd2517774e65074840e0ddb901674b0885794",
+          "e405209f9bc9f37acc90dd1e947c7a56d372c5df73911a52082a80c94bc2f25c",
+          "369286ba1b67beab6ca2b3cae462caaccde5b04bc478f6bccb3d3ee476bd6834",
+          "68e360dc69afa439ef8f7152d1fb4bcf38f132fa95065880b497e96dcd8625c1",
+          "930f26a73fced654b23fd6b3e2ecadbbb5b1dedd92a4fb62a53f58bc7a14343c",
+          "2807a2fc0e5eef61f8a512742bad406f1a22297b7fab7fa98e5c05039f470224",
+          "bdaefd33dbb378bf9e568844b498447680342ac6ec70a4dcb8c4d320a224d165",
+          "3749afa8b2046bf56590a094bf0cea6e647f19fc0fb4839992e46ecb738083dd",
+          "543abf4391bdde857c86a7ba7c8a570ef7c0efaf4cc84622d875b8e882bdb2b2",
+          "04d84118633426ef2fbbf706e25c41ec4bf725a342583fc7eea14e470bcb43f3",
+          "3e24408bf2b11f467dffeecf6151bb55fe4f7d54fbb969b5a3f08fc60824710f",
+          "99977f80301194826800903179fe741121c9822e98f0bca58915227f7e801805",
+          "5d390be5e4f003f26cd5efbfadde3933fe1dd5e2f91bc365499eb24c7c45e5a8",
+          "b9a90332fbbb7e0d554403287052102e294872b428ba83b00ab8379efb09ef77"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.b10.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.a11.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.b11.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.a12.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.b12.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.a13.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.b13.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.a14.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.b14.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.a15.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log10x8.b15.json"
+    ]
+  }
+}

--- a/autoresearch/submissions/2026-07-21-bounded-m31-reduction-cpu-metal/verdict-deep.json
+++ b/autoresearch/submissions/2026-07-21-bounded-m31-reduction-cpu-metal/verdict-deep.json
@@ -1,0 +1,177 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "becd88e4944a",
+  "repo_commit": "a16249f27872",
+  "predecessor_commit": "9efa1dba0714",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 4.92
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.4365 vs targeted budget x1.02; request ratio 0.9460 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "plonk_log14": {
+        "r": 0.943371,
+        "ci": [
+          0.923037,
+          0.95513
+        ],
+        "rounds": 15,
+        "a_median_ms": 6.6915,
+        "b_median_ms": 6.292166
+      }
+    },
+    "R_geomean": 0.943371,
+    "theta": 0.018278,
+    "aa_dispersion": 0.009139,
+    "significant": true,
+    "neutral": false
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "plonk_log14",
+      "verified": true,
+      "artifact_sha256": "ed64ff803f2e7ec8c5eeb81f520ee3cb228c6811795a53137092a8632f9e5e68"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "plonk_log14": {
+        "round_ratios": [
+          0.951301,
+          0.943859,
+          1.003036,
+          0.963886,
+          0.960579,
+          0.887237,
+          0.906545,
+          0.93719,
+          0.958959,
+          0.956921,
+          0.939648,
+          0.953058,
+          0.916908,
+          0.939413,
+          0.882731
+        ],
+        "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf",
+        "request_ratio": 0.94599,
+        "report_sha256s": [
+          "a57034c2f210a93cbb58aa7dc2377ae2bed02ef614f81bae850adc47c9bc28c8",
+          "b101367e3d5bd9695638ce967aad3edc720fa5937dcbabc5b0b89834930ee894",
+          "9606251f361edd53190d79d44ba53278a214bdfd8dbee98fcbdfbc442e680e88",
+          "6e16c6473f90342585d33da59cf0ed93df367fbaabec2dcb02349113bf8248ba",
+          "ee7c03c30aef8c2b61b97c83c8f349c00537b90331d5f79c6d9493220d06044d",
+          "60e74fa9a28f6a42c57ff08d5884884697c7186581a6c971ac5ed0f28b7c2e61",
+          "76018a17119b546ba99d334f3a1ba57ff8e592c4a630501a25218f31d074520e",
+          "f2549d028ec6aaa9747665f7bc5c01814f24eb50018ba87a786404e8b89ad8c0",
+          "a929b5ca70df2cc102ac73bdba2bd44d694618e033e53427e516d6f39c84f00e",
+          "b36940c5d4a8b9cdde9b6bbbda81d2457c84437229fd7e53952bd5299ed66d3c",
+          "9b4bc7a265137bef58f5ef284a74d29baed6af7173b1a76f7213b892bbe98e59",
+          "fe28ddfe9c0ebfbb7e50c34e1cf30bbb4a6a212dfae4842126ffd42cf3890d4d",
+          "0afffc710f53abe336507476ce37b3f89d7cdd94dff851c3c016ee0682d76081",
+          "fbada92cd4e2552e69474be156be981cee650618760319d8c7051fbd8f5983c5",
+          "865c2b13402b7c3c17e1617d8fa0aa49c25829c0ef0a6ef762b9744b1dd3d0a0",
+          "f457cec6883673cf7402a6120eca3ba626bdc783e9f3ae1556059614ed4b7f66",
+          "1c817f349cb492792fe14725985c9ea633fdcacab9891621881ce2f8dca6fa58",
+          "0a71bf7a24a1f058758cd61528c1c3332886c1218bc4674c91798618b8fead3c",
+          "5995526d9e443251a5874a99bb56de164492ae7dd53185e0589db6f225cb500f",
+          "06a5faa569a7bf0f699363389c45fe67c534bbfa08b57fcde655d9fe94dfaca8",
+          "97b63516eee82a0c08a3f8c8cf529ff39606deba4222959e73871c8f17db3b50",
+          "6a09858a4c63b8fbbb082c190ef0f80132619301ae44d8ae9234d930cb238aae",
+          "dc79a7496ce3a89082ba3221c60311cc1c371610fd0113b8241abcdebd876b30",
+          "573ede6296327b6691d3f3bc24f5f5062726d1a2baf978c72bcda6f71a892cad",
+          "d0ba3205a96b91e7b6f8d8f654c3109b76f90a97488f556dc4d6b8df0ae43dd7",
+          "82bc0be7a6cf6e0b75481f401d1026e8d96419eb330c4392e06328b260574787",
+          "1128f13d019ce09224a7348bfb41368b62ca6c499ec7e823d2d8e6597e14d5e4",
+          "dbcfd238e6112469e9d1427db10a77fbd8a351607cb9a0d821fa78cb47858d69",
+          "23be2cf905b7d226dc972124244f146533899e715fdf8b86dae756f737e5c802",
+          "85d2cd2ead3bcc2e130b11834e80aa21c9bf2a6ef9449a3eb937ba36ba84603d"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.b10.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.a11.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.b11.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.a12.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.b12.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.a13.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.b13.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.a14.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.b14.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.a15.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/plonk_log14.b15.json"
+    ]
+  }
+}

--- a/autoresearch/submissions/2026-07-21-bounded-m31-reduction-cpu-metal/verdict-small.json
+++ b/autoresearch/submissions/2026-07-21-bounded-m31-reduction-cpu-metal/verdict-small.json
@@ -1,0 +1,177 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "becd88e4944a",
+  "repo_commit": "a16249f27872",
+  "predecessor_commit": "9efa1dba0714",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 4.75
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.5083 vs targeted budget x1.02; request ratio 0.9477 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log10x8": {
+        "r": 0.936051,
+        "ci": [
+          0.90739,
+          0.959173
+        ],
+        "rounds": 15,
+        "a_median_ms": 1.511209,
+        "b_median_ms": 1.417666
+      }
+    },
+    "R_geomean": 0.936051,
+    "theta": 0.037308,
+    "aa_dispersion": 0.018654,
+    "significant": true,
+    "neutral": false
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "wf_log10x8",
+      "verified": true,
+      "artifact_sha256": "6a2250b56d5e10b6385e3a0f617ef4cee001b5279fd3bbef404a5ccb58ccd7ce"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "wf_log10x8": {
+        "round_ratios": [
+          0.987798,
+          0.845472,
+          0.903841,
+          0.989968,
+          0.927651,
+          0.995881,
+          0.964551,
+          0.891476,
+          0.899263,
+          0.956106,
+          0.939088,
+          0.933655,
+          0.979985,
+          0.894895,
+          0.905217
+        ],
+        "proof_digest": "91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700",
+        "request_ratio": 0.947688,
+        "report_sha256s": [
+          "69098c0837faffcb5f177068bdc82a1a910c7d42f7ff73064fcb27f50a57a14f",
+          "ec1c45648040a9a44ba9845d708f6896c77fb9c759d7cbbc10d5fc2a48724d56",
+          "df1e39f9ebc779305d041a6653dfef8aacdf13d1be4f29e978e7e7d326c88237",
+          "6bd2207efbe271dd873e97a3c12f2096fadc5040cb76e33bac0c3b3a3c7462d2",
+          "cc84b9a0ec69211eb444c1352a835ce19a192f5e07fb96118f1b09297298ce41",
+          "40b3867a6dce0f5719f5d1f210ae4c4fae50c7f1b56c725b799d4079b706bbf6",
+          "92c3f4dd1b47637a5f9d22f5133043a93c818e7ba9689b1b4368ee71bb62b854",
+          "2454fc726649f42ed2d6e1f932c09420dca342e2ed347fa801d3a2bf0643e113",
+          "2b503309316ee1b57693768cfc9f6b51d5961f6f0c7f304b3720b737d02423cb",
+          "6da90abb180959672d744c706c0765dbf733d16ea935e047a0cc14dcecef974c",
+          "a18b620b29a25d2cb64a3cbdcb1f49362b8d4fab1f91ca13f9bc6aead813fb60",
+          "f464843750cbe1189dd6627b1bb3dd3bd571e1ca90285a6b49d4ca2ab3dd395e",
+          "96d4e5b63609083c9de80ae4129de485f40a010af3da07a188cf105ad2b89753",
+          "b5d7b4c8f802ae54cb3e05385d95bcd9747081967ce3bda05114a7de8e7f7aa2",
+          "de59d43294c25aa9e0bdc866ee515626a58a89bff981f7d473b170ef6b0c50c1",
+          "8c4744d93bfd2264d69969cb7ec9ec97df2ca947ad914c5e1b0f0237eed185b3",
+          "7b34c6beb04085cbcc4a4fd21430fa52dcd2cc92e99fb1fdf4ee183909edc0c1",
+          "1099f5b9c4c48da59ef9b4c628ce8a8f5fddd0d6a1c57a9fb6489fc01ad684c2",
+          "89e4b02babde7208d53226f0ea6eb1e00e99defdadc460b843fd4c3a3582dc5e",
+          "9e82bcc3ec3f59613cbd630cf4a85960efca4b86fa2d3c91cf0b5901bfef0db9",
+          "9b7127ee8e8c0a81bd244fceab3868ef57ce390dac374d6be8b6404439e774f8",
+          "2aaadbebff3d0c677780d832ff450d60ae663039e8874555e0aca50bb6cdbd9f",
+          "c079f3c350a7ee5b45cf446a39492947d5717ccef379f5f38fe953854f9ad2ae",
+          "6206b092dca932011c6f50c32cd506c9de984ee25e19d801c8b68edefa031ef3",
+          "6c2457a0b674049fc0d138d5df2a2d5d213d266ca3829677722d3ae683706a7a",
+          "b0a07f940ebff9e793dd55e54ea2f6cdc61fc5bf8f7b008f8b0ff0828a8a86db",
+          "a0e678dd864c07ffd5cd73b303b23a1f2b337e957812771c1351676a9d98fa7d",
+          "3f5fb8bed138c327c7c52d97121459708b3431e12cb4e5e38c6afbe65cf41aee",
+          "b6e4a967d7b7449ef5297d2e12d5ab52f382b41ab25eb87f57c63581d4950881",
+          "cf8e57b5cee72d22ac752c94157f12494e5ef4cff765cb21670c92fb7647496b"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.b10.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.a11.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.b11.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.a12.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.b12.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.a13.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.b13.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.a14.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.b14.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.a15.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log10x8.b15.json"
+    ]
+  }
+}

--- a/autoresearch/submissions/2026-07-21-bounded-m31-reduction-cpu-metal/verdict-wide.json
+++ b/autoresearch/submissions/2026-07-21-bounded-m31-reduction-cpu-metal/verdict-wide.json
@@ -1,0 +1,177 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "becd88e4944a",
+  "repo_commit": "a16249f27872",
+  "predecessor_commit": "9efa1dba0714",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "wide",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 6.05
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.5471 vs targeted budget x1.02; request ratio 0.9155 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log14x32": {
+        "r": 0.923793,
+        "ci": [
+          0.909715,
+          0.947753
+        ],
+        "rounds": 15,
+        "a_median_ms": 10.344041,
+        "b_median_ms": 9.66025
+      }
+    },
+    "R_geomean": 0.923793,
+    "theta": 0.02929,
+    "aa_dispersion": 0.014645,
+    "significant": true,
+    "neutral": false
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "wf_log14x32",
+      "verified": true,
+      "artifact_sha256": "d32393fe3b1f9abbc4795d87c3b3316e06111f014ec30f0635f13ec0ff0587f9"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "wf_log14x32": {
+        "round_ratios": [
+          0.92361,
+          0.879753,
+          0.89911,
+          0.933895,
+          0.92215,
+          0.913234,
+          0.941466,
+          0.872588,
+          0.913591,
+          0.945752,
+          1.014414,
+          1.000397,
+          0.918991,
+          0.937428,
+          0.91026
+        ],
+        "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374",
+        "request_ratio": 0.915524,
+        "report_sha256s": [
+          "ba27e23be385c4e57589c55c060665921b548252114a0c3dd467e006ff4f38a9",
+          "a3b0f2b28985e65b4cd0a75db3855e1e1a158c3cb34e4788db40366288750289",
+          "2a324011de50ceffc2bbcefc45eebfe1dd3a113ccf8325ce6904033fa83d15a2",
+          "730daf021700e8a3c17cfb37ad1b6dcea999099917cee41472d31c180d5c26c7",
+          "8764ef82cee8a9a860db0d4c4b0104e52d9249d2e2892ddc738eef30249ee3c8",
+          "b32593b6e43f88aae4ae37145c2dd10ae65ef542ddb5d9456a154b029f76fa18",
+          "65c21ab5dc158dd91beb402b2295de218a7460399efd18f164e31ebafa201b2d",
+          "88c6911fe946595ff7e7156670de89d8e927e8a6b05a3381c2ac39d969c2f138",
+          "75f2b585cc3ab119267bc58b3ca5b8f31a25e269126ddb57dd89d4c758987a7a",
+          "2a7171264421e470e385d23430bdf9c006de7b2f9ba9a36960d5b35183f75414",
+          "445babaa5c866b20bb7a67cdcabb62ae2d20e8fab31a88112e287f06aa18f173",
+          "91826284479416890079f1d1d355829c2450becfcedb3c5d2134be138ab14501",
+          "ad6ed87a18a6c2f79d6f5b3c92ca8a0eb1fd812f004656617a581fcbef4cf8ca",
+          "732ccc7a06232a13d7e5551cb7423e3af83eb9866f8d7567eccf4afedf5f90b8",
+          "577c3eeb4a44576f9ae5bc0d95f46b96976e0fc07cef727a42da7e2d601fc782",
+          "9c66c6d2c2c9ff4bd241b5bdbce54b7ae8d5ed86609ab22d9cc5f78a7f7dd7b7",
+          "3599749ee76c9522ea2d8e6b6e5f7237836863d669e13b50816510a7d0dca66b",
+          "f8b6ed688b4db775935844e455d7feba1a9092cf54e62b94d2fc39caf0d37ddd",
+          "3f04d1f837cd63e5c81f612cbfeb4b41d2699ac0fa08942eac0586a884d91ac9",
+          "f821da4f95c0d34e569ac323482c2ebd88cb25c8749a7be1ee37a07839f60968",
+          "0aac85e481308c6533d26fb8cd3de11bbf0a9423ff8ae257b438186e42ed555c",
+          "d6e8556d61ee48264efac669415b23739f5d50c49f228cbe5e131adb3054e3ea",
+          "925dc90a797885d1b4b5781ba976f08cc1ba691c4b3603d7db6536c4f3d3a5eb",
+          "4f11d254021b92e584bc51837cf3bd8d225ab59f52622c4204686f219ee7977f",
+          "99cc97a3779a2cf8d933e8cbc22abd9593b3b2b01e81f94ddba7f270eccfc47a",
+          "09fb18ab4cdfe54d9d5810becd522f130d28ade9c5ba3acfc71f38ccd46b3e08",
+          "cff6ab5b702525dbbab307c6e886f632df3461a0e3fce720a3c1b8de6e693d03",
+          "d1b4d69244d436bd5a0978f7f2464b4b83bfae859fe501f0406f72934c415f53",
+          "0a5646a176b5ee894588a21554b1f1184b16d2e8bef554058987a8ceb79f4114",
+          "5e327a8acde4605c11d550a4e89d47aab984078052fac82d71d6fd3683546f01"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.b10.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.a11.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.b11.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.a12.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.b12.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.a13.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.b13.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.a14.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.b14.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.a15.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/wf_log14x32.b15.json"
+    ]
+  }
+}

--- a/autoresearch/submissions/2026-07-21-bounded-m31-reduction-cpu-metal/verdict.json
+++ b/autoresearch/submissions/2026-07-21-bounded-m31-reduction-cpu-metal/verdict.json
@@ -1,0 +1,177 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "becd88e4944a",
+  "repo_commit": "a16249f27872",
+  "predecessor_commit": "9efa1dba0714",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_metal",
+    "workload_class": "wide",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 5.87
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "anchor not frozen; drift budget inactive; request ratio 0.8565 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "mwf_log14x32": {
+        "r": 0.866114,
+        "ci": [
+          0.844814,
+          0.883687
+        ],
+        "rounds": 15,
+        "a_median_ms": 8.911667,
+        "b_median_ms": 7.814709
+      }
+    },
+    "R_geomean": 0.866114,
+    "theta": 0.01,
+    "aa_dispersion": null,
+    "significant": true,
+    "neutral": false
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "mwf_log14x32",
+      "verified": true,
+      "artifact_sha256": "d32393fe3b1f9abbc4795d87c3b3316e06111f014ec30f0635f13ec0ff0587f9"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "mwf_log14x32": {
+        "round_ratios": [
+          0.933834,
+          0.854506,
+          0.87586,
+          0.86105,
+          0.853809,
+          0.866324,
+          0.866949,
+          0.911085,
+          0.883687,
+          0.902345,
+          0.860006,
+          0.8773,
+          0.805942,
+          0.844259,
+          0.737722
+        ],
+        "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374",
+        "request_ratio": 0.856497,
+        "report_sha256s": [
+          "b5f20600262ab2bef2b9583662ef29e1fb3d2a2fa76a03e50e933fce6fe9d985",
+          "809c2deb08a74bab35637ecfbffc6ba9cb1ce3c900e315d0d7ed48cb75636563",
+          "16287ef39ccde812a6c89990f3908435dc93f3b0574ede2f3dff59169f2ca43a",
+          "3552f0d58ce766a805c55b43b578e9e265706ece92640f34e2ff0ac94862796b",
+          "2add27332a1c8de5a58b9581ce7b6aebe025583ead2fd87906dc19d517efa306",
+          "35130f4040f1df79f933724595b70fe15afa7d6a044417f580ec4d53981f3413",
+          "5c472784f02b2342c0ae607a8183035b91d73d225894a022b51fdba237e06883",
+          "dc0a60fa79af60d397aca4fd054e7a5344077833fcd0f878063921e91cc6810e",
+          "1d21479069f5707804581da059145288cc01ff2f14f999625a3d5caf854616c1",
+          "f98b95a987e68808d55f79c9bb6c9e6bc827a323540ddfe7e8e8c36791a75db5",
+          "284f252e0a0ea08ef2f871972d773f5934896f6572cdcbc6f4dc81f8326c631f",
+          "3d30d2a33aae0b1bc4fb80be167b72d76feaad30d0e064f1ad72d5b34a080d50",
+          "a3b815dfd46d2391ee9e8a50be3873a908ce3348398fca0399e3ec08f1fe6986",
+          "4203820cb3f3105fb89745c5392d313ae2893634a40c2eced16a066bd1b44a6e",
+          "706a7106b3f32212f0081e75d5a33381d58bb4e723dc66f42d675e2d8647f417",
+          "2676ae25a7fb0ec0926fdba5e1cc148d7fe5121b38cdfd2b74eb2aa8f83d94b1",
+          "7331188ea321bfffffd21d1f2d5f549368493476532b231e0f11c2264d2d73b4",
+          "e2f1a3ecbf4c81d2a45b02341dcef6c27af0357954f9e366f6fd562a9d451956",
+          "bc51716f889edf333f85d2dca4ce2a17770bc75ec0864c706454f356b1cf5264",
+          "2a08d2d9483a1763500ae94baa3e3db826b816a1dc3227a1dd7097f31d7a902d",
+          "ed93d5b9e9838fd4837d5be6cc207d47bd105a804289a8ecc8d2c4a5c69e93e4",
+          "c217c9673dbe4dfbd8227cbba173aa2e8bcbb78470d113c1b191a3fa6383cebe",
+          "4443fb322e27e07a00eeadf3f384dae3c3ee4914ddaecb4dddb6f0072b42f892",
+          "7f055e070ea65a71f279570a33c86e095e8bc10440458face8f771f65dd751db",
+          "359ce6e228a579bc5898ebf1a0b07741f504397ead3cd9879029f378392880e1",
+          "a09d88079eedf4d0a7019a97aa1c68310615ba466cabd7d8ac25655f0bbac71c",
+          "5148070afa975d67726a827957ccc0558f0ed2a664da084a22585ddd9eb2fced",
+          "092306b54d0063be83f7ceaf3e0291d0b9cf6924c680dda2fc39c4ef978b4731",
+          "88c079b48d814de0983ae56f15ed1646a323558a7fdb63c930902f919aed4b41",
+          "dd6e975711bd76d7e98eb57f4c8918838464721ec13a58f2bedb87ec153d7af3"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.b10.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.a11.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.b11.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.a12.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.b12.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.a13.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.b13.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.a14.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.b14.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.a15.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-02-current/autoresearch/.runs/latest/mwf_log14x32.b15.json"
+    ]
+  }
+}

--- a/src/backends/metal/shaders/include/m31.metal
+++ b/src/backends/metal/shaders/include/m31.metal
@@ -12,9 +12,20 @@ inline uint m31_reduce(ulong value) {
     return result >= 0x7fffffffu ? result - 0x7fffffffu : result;
 }
 
-inline uint m31_add(uint lhs, uint rhs) { return m31_reduce((ulong)lhs + rhs); }
+// Canonical operands sum to less than 2p, so addition needs no 64-bit fold.
+inline uint m31_add(uint lhs, uint rhs) {
+    uint sum = lhs + rhs;
+    return sum >= 0x7fffffffu ? sum - 0x7fffffffu : sum;
+}
 inline uint m31_sub(uint lhs, uint rhs) { return lhs >= rhs ? lhs - rhs : lhs + 0x7fffffffu - rhs; }
-inline uint m31_mul(uint lhs, uint rhs) { return m31_reduce((ulong)lhs * rhs); }
+// A product of canonical operands is below p^2. One Mersenne fold is then
+// below 2p, and one conditional subtraction produces the canonical residue.
+inline uint m31_mul(uint lhs, uint rhs) {
+    ulong product = (ulong)lhs * rhs;
+    ulong folded = (product & 0x7ffffffful) + (product >> 31u);
+    uint result = (uint)folded;
+    return result >= 0x7fffffffu ? result - 0x7fffffffu : result;
+}
 inline uint m31_neg(uint value) { return value == 0u ? 0u : 0x7fffffffu - value; }
 
 inline uint m31_inv(uint value) {

--- a/src/core/fields/m31.zig
+++ b/src/core/fields/m31.zig
@@ -69,7 +69,7 @@ pub const M31 = struct {
 
     pub inline fn mul(a: M31, b: M31) M31 {
         const prod: u64 = @as(u64, a.v) * @as(u64, b.v);
-        return .{ .v = reduce64(prod) };
+        return .{ .v = reduceProduct(prod) };
     }
 
     pub inline fn square(a: M31) M31 {
@@ -160,6 +160,16 @@ fn reduce64(x: u64) u32 {
     return r;
 }
 
+/// Reduce a product of two canonical M31 values. Unlike `reduce64`, the input
+/// is strictly below p^2, so one Mersenne fold lands below 2p and a single
+/// conditional subtraction canonicalizes it.
+inline fn reduceProduct(x: u64) u32 {
+    const p: u64 = Modulus;
+    const folded = (x & p) + (x >> 31);
+    const r: u32 = @intCast(folded);
+    return if (r >= Modulus) r - Modulus else r;
+}
+
 // ---------------------------------------------------------------
 // SIMD vectorized M31 operations (4-lane)
 // ---------------------------------------------------------------
@@ -203,7 +213,15 @@ pub inline fn mulVec4(a: Vec4u32, b: Vec4u32) Vec4u32 {
     const a64: Vec4u64 = a;
     const b64: Vec4u64 = b;
     const prod = a64 * b64;
-    return reduceVec4(prod);
+    return reduceProductVec4(prod);
+}
+
+/// Vector form of `reduceProduct`; every lane is a canonical product.
+inline fn reduceProductVec4(x: Vec4u64) Vec4u32 {
+    const p64: Vec4u64 = @splat(@as(u64, Modulus));
+    const folded = (x & p64) + (x >> @splat(@as(u6, 31)));
+    const r: Vec4u32 = @truncate(folded);
+    return @select(u32, r >= P_VEC, r -% P_VEC, r);
 }
 
 /// Vectorized Mersenne reduction: x mod (2^31 - 1), 4 lanes.
@@ -297,7 +315,15 @@ pub inline fn mulPacked(a: PackedM31, b: PackedM31) PackedM31 {
     const a64: PackedU64 = a;
     const b64: PackedU64 = b;
     const prod = a64 * b64;
-    return reducePacked(prod);
+    return reduceProductPacked(prod);
+}
+
+/// Native-width form of `reduceProduct`; every lane is a canonical product.
+inline fn reduceProductPacked(x: PackedU64) PackedM31 {
+    const p64: PackedU64 = @splat(@as(u64, Modulus));
+    const folded = (x & p64) + (x >> @splat(@as(u6, 31)));
+    const r: PackedM31 = @truncate(folded);
+    return @select(u32, r >= P_PACKED, r -% P_PACKED, r);
 }
 
 /// Packed M31 negation.
@@ -367,6 +393,47 @@ fn powPMinus2(a: M31) M31 {
         }
     }
     return acc;
+}
+
+test "m31: bounded product reduction matches generic reduction" {
+    const edge = [_]u32{ 0, 1, 2, Modulus / 2, Modulus - 2, Modulus - 1 };
+    for (edge) |a| {
+        for (edge) |b| {
+            const product = @as(u64, a) * @as(u64, b);
+            try std.testing.expectEqual(reduce64(product), reduceProduct(product));
+        }
+    }
+
+    var prng = std.Random.DefaultPrng.init(0xd05e_31f0_1d5f_0a57);
+    const random = prng.random();
+    for (0..4096) |_| {
+        const a = random.intRangeLessThan(u32, 0, Modulus);
+        const b = random.intRangeLessThan(u32, 0, Modulus);
+        const product = @as(u64, a) * @as(u64, b);
+        try std.testing.expectEqual(reduce64(product), reduceProduct(product));
+    }
+
+    var lhs4: [VEC_WIDTH]u32 = undefined;
+    var rhs4: [VEC_WIDTH]u32 = undefined;
+    for (&lhs4, &rhs4) |*a, *b| {
+        a.* = random.intRangeLessThan(u32, 0, Modulus);
+        b.* = random.intRangeLessThan(u32, 0, Modulus);
+    }
+    const result4: [VEC_WIDTH]u32 = mulVec4(lhs4, rhs4);
+    for (lhs4, rhs4, result4) |a, b, result| {
+        try std.testing.expectEqual(reduceProduct(@as(u64, a) * b), result);
+    }
+
+    var lhs_packed: [PACK_WIDTH]u32 = undefined;
+    var rhs_packed: [PACK_WIDTH]u32 = undefined;
+    for (&lhs_packed, &rhs_packed) |*a, *b| {
+        a.* = random.intRangeLessThan(u32, 0, Modulus);
+        b.* = random.intRangeLessThan(u32, 0, Modulus);
+    }
+    const packed_result: [PACK_WIDTH]u32 = mulPacked(lhs_packed, rhs_packed);
+    for (lhs_packed, rhs_packed, packed_result) |a, b, result| {
+        try std.testing.expectEqual(reduceProduct(@as(u64, a) * b), result);
+    }
 }
 
 test "m31: packed reduction edge cases" {


### PR DESCRIPTION
Specialize M31 addition/multiplication for their proven canonical operand bounds on both native CPU and Metal. Generic arbitrary-u64 reduction remains unchanged; the fast path removes one Mersenne fold from canonical products and all 64-bit folding from canonical Metal addition.

All six S3 time claims are significant against 9efa1dba:
- CPU small R=0.936051, CI [0.907390, 0.959173]
- Metal small R=0.965743, CI [0.944044, 0.987941]
- CPU wide R=0.923793, CI [0.909715, 0.947753]
- Metal wide R=0.866114, CI [0.844814, 0.883687]
- CPU deep R=0.943371, CI [0.923037, 0.955130]
- Metal deep R=0.960649, CI [0.919915, 0.980512]

Every verdict passes G1-G5 and the pinned Rust oracle with byte-identical cross-arm proofs. Core/prover/native CPU/device-only Metal/AOT tests pass. The one broad resident-FRI Metal failure reproduces unchanged on the predecessor and is documented in the note/transcript.