### PR TITLE
Vectorize QM31 base multiplication on CPU and Metal

### DIFF
--- a/autoresearch/submissions/2026-07-21-qm31-direct-lane-base-multiply-cpu-metal/delta.json
+++ b/autoresearch/submissions/2026-07-21-qm31-direct-lane-base-multiply-cpu-metal/delta.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "1c3f3ca758d1",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "wide",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/core/fields/qm31.zig": "sha256:5c546b9e274660d85e32c983f099a687781b77f5c959a7a9cf571ec21c5bc3e0"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "5e8066ad282804965f71f683f2ca94a87cfaa61ad9c698256f7de3f9bf23907f",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-21-qm31-direct-lane-base-multiply-cpu-metal/note.md
+++ b/autoresearch/submissions/2026-07-21-qm31-direct-lane-base-multiply-cpu-metal/note.md
@@ -1,0 +1,81 @@
+# Vectorize QM31 base multiplication without aggregate copies
+
+## Model and harness
+
+GPT-5 Codex developed and measured candidate `aa7d76d222f7` against corrected
+predecessor `1c3f3ca758d1` with the repository's pinned `stwo-perf` harness at
+`6f3edb9c3f99`. The canonical CLI was updated before the iteration, and remote
+main was checked again before packaging. Native CPU and Native Metal
+source-JIT products were built in ReleaseFast mode on an Apple M5 Max. Metal
+used the macOS runtime compiler for the embedded MSL and reported zero CPU
+fallback.
+
+## Hypothesis
+
+The upstream proof-correctness repair intentionally replaced QM31's generic
+four-coordinate vector conversions with scalar CM31 operations because Zig
+0.15.2 can miscompile optimized by-value aggregate copies. Fresh profiles
+showed that this made the shared wide-Fibonacci composition stage the dominant
+host bottleneck: about 4.63 ms in the CPU product and 5.13 ms in the Metal
+product.
+
+Every coordinate of `QM31.mulM31` is an independent canonical M31 product by
+the same base-field scalar. Loading the four scalar fields directly inside the
+consuming operation should recover NEON execution without creating the unsafe
+`QM31 -> helper -> vector` aggregate copy. Generic QM31 add/sub and all
+full-extension multiplication remain on the corrected scalar implementation.
+
+## Changes
+
+`QM31.mulM31` now constructs one `Vec4u32` directly from
+`c0.a`, `c0.b`, `c1.a`, and `c1.b`, calls the existing bounded
+`m31.mulVec4` with a splatted base-field operand, and reconstructs the canonical
+QM31 result from the four output lanes. No helper accepts a QM31 aggregate by
+value. No field-operation order, representation, ABI, proof format, shader,
+pipeline, resource, command buffer, dispatch, or synchronization behavior
+changes.
+
+The resulting dataflow is:
+
+```text
+four canonical QM31 limbs --direct field loads--> Vec4u32
+                                                   |
+base M31 scalar ------------------------------- splat + mulVec4
+                                                   |
+four canonical products <------------------ direct lane extraction
+```
+
+ReleaseFast disassembly of the live wide-Fibonacci evaluator contains the
+expected `umull.2d`, `umull2.2d`, and `uzp1.4s` sequence. Diagnostic stage
+medians fell from approximately 4.63 to 2.21 ms on CPU and 5.13 to 2.05 ms in
+the Metal product.
+
+## Results
+
+Both paired S3 wide/time verdicts are significant and pass G1-G5:
+
+| board | A median | B median | ratio | 95% CI | request ratio |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| CPU | 11.815 ms | 9.341 ms | 0.7911 | [0.7824, 0.8030] | 0.8062 |
+| Metal | 10.823 ms | 8.096 ms | 0.7598 | [0.7396, 0.7813] | 0.7742 |
+
+This is about 20.9% less CPU prove time and 24.0% less Metal-product prove
+time from one shared host-field mechanism. Both runs pass all 12 impact-mapped
+regression guards and the pinned Rust oracle. Every timed proof verifies,
+cross-arm proofs remain byte-identical, and wide's proof SHA-256 is unchanged
+at `57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374`.
+Metal retains 22 high-level dispatches and zero fallback.
+
+The full 356-source ReleaseFast test closure and source-conformance gate pass.
+The upstream log-10 packed high-block subset-basis regressions specifically
+exercise the optimized `mulM31` call pattern and pass.
+
+## Caveats
+
+An exploratory patch also vectorized QM31 add/sub. It did not improve the
+target and one noisy Metal Poseidon guard missed its confidence budget, so that
+broader patch and its verdicts were discarded. The submitted patch contains
+only the multiplication mechanism; its fresh CPU and Metal verdicts pass every
+guard. The gain is largest on wide Fibonacci, whose composition loop performs
+many secure-by-base products. These are submitter measurements; the judge rerun
+remains authoritative.

--- a/autoresearch/submissions/2026-07-21-qm31-direct-lane-base-multiply-cpu-metal/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-21-qm31-direct-lane-base-multiply-cpu-metal/transcripts/session-01.md
@@ -1,0 +1,161 @@
+# Session 01 — corrected QM31 throughput on CPU and Metal
+
+## Objective and corrected frontier
+
+The continuing objective is one source change that materially improves both
+Native CPU and Native Metal, followed immediately by a paired submission and a
+green PR. The user had paused while a proof-correctness failure was repaired on
+main. Work resumed only after that repair landed.
+
+The repository-resident CLI was updated first. Corrected main is
+`1c3f3ca758d11`, containing `a156e71` (restore correct QM31 arithmetic),
+`e694a34` (production-proof gate), and `1c3f3ca` (isolate pre-push tests from
+hook Git state). Full upstream CI for that frontier is green. Clean candidate
+and predecessor worktrees were created at that exact commit and both Native
+CPU and Native Metal ReleaseFast products were rebuilt. A final fetch before
+packaging confirmed that `origin/main` had not moved.
+
+Two pre-existing untracked research notes in the canonical checkout were
+preserved across the update and were not modified.
+
+## Fresh benchmark grounding
+
+Ten verified samples after ten warmups established the post-correctness
+frontier:
+
+| board/class | prove ms | request ms | proof / telemetry |
+| --- | ---: | ---: | --- |
+| CPU small | 1.922 | 2.151 | `91741aec...bea5700` |
+| CPU wide | 11.882 | 12.704 | `57a7d291...0f3374` |
+| CPU deep | 6.263 | 6.602 | `d63a2c92...b69dbaf` |
+| Metal small | 3.428 | 3.649 | 18 dispatches, zero fallback |
+| Metal wide | 10.594 | 11.392 | 22 dispatches, zero fallback |
+| Metal deep | 4.680 | 5.002 | 24 dispatches, zero fallback |
+
+All 60 samples verified and were byte-identical. Metal used embedded MSL
+source JIT through `newLibraryWithSource`; backend initialization and shader
+compilation were outside the timed samples.
+
+The correctness repair produced a useful natural experiment. Relative to the
+previous promoted source, small and wide slowed sharply while deep remained
+nearly flat. The changed code replaced vectorized QM31 add/sub/base-multiply
+with two scalar CM31 operations and removed private QM31-to-Vec4 conversion
+helpers.
+
+## Stage profiles and bottleneck visualization
+
+Five-sample ReleaseFast stage profiles localized nearly the entire wide loss to
+shared host composition evaluation. GPU dispatch counts and the remaining
+Metal stages were stable.
+
+```text
+CPU wide composition       2.23 ms before fix |███████████
+                            4.63 ms corrected  |███████████████████████
+
+Metal wide composition     2.34 ms before fix |████████████
+                            5.13 ms corrected  |██████████████████████████
+
+Other major stages         approximately flat
+```
+
+On the corrected CPU frontier, composition was about 4.6 ms, FRI quotient
+build/commit about 3.0 ms, and main-trace commit about 1.8 ms. On the Metal
+product, composition was about 5.1 ms and had become larger than any GPU-owned
+stage. This established the highest-leverage Metal-product target as a shared
+host field kernel rather than another shader dispatch.
+
+## Architecture search
+
+Three designs were evaluated.
+
+1. Pack independent wide-Fibonacci rows in the example component. This gives a
+   clean structure-of-arrays kernel and avoids aggregate conversion entirely,
+   but `src/examples/**` is outside the editable manifest. Adding a type-shaped
+   special case in the generic component prover would be unsound, so this path
+   was rejected.
+2. Restore the old private `toVec4(self: QM31)` helper. This recovers speed but
+   recreates the exact optimized by-value aggregate copy implicated by the
+   correctness repair. The new log-10 point-evaluation tests exist to cover
+   that failure mode, so this design was rejected without submission.
+3. Extract the four scalar fields directly inside a consuming operation, feed
+   those scalars to the established Vec4 M31 primitive, and reconstruct the
+   result directly from lanes. This retains SIMD while eliminating the
+   intermediate QM31 aggregate-copy helper.
+
+The chosen design is deliberately narrow:
+
+```text
+QM31 lhs (already in caller registers / fields)
+  |-- c0.a.v --\
+  |-- c0.b.v ---+--> Vec4u32 --> bounded mulVec4(rhs splat) --> four lanes
+  |-- c1.a.v ---+                                             | | | |
+  |-- c1.b.v --/                                              v v v v
+  +------------------------------------------------------ canonical QM31
+
+There is no: QM31 by-value copy --> conversion helper --> vector.
+```
+
+The mathematical invariant is simple. For canonical limbs `x_i` and canonical
+base scalar `r`, every output lane is independently
+`reduceProduct(x_i * r)`. The existing scalar `QM31.mulM31` computes the same
+four products through two CM31 calls. Lane order, reduction, and
+canonicalization are unchanged.
+
+## Isolation and narrowing
+
+The first experiment vectorized only `mulM31`. The 152-source prover closure,
+including the new high-block subset-product and evaluation tests, passed in
+ReleaseFast. A quick CPU-wide run moved from about 11.88 to 9.43 ms with the
+exact fixed proof hash. The Metal composition stage moved from about 5.13 to
+2.54 ms with 22 dispatches and zero fallback.
+
+For diagnosis, direct-lane forms of QM31 add and sub were then enabled as well.
+All correctness tests still passed, but they produced no additional target
+gain. The first full Metal verdict on that broader experiment had a strong
+wide objective, R=0.7623, while one noisy Poseidon guard had R=1.0309 with a
+wide confidence interval crossing the 1.05 budget. Regardless of whether that
+guard was noise, generic add/sub broadened the semantic and performance
+surface without reward. Those changes and all verdicts bound to that commit
+were discarded.
+
+The final patch restores scalar add/sub and changes only `mulM31`: 11 inserted
+lines and 3 removed lines in `src/core/fields/qm31.zig`. Its live
+wide-Fibonacci function disassembly contains `umull.2d`, `umull2.2d`, and
+`uzp1.4s`, confirming that the intended four-lane widening survived inlining.
+Fresh profile medians measured composition at 2.21 ms on CPU and 2.05 ms in the
+Metal product.
+
+## Correctness and paired S3 evidence
+
+The final candidate is `aa7d76d222f7`; the untouched paired predecessor is
+`1c3f3ca758d1`; the harness identity is `6f3edb9c3f99`. The full 356-source
+ReleaseFast test closure, formatting, diff checks, and source conformance pass.
+Direct ten-sample CPU/Metal diagnostics retained all three fixed proof hashes,
+verification, byte identity, expected Metal dispatches, and zero fallback.
+
+The final paired S3 wide/time verdicts are:
+
+| board | A median ms | B median ms | R | 95% CI | request R | guards |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| CPU | 11.815 | 9.341 | 0.7911 | [0.7824, 0.8030] | 0.8062 | 12/12 |
+| Metal | 10.823 | 8.096 | 0.7598 | [0.7396, 0.7813] | 0.7742 | 12/12 |
+
+Both pass G1-G5, the pinned Rust oracle, and cross-arm byte identity. The proof
+digest remains
+`57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374`.
+This is a 20.9% CPU prove-time reduction and a 24.0% Metal-product reduction
+from the same corrected shared-field mechanism.
+
+One rerun initially stopped before measurement because the harness tried to
+create an oracle artifact that already existed in its ignored `.runs/latest`
+directory. The stale CPU and Metal oracle artifacts were moved intact to the
+external evidence directory; the final verdicts above were then generated
+fresh and are bound to the final commit.
+
+## Submission boundary
+
+The submission claims exactly CPU-wide and Metal-wide. Small and deep remain
+guards rather than claimed objectives. The patch does not alter MSL, pipeline
+creation, source-JIT/AOT selection, resource ownership, or synchronization;
+the Metal win comes from removing the new dominant host-side stage in the full
+Metal product. Judge reruns remain authoritative.

--- a/autoresearch/submissions/2026-07-21-qm31-direct-lane-base-multiply-cpu-metal/verdict-core_metal-wide.json
+++ b/autoresearch/submissions/2026-07-21-qm31-direct-lane-base-multiply-cpu-metal/verdict-core_metal-wide.json
@@ -1,0 +1,310 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "6f3edb9c3f99",
+  "repo_commit": "aa7d76d222f7",
+  "predecessor_commit": "1c3f3ca758d1",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_metal",
+    "workload_class": "wide",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 2.11
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "anchor not frozen; drift budget inactive; regression guards 12/12 within budget; request ratio 0.7742 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "mwf_log14x32": {
+        "r": 0.759787,
+        "ci": [
+          0.739638,
+          0.781306
+        ],
+        "rounds": 15,
+        "a_median_ms": 10.823375,
+        "b_median_ms": 8.096208
+      }
+    },
+    "R_geomean": 0.759787,
+    "theta": 0.01,
+    "aa_dispersion": null,
+    "significant": true,
+    "neutral": false
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {
+    "guard_blake_10x10": {
+      "r": 1.012443,
+      "ci": [
+        0.998694,
+        1.036728
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "4153acd6e32a98b9d240730062f7fa35e2e31eca915f01c179337f04d409cbd2"
+    },
+    "guard_blake_12x16": {
+      "r": 0.986722,
+      "ci": [
+        0.955453,
+        1.017792
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "70e516957d2d38ed78214bfda5b0b2bdfe41f1c93439fb68e124bfef096fbc9f"
+    },
+    "guard_plonk_14": {
+      "r": 1.012983,
+      "ci": [
+        0.999843,
+        1.018977
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf"
+    },
+    "guard_plonk_16": {
+      "r": 0.999324,
+      "ci": [
+        0.99587,
+        1.009039
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "cfb36bf17fb3526bf1bdd9401fb885fd91ca46b9982fee1ca5fad33a1d574b72"
+    },
+    "guard_poseidon_10": {
+      "r": 0.980378,
+      "ci": [
+        0.974781,
+        0.995962
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "af33240da8e7947362fdf7e78d306f2e11cb2e3df7e1b6f498a6e86ac3ae7b1b"
+    },
+    "guard_poseidon_13": {
+      "r": 0.95019,
+      "ci": [
+        0.930736,
+        0.968487
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "f196835da5d4a155c6311bafb44335c2863cc028879d69a7ae53b802321200f1"
+    },
+    "guard_sm_14": {
+      "r": 1.00591,
+      "ci": [
+        0.977667,
+        1.020706
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "488fadeeb4e5d76b6fc0a9c10ab258bab6673de8e912ae5de927561650920b37"
+    },
+    "guard_sm_16": {
+      "r": 1.013284,
+      "ci": [
+        0.999098,
+        1.028591
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "88ec35ee88a05ce0a5db4b6cb063f4cf7824ee65284db0908a62a9362879af73"
+    },
+    "guard_wf_14x32": {
+      "r": 0.753354,
+      "ci": [
+        0.722597,
+        0.768595
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374"
+    },
+    "guard_wf_16x64": {
+      "r": 0.586864,
+      "ci": [
+        0.577266,
+        0.603917
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "42086545b7a170c5868afcc390f83d964e06d528e2d1039420fc6bfd7a6aac74"
+    },
+    "guard_xor_14": {
+      "r": 0.994047,
+      "ci": [
+        0.982383,
+        1.027666
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "35bb35714e10888c786a71ccdfe31d2b9b4651c567fac5ba4c9543bc247cad80"
+    },
+    "guard_xor_16": {
+      "r": 1.011878,
+      "ci": [
+        1.006199,
+        1.024039
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "56163b8ea3d877b3b9bf15753b7c0175d4a6ead493640eef8210c59ba7e5215c"
+    }
+  },
+  "rust_oracle": [
+    {
+      "workload": "mwf_log14x32",
+      "verified": true,
+      "artifact_sha256": "d32393fe3b1f9abbc4795d87c3b3316e06111f014ec30f0635f13ec0ff0587f9"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "mwf_log14x32": {
+        "round_ratios": [
+          0.832508,
+          0.717825,
+          0.7417,
+          0.765411,
+          0.716294,
+          0.824458,
+          0.724467,
+          0.779543,
+          0.774424,
+          0.771147,
+          0.749623,
+          0.75919,
+          0.830511,
+          0.732101,
+          0.713865
+        ],
+        "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374",
+        "request_ratio": 0.774172,
+        "report_sha256s": [
+          "750a1ee6ef2544daf89e0c59b1e09748513d90403ae7736aef05919d9aedb987",
+          "f5b8bc150990a094903f910409f8aa478fdddc8c3aa854074c64856d54ccc6eb",
+          "a47b31fdb71ea4170b1ea4b3dd585b1201dab5c65b891ced8ffbd2017f723bd8",
+          "75847ed2c9df92511c5b44389b08faf8e9087e8bb7534dbced4396a081b943b5",
+          "368f8e801175e4252247f9502fedb7353facb40d31a7b49ed287a12604bf35b9",
+          "f85eef30964bf8e8c76dc021cba8e11f182a8ffff6e94961a503f4a07dbcddc0",
+          "70f7e986bc950f6b226660ef66cec7e72b925ff3886b92d47f29e6aba75b6af7",
+          "40c9eb2b07e67b39a2fb3d8f807daa4be0e2ed9be272c1e14cb02156dc658053",
+          "2152d65f511e67a4943670da794d61422e74f679075bbbde7244c52cb8e663ca",
+          "970146b2d85ece7b0d2044ba10d640c186cc7dbc0ed306ba746c1dca443cd934",
+          "b8d698ffa3419ac7cc2c8856b2e2030b6f8b5ed99fa53d2cd76a133bc2640c07",
+          "7940d16353119a834041ec8322e93ea08148ec875b1f56099f838f3e7fabfb8f",
+          "5943c5f2a5cc2764c3dd3916c9a8b7bd2fc85096db4b2ff9d58f1fcaf5b645d2",
+          "0d4857ad1fa8c47fee09a8eabb2a224faff0a2b0d260ee850fc1340d9fc4fd23",
+          "0d07137e65e7a46cafb0b52b6f7aadd4e46821b259b2143e534c965291a3fdea",
+          "c0feef226b3d98d94500f582e4d5cb82297214e0aabb86d2122d7e411c26efaa",
+          "3c250b5f597bf237d7a1d13862f818deba02813cb714f9fb386fc688de2dec73",
+          "9122cd74728a5dad5be53af524006c26c4da48e0775674b1119cac6249aa1301",
+          "e712573f58ac27dc599e13e1f0a74ea0b39587cb8edfee0a625fd3dfed79722c",
+          "45f0404d84d19ba3a5073f31b139faec51791a48e6bcf176bc9e2666f703a968",
+          "5492d62c5d9aff74a514eff2c8df7a97c99dd9dfbd1ab004400778be1a3b19a1",
+          "568daada10c9a7229381d750dc6a5a33bb4000deddcd54a789df7fe17ef033af",
+          "a5b8df7f0560b5907239955ef4bed3878e9f18c05b80bfdeac81d1ecb550b4e6",
+          "08f34977aa09e90acc234bb36d7785cd64515161c44b7c7311e231eb1cd9749c",
+          "e4241f531140c1ee5ec5cadab8dae39a835f3b3c37aa738368a1fa5bbbbe53c9",
+          "ea9ef4fa3fc48929fc5ed1e502098127560f99299dda4fcba082f47511403e00",
+          "0ab278b8715e223f30598f7c50a94e2f0ed43230eff613ed9b86757b6926dcb5",
+          "83229fb208ee8cf32a33007a583621865034b8e6a13060ea0faff671f7757678",
+          "469f3c7402409f09934b8628a5f22e5b5db0cb77365010604d169e0b82f22a5f",
+          "bf460d450acdd21d336900355de4f01f745f9857d4c4f0c69a62d4b0e50d5417"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.b10.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.a11.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.b11.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.a12.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.b12.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.a13.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.b13.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.a14.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.b14.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.a15.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/mwf_log14x32.b15.json"
+    ]
+  }
+}

--- a/autoresearch/submissions/2026-07-21-qm31-direct-lane-base-multiply-cpu-metal/verdict.json
+++ b/autoresearch/submissions/2026-07-21-qm31-direct-lane-base-multiply-cpu-metal/verdict.json
@@ -1,0 +1,270 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "6f3edb9c3f99",
+  "repo_commit": "aa7d76d222f7",
+  "predecessor_commit": "1c3f3ca758d1",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "wide",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 2.28
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned Rust oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "mechanism binding recorded in note; telemetry wiring pending (F.8 item 2)"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.5291 vs targeted budget x1.02; regression guards 12/12 within budget; request ratio 0.8062 vs budget x1.05"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log14x32": {
+        "r": 0.791075,
+        "ci": [
+          0.782357,
+          0.803033
+        ],
+        "rounds": 7,
+        "a_median_ms": 11.815208,
+        "b_median_ms": 9.340916
+      }
+    },
+    "R_geomean": 0.791075,
+    "theta": 0.02929,
+    "aa_dispersion": 0.014645,
+    "significant": true,
+    "neutral": false
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {
+    "guard_blake_10x10": {
+      "r": 0.998705,
+      "ci": [
+        0.994117,
+        1.001942
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "4153acd6e32a98b9d240730062f7fa35e2e31eca915f01c179337f04d409cbd2"
+    },
+    "guard_blake_12x16": {
+      "r": 0.971988,
+      "ci": [
+        0.94872,
+        0.987048
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "70e516957d2d38ed78214bfda5b0b2bdfe41f1c93439fb68e124bfef096fbc9f"
+    },
+    "guard_plonk_14": {
+      "r": 0.999635,
+      "ci": [
+        0.974308,
+        1.012499
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf"
+    },
+    "guard_plonk_16": {
+      "r": 0.981429,
+      "ci": [
+        0.951149,
+        1.010743
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "cfb36bf17fb3526bf1bdd9401fb885fd91ca46b9982fee1ca5fad33a1d574b72"
+    },
+    "guard_poseidon_10": {
+      "r": 1.016505,
+      "ci": [
+        1.01073,
+        1.020419
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "af33240da8e7947362fdf7e78d306f2e11cb2e3df7e1b6f498a6e86ac3ae7b1b"
+    },
+    "guard_poseidon_13": {
+      "r": 0.999233,
+      "ci": [
+        0.992071,
+        1.002156
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "f196835da5d4a155c6311bafb44335c2863cc028879d69a7ae53b802321200f1"
+    },
+    "guard_sm_14": {
+      "r": 1.010143,
+      "ci": [
+        1.008912,
+        1.01084
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "488fadeeb4e5d76b6fc0a9c10ab258bab6673de8e912ae5de927561650920b37"
+    },
+    "guard_sm_16": {
+      "r": 1.001788,
+      "ci": [
+        0.990009,
+        1.012035
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "88ec35ee88a05ce0a5db4b6cb063f4cf7824ee65284db0908a62a9362879af73"
+    },
+    "guard_wf_14x32": {
+      "r": 0.793426,
+      "ci": [
+        0.777618,
+        0.814636
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374"
+    },
+    "guard_wf_16x64": {
+      "r": 0.555031,
+      "ci": [
+        0.529972,
+        0.578926
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "42086545b7a170c5868afcc390f83d964e06d528e2d1039420fc6bfd7a6aac74"
+    },
+    "guard_xor_14": {
+      "r": 0.993017,
+      "ci": [
+        0.978919,
+        0.999974
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "35bb35714e10888c786a71ccdfe31d2b9b4651c567fac5ba4c9543bc247cad80"
+    },
+    "guard_xor_16": {
+      "r": 1.011807,
+      "ci": [
+        1.003052,
+        1.024802
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "56163b8ea3d877b3b9bf15753b7c0175d4a6ead493640eef8210c59ba7e5215c"
+    }
+  },
+  "rust_oracle": [
+    {
+      "workload": "wf_log14x32",
+      "verified": true,
+      "artifact_sha256": "d32393fe3b1f9abbc4795d87c3b3316e06111f014ec30f0635f13ec0ff0587f9"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "stark-v adapter pending release gate"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "wf_log14x32": {
+        "round_ratios": [
+          0.776158,
+          0.805043,
+          0.797555,
+          0.803033,
+          0.785544,
+          0.790165,
+          0.782357
+        ],
+        "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374",
+        "request_ratio": 0.806196,
+        "report_sha256s": [
+          "1f43f64e0b74f0235094cdaadc980c5b70e47f68312e292df06d960ddfa75360",
+          "d95741683dbed401fa3811afbb4bcee67d04a767b9ebc09a37650035ae960e28",
+          "5a4fe3730f706d094d138aab8b9b2abf70e9d923d36e015ea1b44adddc1a303a",
+          "a859622314ce19422a5983352220d7013363c1fe86397bcab8a08075a0dbc50e",
+          "e6036ae6e784868da3bb93361104f82ec2c4253cb1e8c58cca08a3e7fdc97070",
+          "cc24ba5469046704b0b20448aa7937e0379c7636d0e0c6cb8f57d613423f12b3",
+          "6cd24d4977f2f99f74283a78347d1f4ace86db0c8974569bed4a49090b804d14",
+          "6d763cb7545d815651195b5b761b1496dec79479cb317fbc65f663113c6cf8e6",
+          "42395204b2c2832c6223e6d3a9b5457a7ea687dfb17fe5736062ce76635dbc17",
+          "8643d901a9b7f4cf947d048d92983a7b3fb43ce28bb96aacd47c8545923a05a8",
+          "5632276df2c9407805915226e1308d9a7465fda4d33d845dbd31140271669bc0",
+          "0b310b1cd334c64c6d7801204bf73d2071aa1940ab819a094877e238fbaa8aaa",
+          "6a12494aa64240e258694373d72f2b323350a9bc59d283c7df929847bc744daf",
+          "bf20b232080168f54d414c60554b72cce0cac67720e52d0e8af942407139773f"
+        ]
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/wf_log14x32.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/wf_log14x32.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/wf_log14x32.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/wf_log14x32.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/wf_log14x32.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/wf_log14x32.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/wf_log14x32.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/wf_log14x32.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/wf_log14x32.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/wf_log14x32.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/wf_log14x32.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/wf_log14x32.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/wf_log14x32.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-dual-03/autoresearch/.runs/latest/wf_log14x32.b7.json"
+    ]
+  }
+}

--- a/src/core/fields/qm31.zig
+++ b/src/core/fields/qm31.zig
@@ -147,10 +147,18 @@ pub const QM31 = struct {
     }
 
     pub inline fn mulM31(lhs: QM31, rhs: M31) QM31 {
-        return .{
-            .c0 = lhs.c0.mulM31(rhs),
-            .c1 = lhs.c1.mulM31(rhs),
+        // Keep aggregate-to-lane extraction in the consuming operation. Zig
+        // 0.15.2 can miscompile an inlined helper that first copies a by-value
+        // QM31 aggregate; these direct field loads are covered by the packed
+        // high-block point-evaluation regressions.
+        const lanes: m31_mod.Vec4u32 = .{
+            lhs.c0.a.v,
+            lhs.c0.b.v,
+            lhs.c1.a.v,
+            lhs.c1.b.v,
         };
+        const product = m31_mod.mulVec4(lanes, @splat(rhs.v));
+        return fromU32Unchecked(product[0], product[1], product[2], product[3]);
     }
 
     pub inline fn square(self: QM31) QM31 {


### PR DESCRIPTION
## Summary

- vectorize `QM31.mulM31` across its four canonical M31 coordinates
- extract fields directly inside the consuming operation, avoiding the Zig 0.15.2 by-value aggregate conversion pattern fixed on main
- submit paired CPU-wide and Metal-wide S3 verdicts from the corrected frontier

## Performance

| board | A median | B median | ratio | 95% CI |
| --- | ---: | ---: | ---: | ---: |
| CPU wide | 11.815 ms | 9.341 ms | 0.7911 | [0.7824, 0.8030] |
| Metal wide | 10.823 ms | 8.096 ms | 0.7598 | [0.7396, 0.7813] |

Both verdicts pass G1-G5, all 12 regression guards, pinned Rust-oracle verification, and cross-arm byte identity. Metal retains 22 dispatches and zero CPU fallback.

## Validation

- `zig build test -Doptimize=ReleaseFast`
- `zig build test-native-cpu-product test-native-metal metal-check test-metal-core-aot test-metal-core-aot-probe fmt source-conformance -Doptimize=ReleaseFast`
- `python3 -m unittest discover -s autoresearch/tests -v` (192 tests)
- `BASE_REF=origin/main python3 autoresearch/bots/validate_action.py`
