### PR TITLE
Autoresearch: fix guard workload test fixture

### DIFF
--- a/autoresearch/tests/test_guards.py
+++ b/autoresearch/tests/test_guards.py
@@ -15,7 +15,8 @@ def fake_manifest(guards: dict) -> mock.Mock:
 
 
 GROUP = WorkloadGroup(
-    group_id="native", enabled=True, disabled_reason=None, board="core_cpu",
+    group_id="native", enabled=True, promotion_eligible=True,
+    disabled_reason=None, board="core_cpu",
     build_step="zig build bench", binary="zig-out/bin/bench",
     report_schema="native_proof_v6", workloads=[],
 )


### PR DESCRIPTION
WorkloadGroup.promotion_eligible became required in the staged portfolio changes, but the module-level fixture in test_guards.py was not updated. This prevented the entire autoresearch validation suite from importing on current main.

Adds the explicit eligible value to the native test fixture.

Validation: python3 -m unittest discover -s autoresearch/tests -v (231 tests pass).