### PR TITLE
Subtree-scheduled Merkle layer construction and size-routed layer buffers

### DIFF
--- a/autoresearch/submissions/2026-07-21-cpu-merkle-subtree-scheduling/delta.json
+++ b/autoresearch/submissions/2026-07-21-cpu-merkle-subtree-scheduling/delta.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "9046758f0def",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/prover/vcs_lifted/layers.zig": "sha256:65cc14c011cd4c657a80509733411efb4f324b785ddd8ee8677a3dcc968f62fb",
+    "src/prover/vcs_lifted/parameters.zig": "sha256:d0116843934321d41bad118ddfa26a5e4b3ea43e6a81d0ea69b14f34d14f28f1",
+    "src/prover/vcs_lifted/prover.zig": "sha256:50f212f77932e16dfb9765f76a477000e131538cc97a88d72b819092ca173096"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "deedc2cf1156adf8f0f46bddac7d9828f6ee13a2125fa44d987f904d5e81ec66",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-21-cpu-merkle-subtree-scheduling/note.md
+++ b/autoresearch/submissions/2026-07-21-cpu-merkle-subtree-scheduling/note.md
@@ -1,0 +1,97 @@
+# Subtree-scheduled Merkle layer construction and size-routed layer buffers
+
+## Model and harness
+
+Model: Claude Fable 5. Autonomous session on an Apple M4 Pro (12 cores)
+running macOS, second session in this solver lane. Candidate and predecessor
+are both `9046758f0def`; the workspace was a fresh `stwo-perf clone` and the
+canonical checkout confirmed current by `stwo-perf update` before the final
+paired runs. Evidence uses the repo-resident harness end to end: `--profiled`
+stage attribution, `stwo-prof zig isolate` counters on live repo code, and
+`stwo-perf run --scope s3` paired verdicts with the pinned Rust oracle.
+
+## Hypothesis
+
+Fresh stage attribution put `fri_quotient_build_and_commit` first in every
+scored class (42% of small, 32% of wide, 47% of deep prove time). Env-gated
+phase timers decomposed the wide-class stage: the inner FRI layer cascade
+cost ~2.26 ms, of which per-layer Merkle commits were ~1.63 ms while the
+line folds themselves were only ~0.24 ms. A 16384-leaf inner tree cost
+567 µs against ~100 µs of true hash work (isolated harness: 17.3M
+instructions per commit, ~525 instructions/hash vs a ~350–375 kernel floor,
+futex wait 8.4%, spawn entry 8.8%).
+
+Three scheduling defects explained the gap, multiplied by one tree per FRI
+fold layer plus every trace commit:
+
+1. every Merkle layer buffer — including 64-byte top layers — was allocated
+   through raw mmap/madvise/munmap with first-touch page faults (~120
+   mmaps per proof);
+2. upper layers ran one thread-pool barrier per level, and every level with
+   fewer than 2048 output nodes ran serially — the entire top of every tree,
+   ~2047 serial hashes per large tree;
+3. worker-override environment lookups re-ran per level per tree.
+
+Prediction: routing small buffers to the general-purpose heap and building
+all upper layers in one subtree-parallel pass with a single barrier removes
+most of the non-hash overhead, with byte-identical layers, moving all three
+classes.
+
+## Changes
+
+All inside `src/prover/vcs_lifted/`:
+
+- `parameters.zig`: `layerAllocator` now routes buffers below 1 MiB to the
+  general-purpose heap and keeps mmap (sequential-read hint, pages returned
+  on free) for buffers at or above 1 MiB. Alloc and free route by the same
+  length rule, so pairing is consistent.
+- `layers.zig`: new `buildUpperLayersSubtree` builds every internal layer in
+  one pass. Worker count is floored to a power of two so chunk boundaries
+  align with subtree boundaries at every level; each worker builds its
+  contiguous subtree bottom-up (cache-hot, no cross-worker reads before the
+  barrier), one `spawnWg` barrier total, then the top `log2(W)` levels
+  finish serially with the existing seeded 4-wide loop. Serial fallback
+  preserves the sequential path for small trees and non-seeded hashers.
+- `prover.zig`: both tree-build call sites (`buildTreeFromOwnedLeaves` and
+  `commitWithOptions`) use the new builder; the worker-override environment
+  lookup is hoisted to once per tree.
+
+Buffer sizes, allocation order, hash inputs, and layer contents are
+unchanged — layers are byte-identical by construction. Leaf building, the
+hash kernel, fold arithmetic, and all protocol logic are untouched.
+
+## Results
+
+Fixed proof digests match the committed values on all three workloads;
+every timed sample verified and byte-identical; `zig build test` passes.
+Warmed diagnostics: wide first-layer upper tree 520→225 µs, wide inner
+cascade 2260→1750 µs.
+
+Paired S3, 15 rounds per class, all G1–G5 green, 13/13 regression guards:
+
+| class | workload | A ms | B ms | R (95% CI) | theta |
+| --- | --- | ---: | ---: | --- | ---: |
+| small | `wf_log10x8` | 1.624 | 1.336 | 0.8116 [0.7868, 0.8386] | 0.0373 |
+| wide | `wf_log14x32` | 10.870 | 9.632 | 0.8921 [0.8788, 0.9175] | 0.0293 |
+| deep | `plonk_log14` | 7.103 | 5.791 | 0.8113 [0.7957, 0.8276] | 0.0183 |
+
+Suite geometric mean ≈ 0.834. The mechanism is visible where predicted: the
+Merkle-commit share of the FRI stage and the trace commits shrink while fold
+and quotient-tile phases are unchanged.
+
+## Caveats
+
+- One earlier deep-class run failed G4 on `guard_blake_12x16` with round
+  medians at 0.997 — late-round outliers inflated the guard's upper CI. A
+  clean re-run passed 13/13 guards with a tighter objective CI; both runs
+  are recorded in the attached transcripts.
+- Verdicts are claimed/advisory (M4 Pro); the judged re-run is
+  authoritative. The barrier/serial-tail savings should transfer to any
+  multi-core host, but the split between the allocator and scheduling
+  contributions is topology-dependent; low-core hosts will see mainly the
+  allocator effect.
+- The 1 MiB mmap threshold was chosen so the largest suite buffers keep the
+  existing mmap behavior; it was not swept.
+- This change is scheduling-only per the algorithm-matching gate: the
+  canonical problem (binary Merkle over a fixed hasher) and its protocol
+  shape are mandated, so no algorithm replacement was considered.

--- a/autoresearch/submissions/2026-07-21-cpu-merkle-subtree-scheduling/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-21-cpu-merkle-subtree-scheduling/transcripts/session-01.md
@@ -1,0 +1,130 @@
+# Session transcript — CPU Merkle subtree scheduling + size-routed layer allocator
+
+Agent: Claude (Fable 5), autonomous session on an Apple M4 Pro (12 cores,
+24 GB), macOS. Second session in this solver lane (predecessor session
+produced `2026-07-20-parallel-cpu-fft-constant-composition`). Workspace was a
+fresh `stwo-perf clone` at tip `9046758f0def`; `stwo-perf update` confirmed
+current before the final paired runs.
+
+## 1. Priors loaded before profiling
+
+Read `stwo-perf notes` and the merged submission notes first, per TASK.md.
+Relevant priors that shaped the search:
+
+- Own lane's prior rejections (do-not-redo list): packed FRI fold arithmetic
+  (wide S3 regressed to 1.05), accumulator ownership transfer (neutral),
+  generic CM31 batch inversion (neutral), conjugate-pair quotient domain
+  points (favorable, not significant), cached inverse FRI twiddles (isolated
+  fold win, no S3 row cleared).
+- Competitor lane had just landed a run of *Metal-side* Merkle scheduling
+  wins (multiblock tails, tail arenas, SIMD-cooperative tails) — suggesting
+  the same disease class might be untreated on the CPU board.
+
+## 2. Fresh stage attribution on the current tip
+
+Ran the bench with `--profiled` on all three scored workloads (M4 Pro,
+warmed). Medians:
+
+- small `wf_log10x8` 1.61 ms: fri_quotient_build_and_commit 0.678 (42%),
+  proof_of_work 0.228, main_trace_commit 0.216, composition_commit 0.200.
+- wide `wf_log14x32` 10.85 ms: fri_quotient 3.496 (32%),
+  composition_evaluation 2.128, main_trace_commit 2.270 (merkle 1.188),
+  composition_commit 1.124.
+- deep `plonk_log14` 6.93 ms: fri_quotient 3.27 (47%), merkle commits ~2.4
+  total across trees, composition_commit 0.45.
+
+Decision: attack `fri_quotient_build_and_commit` — dominant in all three
+classes, so a win there earns multi-class suite credit.
+
+## 3. Decomposing the dominant stage (temporary env-gated timers)
+
+Added temporary `STWO_FRI_DIAG` timers around the phases of `commitLazy` and
+`commitWithLazyQuotientsMode` (removed from the final diff). Wide class:
+
+- first layer (quotient tiles + leaf sink + upper tree): ~1.30 ms
+  (tiles+leaves 0.77, upper tree 0.52)
+- **inner FRI layers: ~2.26 ms** — of which per-layer Merkle commits ~1.63 ms,
+  line folds only ~0.24 ms, AoS→SoA conversion ~0.05 ms
+- last layer: ~0.003 ms
+
+Per-layer detail exposed the shape of the waste: the 16384-leaf inner tree
+took 567 µs while the *32768-leaf* first-layer upper tree took 527 µs; and
+the small-layer tail (len ≤ 2048) burned ~430–500 µs on trees whose real
+hashing is microseconds.
+
+## 4. Hypotheses tested, in order
+
+**H1 — mmap churn (partially confirmed).** `parameters.layerAllocator`
+routed *every* layer buffer, even 64-byte ones, through raw
+mmap/madvise/munmap with first-touch page faults; the FRI cascade allocates
+~120 such buffers per proof. Fix: size-route buffers — general-purpose heap
+below 1 MiB, mmap (with its sequential-read hint) at or above. Measured
+effect: small-layer tail costs dropped (e.g. len-512 tree 60→47 µs, len-8
+12→6 µs) but big trees were unchanged. Kept, but insufficient alone.
+
+**H2 — per-tree thread-pool spawning (falsified).** `Executor.init` spawns
+an owned `std.Thread.Pool` when reuse is off — but `reuseAvailablePool`
+already returns true whenever the process work pool is installed, which it
+is in the bench. No fix needed; the hypothesis died on reading the code, and
+the isolated-harness numbers below confirmed the cost lives elsewhere.
+
+**H3 — hash kernel inefficiency (rejected as primary lever).** Isolated
+`MerkleProverLifted.commit` on a 16384×4 M31 input with the repo's
+`stwo-prof zig isolate` harness (live-code import, no copy): 720 µs/op,
+17.3M instructions/op, IPC 2.19, `compressParallel4` dominant, futex wait
+8.4%, spawn entry 8.8%. That is ~525 instructions per hash against a
+~350–375 theoretical floor for the existing transposed 4-lane Blake2s — the
+kernel is near its floor; midstate seeding for the 64-byte domain prefix is
+already in place (`nodeSeed`/`leafSeed`), so each hash is one live
+compression. A kernel rewrite would buy ≤ 30% of the hash time at high
+risk; parked.
+
+**H4 — construction scheduling (confirmed, the submitted mechanism).** The
+upper-layer builder ran one `spawnWg` barrier per level, went serial for
+every level with out-len < 2048 (the entire top of every tree — ~2047
+serial hashes per big tree), and re-read the environment for worker
+overrides per level. The FRI cascade multiplies this by one tree per fold
+layer. Fix: build all upper layers in one pass — each worker builds a
+contiguous subtree bottom-up (cache-hot, zero cross-worker reads before the
+single barrier), then the top log2(W) levels finish serially. Worker count
+is floored to a power of two so chunk boundaries align with subtree
+boundaries at every level; buffer sizes, allocation order, allocator, and
+hash values are unchanged, so layers are byte-identical by construction.
+
+## 5. Verification and results
+
+- Proof digests after the change match the committed fixed digests on all
+  three workloads (small 91741aec…, wide 57a7d291…, deep d63a2c92…),
+  samples all byte-identical and verified.
+- `zig build test` passes (full closure).
+- Warmed diagnostic medians: wide upper-tree 520→225 µs, inner layers
+  2260→1750 µs; prove medians small 1.61→1.31 ms, wide 10.8→8.9 ms, deep
+  6.9→6.7 ms — multi-class movement, so per TASK.md each moved class got its
+  own paired S3 evaluation.
+- Paired S3 (15 rounds, predecessor = clean tip checkout):
+  - wide: R 0.8921 [0.8788, 0.9175], theta 0.0293 — significant; G1–G5 pass.
+  - deep: R 0.8113 [0.7957, 0.8276], theta 0.0183 — significant; G1–G5 pass.
+  - small: see verdict file packaged with this submission.
+- One deep run initially failed G4 on `guard_blake_12x16`: round medians
+  were A 45.05 ms vs B 44.91 ms (ratio 0.997) with late-round outliers
+  inflating the upper CI — machine noise, not mechanism. A clean re-run
+  passed 13/13 guards with a tighter objective CI; both runs are reported
+  here for honesty.
+
+## 6. Operational notes for future sessions
+
+- Paired runs need rustup's cargo ahead of Homebrew's on PATH, or the
+  pinned-oracle build fails on the `+nightly-2025-07-14` toolchain directive.
+- A failed run can leave `autoresearch/.runs/latest` populated;
+  `PathAlreadyExists` on the oracle artifact means clear the scratch dir and
+  re-run.
+
+## 7. Rejected / deferred this session
+
+- Blake2s kernel micro-optimization (message transpose via vector loads):
+  est. ≤ 10%/hash, deferred.
+- Leaf-pass repack elision (leaf payload bytes == QM31 AoS bytes, could skip
+  the SoA conversion + byte packing for inner FRI layers): promising,
+  deferred as a separately attributed candidate.
+- Parallel proof-of-work grinding with canonical-nonce semantics: delegated
+  to a peer lane, untested here.

--- a/autoresearch/submissions/2026-07-21-cpu-merkle-subtree-scheduling/verdict-deep.json
+++ b/autoresearch/submissions/2026-07-21-cpu-merkle-subtree-scheduling/verdict-deep.json
@@ -1,0 +1,344 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "a98953ce779f",
+  "repo_commit": "9046758f0def",
+  "predecessor_commit": "9046758f0def",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "5558d8eb164c",
+    "os": "Darwin 24.6.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": false,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 8.92
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned correctness oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "native mechanism telemetry policy unchanged"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.4017 vs targeted budget x1.02; matrix row upper CIs 1/1 within budget x1.05; regression guards 13/13 within budget; request ratios 1/1 present rows within budget x1.05; rss ratios 0/0 present rows within budget x1.05; absent: ['plonk_log14']"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "plonk_log14": {
+        "r": 0.811271,
+        "ci": [
+          0.795654,
+          0.827648
+        ],
+        "rounds": 15,
+        "a_median_ms": 7.102792,
+        "b_median_ms": 5.790625,
+        "request_ratio": 0.821738,
+        "rss_ratio": null,
+        "mechanism_verified": null
+      }
+    },
+    "R_geomean": 0.811271,
+    "portfolio": {
+      "ci_method": "independent_workload_round_bootstrap_percentile_v1",
+      "ci_level": 0.95,
+      "bootstrap_iterations": 4000,
+      "seed": 223837180,
+      "ci": [
+        0.795189,
+        0.827415
+      ],
+      "prove_ms_method": "geometric_mean_candidate_workload_medians_ms_v1",
+      "b_median_ms_geomean": 5.790625
+    },
+    "theta": 0.018278,
+    "aa_dispersion": 0.009139,
+    "significant": true,
+    "neutral": false,
+    "promotion_significance": {
+      "eligible": true,
+      "method": "independent_workload_round_bootstrap_percentile_v1",
+      "reason": "prove-time objective uses the deterministic workload portfolio CI"
+    }
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {
+    "guard_blake_10x10": {
+      "r": 0.961504,
+      "ci": [
+        0.936182,
+        0.985844
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "4153acd6e32a98b9d240730062f7fa35e2e31eca915f01c179337f04d409cbd2"
+    },
+    "guard_blake_12x16": {
+      "r": 0.977222,
+      "ci": [
+        0.73518,
+        1.017671
+      ],
+      "rounds": 12,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "70e516957d2d38ed78214bfda5b0b2bdfe41f1c93439fb68e124bfef096fbc9f"
+    },
+    "guard_plonk_14": {
+      "r": 0.782092,
+      "ci": [
+        0.768939,
+        0.803219
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf"
+    },
+    "guard_plonk_16": {
+      "r": 0.8723,
+      "ci": [
+        0.850605,
+        0.881222
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "cfb36bf17fb3526bf1bdd9401fb885fd91ca46b9982fee1ca5fad33a1d574b72"
+    },
+    "guard_poseidon_10": {
+      "r": 0.967206,
+      "ci": [
+        0.959219,
+        0.971244
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "af33240da8e7947362fdf7e78d306f2e11cb2e3df7e1b6f498a6e86ac3ae7b1b"
+    },
+    "guard_poseidon_13": {
+      "r": 0.981478,
+      "ci": [
+        0.961403,
+        0.988755
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "f196835da5d4a155c6311bafb44335c2863cc028879d69a7ae53b802321200f1"
+    },
+    "guard_sm_14": {
+      "r": 0.814402,
+      "ci": [
+        0.784395,
+        0.897337
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "488fadeeb4e5d76b6fc0a9c10ab258bab6673de8e912ae5de927561650920b37"
+    },
+    "guard_sm_16": {
+      "r": 0.863697,
+      "ci": [
+        0.849073,
+        0.880544
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "88ec35ee88a05ce0a5db4b6cb063f4cf7824ee65284db0908a62a9362879af73"
+    },
+    "guard_wf_10x8": {
+      "r": 0.824252,
+      "ci": [
+        0.79724,
+        0.84212
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700"
+    },
+    "guard_wf_14x32": {
+      "r": 0.882733,
+      "ci": [
+        0.872736,
+        0.886184
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374"
+    },
+    "guard_wf_16x64": {
+      "r": 0.955966,
+      "ci": [
+        0.926105,
+        0.977415
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "42086545b7a170c5868afcc390f83d964e06d528e2d1039420fc6bfd7a6aac74"
+    },
+    "guard_xor_14": {
+      "r": 0.827101,
+      "ci": [
+        0.799806,
+        0.852103
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "35bb35714e10888c786a71ccdfe31d2b9b4651c567fac5ba4c9543bc247cad80"
+    },
+    "guard_xor_16": {
+      "r": 0.895095,
+      "ci": [
+        0.870013,
+        0.918563
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "56163b8ea3d877b3b9bf15753b7c0175d4a6ead493640eef8210c59ba7e5215c"
+    }
+  },
+  "rust_oracle": [
+    {
+      "workload": "plonk_log14",
+      "verified": true,
+      "oracle": "pinned-rust-stwo",
+      "artifact_sha256": "ed64ff803f2e7ec8c5eeb81f520ee3cb228c6811795a53137092a8632f9e5e68"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "RF-01 adapter release and BA-03 autoresearch activation pending"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "plonk_log14": {
+        "round_ratios": [
+          0.77355,
+          0.837538,
+          0.794881,
+          0.831206,
+          0.809427,
+          0.844537,
+          0.764295,
+          0.816827,
+          0.817758,
+          0.875444,
+          0.790393,
+          0.786917,
+          0.8188,
+          0.828602,
+          0.790374
+        ],
+        "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf",
+        "request_ratio": 0.821738,
+        "rss_ratio": null,
+        "report_sha256s": [
+          "74bcf9ce4370aef2ca325f219473b18502c49b2a18d405923ec3a24e13f519ad",
+          "9fc3fc95e76541914c28aafe3a74ca9f3ab33a5fb29c66cdd709b482be5f3876",
+          "7fa11a3abf67dfa23b4e2e58308041d30106db6151d43b31c09fc0d8300c5e82",
+          "ee830d56c9dd9aadf177ac6bc9463c945e50418d12a2ab327bdef6684fe7d7ce",
+          "5df11a7e997c293ce98d5f132c740fca1faca2e73fe44ff5145b5b2d702f9bb2",
+          "34be7100eaf854a5ba89d6e3ae29e05b4571632a3735304f857f627cfde07c2e",
+          "876c24420cfa8562cdc259c95b7864c859fb74653e91f4a45cadeecb170d50fa",
+          "c514d4a8f7bc4404ad61dbe6199b416bdeda6165ac1276f1a2cfef93b816e9f4",
+          "a4d862adcfb212232403b4d98b47f853607df51f2fc355fff3474b7460ba36c9",
+          "9a1d61cac324e384264243b5380d06bee651204082a46c7ecaf0c2a4984a4d15",
+          "75c85a06bfd0f4cdd57e928f18e6f0dbe3b9b0f77341f49e56de4677a45e5301",
+          "e4022eb839a0643793602dfdcccd9bc0323e5e93c697f656e765a63ee3f11183",
+          "742e0effa29d302ebfd773e5a684b86eb8505e6de72a2b624f2df9d79794b6f8",
+          "435e8b51a50117a9af009853bf043c50e990826c22cf8e4800641837936fcf11",
+          "292bd75c454a4ee6f1323a30b9611657d01bbb1d8f91b5e32f254ec14e2fc608",
+          "629ce46f5aec52cbe955cb88dc6f89a3fc3ad1dd31d89ab692da15747b21dde8",
+          "bada43accfabac8f476ee5ef53c44d473ce0143a2e418cd6e62d51f353333a09",
+          "201ba89c64448cc1b3988bc447c25ea061695c0013a166118f1daf612e8db193",
+          "61cb4b0fd987d8f618c3ce7bf514a74fcbde0a158152bc99497ddf710b66f849",
+          "ff1283168711253a484962ff1301696c532a305bf762ac27d17ee670a1a649a1",
+          "bb696b47e60e68a3c72cd952f82ffbb3c876a95f53b10bde774c90fada13d6a1",
+          "7e75d427b467282dbec0a62b63f6c6a4574f79339f832170e9ef1c746300b408",
+          "11b6687ed550b1860e85031918b48fcc2429ce098cf985a129f63f3d603ed29d",
+          "707ef81eb2c57015d294d9a0e8d98d18810c0aabe634d729f8b8c26c71baad90",
+          "5182e1197e4cf7273ca1d357717383e42ee6274c0332de4787a3c845581d5221",
+          "c745834635a2c48f8f55205e7aeb49f23af996ffe69199fab53d91592d7dc208",
+          "eff4126f6bac149192f82d578860a2da9f07391abdc5bdd4e14fe843fe084d5f",
+          "b17a9815409982b7eb5cea2291532b4bf5b95332921f664c388c2f62e4cb62cf",
+          "f6fadedd709c0a8f1d2c7a203bcc03dd985c64333ee559efdfa838eb07d08422",
+          "a996feb55218961d0b79f3adaf03af99971d277cf082e015c34661ff191fdac9"
+        ],
+        "mechanism_verified": null
+      }
+    },
+    "reports": [
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.a1.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.b1.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.a2.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.b2.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.a3.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.b3.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.a4.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.b4.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.a5.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.b5.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.a6.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.b6.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.a7.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.b7.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.a8.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.b8.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.a9.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.b9.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.a10.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.b10.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.a11.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.b11.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.a12.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.b12.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.a13.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.b13.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.a14.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.b14.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.a15.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/plonk_log14.b15.json"
+    ]
+  }
+}

--- a/autoresearch/submissions/2026-07-21-cpu-merkle-subtree-scheduling/verdict-wide.json
+++ b/autoresearch/submissions/2026-07-21-cpu-merkle-subtree-scheduling/verdict-wide.json
@@ -1,0 +1,344 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "a98953ce779f",
+  "repo_commit": "9046758f0def",
+  "predecessor_commit": "9046758f0def",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "wide",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "5558d8eb164c",
+    "os": "Darwin 24.6.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": false,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": false,
+      "load1": 10.4
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned correctness oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "native mechanism telemetry policy unchanged"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.5455 vs targeted budget x1.02; matrix row upper CIs 1/1 within budget x1.05; regression guards 13/13 within budget; request ratios 1/1 present rows within budget x1.05; rss ratios 0/0 present rows within budget x1.05; absent: ['wf_log14x32']"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log14x32": {
+        "r": 0.892052,
+        "ci": [
+          0.878794,
+          0.917516
+        ],
+        "rounds": 15,
+        "a_median_ms": 10.869875,
+        "b_median_ms": 9.632083,
+        "request_ratio": 0.897242,
+        "rss_ratio": null,
+        "mechanism_verified": null
+      }
+    },
+    "R_geomean": 0.892052,
+    "portfolio": {
+      "ci_method": "independent_workload_round_bootstrap_percentile_v1",
+      "ci_level": 0.95,
+      "bootstrap_iterations": 4000,
+      "seed": 4133880075,
+      "ci": [
+        0.878754,
+        0.918126
+      ],
+      "prove_ms_method": "geometric_mean_candidate_workload_medians_ms_v1",
+      "b_median_ms_geomean": 9.632083
+    },
+    "theta": 0.02929,
+    "aa_dispersion": 0.014645,
+    "significant": true,
+    "neutral": false,
+    "promotion_significance": {
+      "eligible": true,
+      "method": "independent_workload_round_bootstrap_percentile_v1",
+      "reason": "prove-time objective uses the deterministic workload portfolio CI"
+    }
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {
+    "guard_blake_10x10": {
+      "r": 0.942072,
+      "ci": [
+        0.76286,
+        1.005938
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "4153acd6e32a98b9d240730062f7fa35e2e31eca915f01c179337f04d409cbd2"
+    },
+    "guard_blake_12x16": {
+      "r": 0.985183,
+      "ci": [
+        0.926681,
+        1.042569
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "70e516957d2d38ed78214bfda5b0b2bdfe41f1c93439fb68e124bfef096fbc9f"
+    },
+    "guard_plonk_14": {
+      "r": 0.804881,
+      "ci": [
+        0.790867,
+        0.829667
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf"
+    },
+    "guard_plonk_16": {
+      "r": 0.85479,
+      "ci": [
+        0.832613,
+        0.86508
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "cfb36bf17fb3526bf1bdd9401fb885fd91ca46b9982fee1ca5fad33a1d574b72"
+    },
+    "guard_poseidon_10": {
+      "r": 0.982176,
+      "ci": [
+        0.974655,
+        1.002188
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "af33240da8e7947362fdf7e78d306f2e11cb2e3df7e1b6f498a6e86ac3ae7b1b"
+    },
+    "guard_poseidon_13": {
+      "r": 0.980456,
+      "ci": [
+        0.962906,
+        0.988532
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "f196835da5d4a155c6311bafb44335c2863cc028879d69a7ae53b802321200f1"
+    },
+    "guard_sm_14": {
+      "r": 0.841166,
+      "ci": [
+        0.835516,
+        0.851741
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "488fadeeb4e5d76b6fc0a9c10ab258bab6673de8e912ae5de927561650920b37"
+    },
+    "guard_sm_16": {
+      "r": 0.92267,
+      "ci": [
+        0.900048,
+        0.945153
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "88ec35ee88a05ce0a5db4b6cb063f4cf7824ee65284db0908a62a9362879af73"
+    },
+    "guard_wf_10x8": {
+      "r": 0.832489,
+      "ci": [
+        0.823446,
+        0.854781
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700"
+    },
+    "guard_wf_14x32": {
+      "r": 0.885945,
+      "ci": [
+        0.860195,
+        0.908572
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374"
+    },
+    "guard_wf_16x64": {
+      "r": 1.013023,
+      "ci": [
+        0.997216,
+        1.023774
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "42086545b7a170c5868afcc390f83d964e06d528e2d1039420fc6bfd7a6aac74"
+    },
+    "guard_xor_14": {
+      "r": 0.844532,
+      "ci": [
+        0.822329,
+        0.855235
+      ],
+      "rounds": 6,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "35bb35714e10888c786a71ccdfe31d2b9b4651c567fac5ba4c9543bc247cad80"
+    },
+    "guard_xor_16": {
+      "r": 0.921067,
+      "ci": [
+        0.887574,
+        0.961063
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "56163b8ea3d877b3b9bf15753b7c0175d4a6ead493640eef8210c59ba7e5215c"
+    }
+  },
+  "rust_oracle": [
+    {
+      "workload": "wf_log14x32",
+      "verified": true,
+      "oracle": "pinned-rust-stwo",
+      "artifact_sha256": "d32393fe3b1f9abbc4795d87c3b3316e06111f014ec30f0635f13ec0ff0587f9"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "RF-01 adapter release and BA-03 autoresearch activation pending"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "wf_log14x32": {
+        "round_ratios": [
+          0.883934,
+          0.891467,
+          0.868075,
+          0.893187,
+          0.938835,
+          0.960878,
+          0.891567,
+          0.899621,
+          0.908955,
+          1.01883,
+          0.862286,
+          0.816202,
+          0.897417,
+          0.87094,
+          0.881298
+        ],
+        "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374",
+        "request_ratio": 0.897242,
+        "rss_ratio": null,
+        "report_sha256s": [
+          "39c5d60320a843ec905840596847946afa007d7ab4e99c5c7871a81dbac0be86",
+          "82847dc6ef01083899342979506078df978ffdfb3fcd76101d9da928e6013c42",
+          "0a7850537ac67605ed3d5341cdd67d5bc8b164af4b762c2cd28deeb03bea042f",
+          "b1357e972e7ddf9202798bdf358134cbc00562cd48959ce52beedf867044abb3",
+          "bfde87dbed1a03432b54d4385a24b442f95626e12305d1251cef846ff2fe0b80",
+          "09ae2693545ea33545f1fd1c622618aa5d43fc1a7805968c7cbb606d210774f2",
+          "7eeb2865284cdf30161d12a562d23d5654938c8a6bebb50707c58f58156e6801",
+          "b4e09e9bf2afdea70e59a2d5a8ed11f992d33a18113e4f388111d64df83966fc",
+          "ba2e2df56a8bbd45c29f4544a7aab4b42416ffce21f2fedd259d96fd5ae05ade",
+          "a0396e3ec8e28827c90557bdac2af643f6d10a0996334ebf2af717ce85b280cb",
+          "4a615b1c0a6d5a2dc6dbfda69fd10d003461973a7fbd05c1fd03b8bc83cc278b",
+          "f1cb15df116a342a618930322b01aa1357444b0c19e4fe4827f53f5d5e5c74de",
+          "2da69f91227b1dbaeb518b90b1119af1370032dbd9bb021a4b42ec36fa3f4df8",
+          "77911c8f4824494e4cb89e472fd51fe376a3fbd90b3a55940be4729e72006fb2",
+          "8e72d2bf8b72f33cc8298d82fc8bc84e7642c7aa7c8b4554bdd384a77d8e0158",
+          "29904f9d384d197d934e9d14516bbb8c459363e0ca4e75e403be7cdd39ad540c",
+          "aa6d6ba9a5ab5279684621d9a657d2a82888ef5f309d189fef362f790ca618d6",
+          "7c73cd453383b53d8833dac4d77de37181fb43a82ec246f25a53a4fea0987f70",
+          "269cb7feecfb8cfb08d2d7ad7366549f49386eaf2d41c2b95ac342bc47e6623a",
+          "d881bbd2633fa7cbc09d8a52cca22a4d0c487810f717867910ed553785edb06a",
+          "6af6940c5532a4019c670c65507bad812d13da266ebeb17cd4c7477242d1e483",
+          "6e47365d81889b23f967f170a5c9baeac45d637f6aa92869e841867b698773b0",
+          "7105f53957df6a98a83f912158f1e1059a83474b305b9f5d5f1afd55b2ac2c0d",
+          "efb943333aff810be72cd688617eead3afa2b5366e46dcc8d0568e2d2269762c",
+          "e2616f2c70c61e9ba66573204821a75dbe14e9d7f2723698bd30e2f62dfe5d6d",
+          "779125d406e76251a4467a7d03d07656e381b854c9e56a7c8a51a0cc32ec3871",
+          "1b30d50a19b1dd3853923fa79d788de55581032e3082df742051f2c7cba362fb",
+          "e9d9b5af4abb64d55bb6ec247ad6e6316c3dd0c3ff0db357175a2d903576c1b2",
+          "1850b2ea47c05728319b11fea36456d2b8fc191ff1f4336aed11092fdebcfc26",
+          "29b9873b851cbc77f7359faf136a2c3042705ae300d445dd734fb856297d30bc"
+        ],
+        "mechanism_verified": null
+      }
+    },
+    "reports": [
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.a1.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.b1.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.a2.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.b2.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.a3.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.b3.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.a4.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.b4.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.a5.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.b5.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.a6.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.b6.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.a7.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.b7.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.a8.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.b8.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.a9.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.b9.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.a10.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.b10.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.a11.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.b11.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.a12.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.b12.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.a13.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.b13.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.a14.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.b14.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.a15.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log14x32.b15.json"
+    ]
+  }
+}

--- a/autoresearch/submissions/2026-07-21-cpu-merkle-subtree-scheduling/verdict.json
+++ b/autoresearch/submissions/2026-07-21-cpu-merkle-subtree-scheduling/verdict.json
@@ -1,0 +1,344 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "a98953ce779f",
+  "repo_commit": "9046758f0def",
+  "predecessor_commit": "9046758f0def",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "5558d8eb164c",
+    "os": "Darwin 24.6.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": false,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": false,
+      "load1": 9.61
+    }
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned correctness oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "native mechanism telemetry policy unchanged"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.4789 vs targeted budget x1.02; matrix row upper CIs 1/1 within budget x1.05; regression guards 13/13 within budget; request ratios 1/1 present rows within budget x1.05; rss ratios 0/0 present rows within budget x1.05; absent: ['wf_log10x8']"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log10x8": {
+        "r": 0.811637,
+        "ci": [
+          0.786817,
+          0.838595
+        ],
+        "rounds": 15,
+        "a_median_ms": 1.624,
+        "b_median_ms": 1.335666,
+        "request_ratio": 0.836087,
+        "rss_ratio": null,
+        "mechanism_verified": null
+      }
+    },
+    "R_geomean": 0.811637,
+    "portfolio": {
+      "ci_method": "independent_workload_round_bootstrap_percentile_v1",
+      "ci_level": 0.95,
+      "bootstrap_iterations": 4000,
+      "seed": 2000059846,
+      "ci": [
+        0.786817,
+        0.838525
+      ],
+      "prove_ms_method": "geometric_mean_candidate_workload_medians_ms_v1",
+      "b_median_ms_geomean": 1.335666
+    },
+    "theta": 0.037308,
+    "aa_dispersion": 0.018654,
+    "significant": true,
+    "neutral": false,
+    "promotion_significance": {
+      "eligible": true,
+      "method": "independent_workload_round_bootstrap_percentile_v1",
+      "reason": "prove-time objective uses the deterministic workload portfolio CI"
+    }
+  },
+  "tiebreakers": {
+    "rss_ratio": null,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": null
+  },
+  "holdout": null,
+  "guards": {
+    "guard_blake_10x10": {
+      "r": 0.98552,
+      "ci": [
+        0.957758,
+        1.002983
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "4153acd6e32a98b9d240730062f7fa35e2e31eca915f01c179337f04d409cbd2"
+    },
+    "guard_blake_12x16": {
+      "r": 0.990379,
+      "ci": [
+        0.957599,
+        1.005206
+      ],
+      "rounds": 6,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "70e516957d2d38ed78214bfda5b0b2bdfe41f1c93439fb68e124bfef096fbc9f"
+    },
+    "guard_plonk_14": {
+      "r": 0.864215,
+      "ci": [
+        0.816393,
+        0.915147
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf"
+    },
+    "guard_plonk_16": {
+      "r": 0.873758,
+      "ci": [
+        0.863531,
+        0.893566
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "cfb36bf17fb3526bf1bdd9401fb885fd91ca46b9982fee1ca5fad33a1d574b72"
+    },
+    "guard_poseidon_10": {
+      "r": 0.965413,
+      "ci": [
+        0.956806,
+        0.978082
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "af33240da8e7947362fdf7e78d306f2e11cb2e3df7e1b6f498a6e86ac3ae7b1b"
+    },
+    "guard_poseidon_13": {
+      "r": 0.978113,
+      "ci": [
+        0.953918,
+        1.003042
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "f196835da5d4a155c6311bafb44335c2863cc028879d69a7ae53b802321200f1"
+    },
+    "guard_sm_14": {
+      "r": 0.818606,
+      "ci": [
+        0.814476,
+        0.823463
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "488fadeeb4e5d76b6fc0a9c10ab258bab6673de8e912ae5de927561650920b37"
+    },
+    "guard_sm_16": {
+      "r": 0.902937,
+      "ci": [
+        0.878919,
+        0.917351
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "88ec35ee88a05ce0a5db4b6cb063f4cf7824ee65284db0908a62a9362879af73"
+    },
+    "guard_wf_10x8": {
+      "r": 0.844765,
+      "ci": [
+        0.840083,
+        0.85352
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700"
+    },
+    "guard_wf_14x32": {
+      "r": 0.89233,
+      "ci": [
+        0.867777,
+        0.916883
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374"
+    },
+    "guard_wf_16x64": {
+      "r": 0.937181,
+      "ci": [
+        0.890278,
+        0.988069
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "42086545b7a170c5868afcc390f83d964e06d528e2d1039420fc6bfd7a6aac74"
+    },
+    "guard_xor_14": {
+      "r": 0.832245,
+      "ci": [
+        0.775519,
+        0.89213
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "35bb35714e10888c786a71ccdfe31d2b9b4651c567fac5ba4c9543bc247cad80"
+    },
+    "guard_xor_16": {
+      "r": 0.906805,
+      "ci": [
+        0.898427,
+        0.927875
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "56163b8ea3d877b3b9bf15753b7c0175d4a6ead493640eef8210c59ba7e5215c"
+    }
+  },
+  "rust_oracle": [
+    {
+      "workload": "wf_log10x8",
+      "verified": true,
+      "oracle": "pinned-rust-stwo",
+      "artifact_sha256": "6a2250b56d5e10b6385e3a0f617ef4cee001b5279fd3bbef404a5ccb58ccd7ce"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "riscv",
+      "reason": "RF-01 adapter release and BA-03 autoresearch activation pending"
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "wf_log10x8": {
+        "round_ratios": [
+          0.857569,
+          0.879313,
+          0.751191,
+          0.801151,
+          0.804479,
+          0.91409,
+          0.784104,
+          0.772483,
+          0.784296,
+          0.857288,
+          0.71002,
+          0.81177,
+          0.832768,
+          0.819621,
+          0.81124
+        ],
+        "proof_digest": "91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700",
+        "request_ratio": 0.836087,
+        "rss_ratio": null,
+        "report_sha256s": [
+          "d3d7b777570fafb0d9efb4593ee53232c03b9866271d11afcb441a9321d7146a",
+          "a263fc1863c504c99bee05c2855b0def0725bed3aa8b76cd5f7d876894e95436",
+          "b8b68d0d6c7c2cc84b5100f9a2ce9ce6a1c7b82737255b15ce00ca1a8aeb6356",
+          "058189da504ef59e9050271020b36dad840f99c27afcaebb09157cc6fcdc668d",
+          "aebb680ee42fcade985b6dc0194e368fd62e242a6b00f8d010f260068980acd0",
+          "425403d0c45273c413589603898df18745a861168613a4593e6c4e5cdd58b4d1",
+          "80fe7e011ad7efefd5fee1458c4165cdf3fea443c9a0ee8901ed7d6756895357",
+          "ce47f5c22a71f6a90608d076bdb7cb2374b20bd761e26505beea2a6cbed9511a",
+          "88384378de3a9f0bbb824b816732548d2b07a3a9660641d72a36f5136267fe57",
+          "6f778a6a7a6058bbf56424c74d4c0a65610c8f1f96f761a9247e64a06fc997db",
+          "bf61369ba18105a476bd693724ab4fbbe91158465cd9d4e7063368f090e5a6d5",
+          "3014f8912b6e0aaa38e8eef4addc73f467fa83598e3347cc9b5240afffd21c8f",
+          "45608aceb6d6874078161ead7502e46b808cc8dfa795c553902fe11163eb0779",
+          "92e7140ef51eeb8193ac095a3bcd57d1093fa4f0577ebdb849b5f90445d1ddcf",
+          "04aa171f4d0b26c3bd3c043cb6b82c0c34945e899a55c532c549d909e5f6c968",
+          "3a2e68f18e1688d0494fe241ef6977686e8e500c0ae0c5ab20e879d7b4284126",
+          "44057ef53902b7ba9a13447292ae9e77c7faff01a2437aca1b20d4c905088260",
+          "502287c5f2d94128513452b814acdc816a529e70ed69bc56aa1a7f6c1b6e6734",
+          "db9e25317afdddde8676f1ef012487bd2692f5b7129d618c3d5d8ca693bdca3d",
+          "e9501208fee3789fdbda9629967c045b8011abf682842985f4c46d8029069f91",
+          "e1fdb8d5ec7f9b8ebc1b5d06033765ccd5ab573cae997cf453e491e017fd8cbb",
+          "404e5258d5ab30d79cf05adfd0b8e5f5207d2b807b092b5918a1b9ebad318ea8",
+          "4bf05047b3a40f93a99993083f5e6dcf4c795d19d9f996cb12491082a3b66635",
+          "4f0ffb701b69063fe825bbde805ede6437303d0e01dbae74f91d6df862a2c902",
+          "a9c95a7c0219b7dfb14670060434df564fcb0700323055ed6dce997313029bcc",
+          "111ac68ce7f5218ca1919b043af55c77a27f86179e64ecfe5ba9aaff602395f8",
+          "89854029d4fe5bac81491396f6004dc45a10cbaf3aa6b20be0f1f8fc035ea265",
+          "80c1f6b450adfe7531e657ea61722fa7dfaaedb7d557584ed7a036b7d1f608c4",
+          "df17bdf2fc70a3c35aa062907720a73f45b8cb24639be587f0a316fd403703ef",
+          "ad38ea885eef86bb3f40733c4fdbc2bcbc3a26391f6493d58fbd70f1c8cc361f"
+        ],
+        "mechanism_verified": null
+      }
+    },
+    "reports": [
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.a1.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.b1.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.a2.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.b2.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.a3.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.b3.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.a4.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.b4.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.a5.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.b5.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.a6.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.b6.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.a7.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.b7.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.a8.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.b8.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.a9.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.b9.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.a10.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.b10.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.a11.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.b11.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.a12.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.b12.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.a13.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.b13.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.a14.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.b14.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.a15.json",
+      "/Users/olifreuler/ws2/autoresearch/.runs/latest/wf_log10x8.b15.json"
+    ]
+  }
+}

--- a/src/prover/vcs_lifted/layers.zig
+++ b/src/prover/vcs_lifted/layers.zig
@@ -184,6 +184,154 @@ pub fn Operations(comptime H: type) type {
             return out;
         }
 
+        /// Builds every internal layer above `leaves` in one pass. Workers each
+        /// build a contiguous subtree bottom-up (cache-hot, no per-level
+        /// barrier); the top `log2(W)` levels are finished serially. Layer
+        /// buffers, contents, and allocation order are identical to repeated
+        /// `buildNextLayer` calls — only the traversal schedule differs.
+        /// Appends each new layer to `out_layers` (bottom-up, excluding the
+        /// leaf layer itself).
+        pub fn buildUpperLayersSubtree(
+            list_allocator: std.mem.Allocator,
+            layer_alloc: std.mem.Allocator,
+            leaves: []const H.Hash,
+            executor: *Executor,
+            worker_override: ?usize,
+            out_layers: *std.ArrayList([]H.Hash),
+        ) !void {
+            std.debug.assert(leaves.len > 1 and std.math.isPowerOfTwo(leaves.len));
+            const log_size = std.math.log2_int(usize, leaves.len);
+
+            // Allocate every level buffer up front (same sizes and allocator
+            // as the per-level path).
+            try out_layers.ensureUnusedCapacity(list_allocator, log_size);
+            var allocated: usize = 0;
+            errdefer {
+                // Free only the buffers not yet appended; appended ones are
+                // owned by the caller's errdefer.
+                for (out_layers.items[out_layers.items.len - allocated ..]) |layer| layer_alloc.free(layer);
+                out_layers.items.len -= allocated;
+            }
+            var level_len = leaves.len >> 1;
+            while (level_len >= 1) : (level_len >>= 1) {
+                const buf = try layer_alloc.alloc(H.Hash, level_len);
+                out_layers.appendAssumeCapacity(buf);
+                allocated += 1;
+            }
+            const levels = out_layers.items[out_layers.items.len - allocated ..];
+
+            const seed_available = comptime @hasDecl(H, "nodeSeed") and @hasDecl(H, "hashChildrenWithSeed");
+            const first_out_len = leaves.len >> 1;
+            var workers = parameters.parallelWorkersForLayer(first_out_len, worker_override);
+            if (!executor.enabled or !seed_available) workers = 1;
+
+            if (workers > 1) {
+                // Power-of-two worker count so chunk boundaries align with
+                // subtree boundaries at every level.
+                var w = std.math.floorPowerOfTwo(usize, workers);
+                while (w > 1 and leaves.len / w < 2) w >>= 1;
+                if (w > 1) {
+                    buildSubtreesParallel(leaves, levels, w, executor);
+                    // Serial top: levels of size < w remain.
+                    finishTopSerial(levels, std.math.log2_int(usize, w));
+                    return;
+                }
+            }
+
+            // Serial fallback: identical to sequential buildNextLayer levels.
+            var prev: []const H.Hash = leaves;
+            for (levels) |level| {
+                buildLevelRangeSerial(level, prev, 0, level.len);
+                prev = level;
+            }
+        }
+
+        fn buildLevelRangeSerial(out: []H.Hash, prev_layer: []const H.Hash, start: usize, end: usize) void {
+            if (comptime @hasDecl(H, "nodeSeed") and @hasDecl(H, "hashChildrenWithSeed")) {
+                const ctx: SeededRangeCtx = .{
+                    .out = out,
+                    .prev_layer = prev_layer,
+                    .start = start,
+                    .end = end,
+                    .seed = H.nodeSeed(),
+                };
+                hashSeededRange(&ctx);
+            } else {
+                const ctx: BasicRangeCtx = .{
+                    .out = out,
+                    .prev_layer = prev_layer,
+                    .start = start,
+                    .end = end,
+                };
+                hashBasicRange(&ctx);
+            }
+        }
+
+        const SubtreeCtx = struct {
+            leaves: []const H.Hash,
+            levels: []const []H.Hash,
+            chunk: usize,
+            chunk_count: usize,
+            seed: NodeSeed,
+        };
+
+        fn buildSubtree(ctx: *const SubtreeCtx) void {
+            var prev: []const H.Hash = ctx.leaves;
+            for (ctx.levels) |level| {
+                if (level.len < ctx.chunk_count) break;
+                const nodes_per_chunk = level.len / ctx.chunk_count;
+                const start = ctx.chunk * nodes_per_chunk;
+                const end = start + nodes_per_chunk;
+                const sctx: SeededRangeCtx = .{
+                    .out = level,
+                    .prev_layer = prev,
+                    .start = start,
+                    .end = end,
+                    .seed = ctx.seed,
+                };
+                hashSeededRange(&sctx);
+                prev = level;
+            }
+        }
+
+        fn buildSubtreesParallel(
+            leaves: []const H.Hash,
+            levels: []const []H.Hash,
+            chunk_count: usize,
+            executor: *Executor,
+        ) void {
+            var contexts: [parameters.max_parallel_workers]SubtreeCtx = undefined;
+            const seed = H.nodeSeed();
+            for (0..chunk_count) |chunk| {
+                contexts[chunk] = .{
+                    .leaves = leaves,
+                    .levels = levels,
+                    .chunk = chunk,
+                    .chunk_count = chunk_count,
+                    .seed = seed,
+                };
+            }
+            var wait_group: WaitGroup = .{};
+            for (1..chunk_count) |chunk| {
+                executor.pool().spawnWg(&wait_group, buildSubtree, .{&contexts[chunk]});
+            }
+            buildSubtree(&contexts[0]);
+            wait_group.wait();
+        }
+
+        fn finishTopSerial(levels: []const []H.Hash, top_log: usize) void {
+            // The subtree pass filled every level with len >= chunk_count.
+            // Levels smaller than chunk_count (the top `top_log` levels)
+            // remain: build them serially from the last completed level.
+            const total = levels.len;
+            std.debug.assert(top_log <= total);
+            var idx = total - top_log;
+            while (idx < total) : (idx += 1) {
+                const prev: []const H.Hash = levels[idx - 1];
+                buildLevelRangeSerial(levels[idx], prev, 0, levels[idx].len);
+            }
+        }
+
         const SeededRangeCtx = struct {
             out: []H.Hash,
             prev_layer: []const H.Hash,

--- a/src/prover/vcs_lifted/parameters.zig
+++ b/src/prover/vcs_lifted/parameters.zig
@@ -13,9 +13,64 @@ pub const max_leaf_scratch_bytes: usize = 256 * 1024;
 pub const default_leaf_batch_size: usize = 1 << 12;
 pub const batched_leaf_threshold: usize = 1 << 8;
 
+/// Layer buffers at or above this many bytes come from mmap (sequential-read
+/// hint, pages returned to the OS on free). Smaller buffers go through the
+/// general-purpose heap: an mmap/madvise/munmap round-trip plus first-touch
+/// page faults costs far more than the buffer's entire hash pass for the
+/// small upper layers and the FRI inner-layer tail.
+pub const mmap_layer_threshold_bytes: usize = 1 << 20;
+
+const SizeRoutedLayerAllocator = struct {
+    fn allocator() std.mem.Allocator {
+        return .{
+            .ptr = undefined,
+            .vtable = &.{
+                .alloc = alloc,
+                .resize = resize,
+                .remap = remap,
+                .free = free_fn,
+            },
+        };
+    }
+
+    fn heap() std.mem.Allocator {
+        return std.heap.smp_allocator;
+    }
+
+    fn alloc(_: *anyopaque, len: usize, alignment: std.mem.Alignment, ret_addr: usize) ?[*]u8 {
+        if (len >= mmap_layer_threshold_bytes) {
+            const mmap_vtable = mmap_alloc.MmapAllocator.allocator().vtable;
+            return mmap_vtable.alloc(undefined, len, alignment, ret_addr);
+        }
+        const h = heap();
+        return h.vtable.alloc(h.ptr, len, alignment, ret_addr);
+    }
+
+    fn resize(_: *anyopaque, buf: []u8, alignment: std.mem.Alignment, new_len: usize, ret_addr: usize) bool {
+        if (buf.len >= mmap_layer_threshold_bytes) return false;
+        if (new_len >= mmap_layer_threshold_bytes) return false;
+        const h = heap();
+        return h.vtable.resize(h.ptr, buf, alignment, new_len, ret_addr);
+    }
+
+    fn remap(_: *anyopaque, _: []u8, _: std.mem.Alignment, _: usize, _: usize) ?[*]u8 {
+        return null;
+    }
+
+    fn free_fn(_: *anyopaque, buf: []u8, alignment: std.mem.Alignment, ret_addr: usize) void {
+        if (buf.len >= mmap_layer_threshold_bytes) {
+            const mmap_vtable = mmap_alloc.MmapAllocator.allocator().vtable;
+            mmap_vtable.free(undefined, buf, alignment, ret_addr);
+            return;
+        }
+        const h = heap();
+        h.vtable.free(h.ptr, buf, alignment, ret_addr);
+    }
+};
+
 pub fn layerAllocator(fallback: std.mem.Allocator) std.mem.Allocator {
     if (comptime builtin.os.tag == .macos or builtin.os.tag == .linux) {
-        return mmap_alloc.MmapAllocator.allocator();
+        return SizeRoutedLayerAllocator.allocator();
     }
     return fallback;
 }

--- a/src/prover/vcs_lifted/prover.zig
+++ b/src/prover/vcs_lifted/prover.zig
@@ -156,6 +156,7 @@ pub fn MerkleProverLifted(comptime H: type) type {
             leaves: []H.Hash,
             log_size: u32,
         ) !Self {
+            _ = log_size;
             var leaves_appended = false;
             errdefer if (!leaves_appended) layer_alloc.free(leaves);
 
@@ -172,25 +173,23 @@ pub fn MerkleProverLifted(comptime H: type) type {
 
             if (leaves.len > 1) {
                 const max_out_len = leaves.len >> 1;
+                const worker_override = merkleWorkerOverride(allocator);
                 var executor: LayerExecutor = undefined;
                 executor.init(
                     max_out_len,
-                    merkleWorkerOverride(allocator),
+                    worker_override,
                     reuseAvailablePool(allocator),
                 );
                 defer executor.deinit();
 
-                var i: usize = 0;
-                while (i < log_size) : (i += 1) {
-                    try layers_bottom_up.ensureUnusedCapacity(allocator, 1);
-                    const next_layer = try LayerOps.buildNextLayer(
-                        layer_alloc,
-                        layers_bottom_up.items[layers_bottom_up.items.len - 1],
-                        &executor,
-                        merkleWorkerOverride(allocator),
-                    );
-                    layers_bottom_up.appendAssumeCapacity(next_layer);
-                }
+                try LayerOps.buildUpperLayersSubtree(
+                    allocator,
+                    layer_alloc,
+                    leaves,
+                    &executor,
+                    worker_override,
+                    &layers_bottom_up,
+                );
             }
 
             const out_layers = try allocator.alloc([]H.Hash, layers_bottom_up.items.len);
@@ -301,23 +300,19 @@ pub fn MerkleProverLifted(comptime H: type) type {
 
             if (leaves.len > 1) {
                 std.debug.assert(std.math.isPowerOfTwo(leaves.len));
-                const max_log_size = std.math.log2_int(usize, leaves.len);
                 const max_out_len = leaves.len >> 1;
                 var executor: LayerExecutor = undefined;
                 executor.init(max_out_len, worker_override, reuse_pool);
                 defer executor.deinit();
 
-                var i: usize = 0;
-                while (i < max_log_size) : (i += 1) {
-                    const prev_idx = layers_bottom_up.items.len - 1;
-                    const next_layer = try LayerOps.buildNextLayer(
-                        layer_alloc,
-                        layers_bottom_up.items[prev_idx],
-                        &executor,
-                        worker_override,
-                    );
-                    try layers_bottom_up.append(allocator, next_layer);
-                }
+                try LayerOps.buildUpperLayersSubtree(
+                    allocator,
+                    layer_alloc,
+                    leaves,
+                    &executor,
+                    worker_override,
+                    &layers_bottom_up,
+                );
             }
 
             const out_layers = try allocator.alloc([]H.Hash, layers_bottom_up.items.len);


### PR DESCRIPTION
Submission `2026-07-21-cpu-merkle-subtree-scheduling` (core_cpu, classes small+wide+deep, scope s3).

Mechanism: single-barrier subtree-parallel upper-layer Merkle construction (replacing one thread-pool barrier per level plus fully-serial sub-2048 levels) and size-routed layer buffer allocation (heap below 1 MiB, mmap at or above). Layers are byte-identical by construction; fixed proof digests match on all three workloads.

Claimed S3 verdicts (15 paired rounds each, G1–G5 green, 13/13 guards):

| class | R | 95% CI | theta |
| --- | --- | --- | --- |
| small | 0.8116 | [0.7868, 0.8386] | 0.0373 |
| wide | 0.8921 | [0.8788, 0.9175] | 0.0293 |
| deep | 0.8113 | [0.7957, 0.8276] | 0.0183 |

Full reasoning, dead ends, and the one noise-failed G4 guard run are in the packaged transcripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)