### PR TITLE
Fix guard confidence policy propagation

### DIFF
--- a/autoresearch/cli/stwo_perf/runner.py
+++ b/autoresearch/cli/stwo_perf/runner.py
@@ -1637,6 +1637,7 @@ def run_guards(a_root: Path, b_root: Path, manifest: Manifest,
         "theta_floor": max(budget - 1.0, 0.01),
         "wall_clock_cap_seconds": {"guard": 300},
         "command_timeout_seconds": 300,
+        "ci_level": float(manifest.gates["ci_level"]),
     }
     extra = int(policy.get("inconclusive_extra_rounds", 4))
     results: dict[str, dict] = {}

--- a/autoresearch/tests/test_guards.py
+++ b/autoresearch/tests/test_guards.py
@@ -8,9 +8,13 @@ from stwo_perf import runner  # noqa: E402
 from stwo_perf.manifest import Workload, WorkloadGroup  # noqa: E402
 
 
-def fake_manifest(guards: dict) -> mock.Mock:
+def fake_manifest(guards: dict, ci_level: float = 0.95) -> mock.Mock:
     m = mock.Mock()
-    m.raw = {"workload_registry": {"guards": guards}}
+    m.raw = {
+        "gates_policy": {"ci_level": ci_level},
+        "workload_registry": {"guards": guards},
+    }
+    m.gates = {"ci_level": ci_level}
     return m
 
 
@@ -87,6 +91,30 @@ class CrossArmDigestTest(unittest.TestCase):
                 runner.paired_rounds(
                     Path("/a"), Path("/b"), mock.Mock(), workload, policy, Path("/tmp")
                 )
+
+
+class GuardPolicyTest(unittest.TestCase):
+    def test_guards_inherit_manifest_ci_level(self):
+        workload = Workload(
+            "guard_blake", "guard", "--example blake", "rounds", "native",
+        )
+        score = mock.Mock(
+            r=0.95,
+            ci=(0.90, 0.99),
+            ratios=[0.95],
+            proof_digest="a" * 64,
+        )
+        with mock.patch.object(runner, "paired_rounds", return_value=score) as paired:
+            result = runner.run_guards(
+                Path("/a"),
+                Path("/b"),
+                fake_manifest(GUARDS, ci_level=0.91),
+                [workload],
+                Path("/tmp"),
+            )
+
+        self.assertTrue(result["guard_blake"]["pass"])
+        self.assertEqual(paired.call_args.args[4]["ci_level"], 0.91)
 
 
 class GateFoldingTest(unittest.TestCase):


### PR DESCRIPTION
Fixes #57's deterministic guard-phase crash introduced by Metrics v2.

`paired_rounds` now computes resource-dimension confidence intervals and
requires `policy["ci_level"]`, but `run_guards` constructed a reduced policy
without that field. The guard policy now inherits the authoritative confidence
level from `MANIFEST.json`, matching objective scoring.

The regression test uses a non-default confidence level and verifies that it
reaches the paired guard call. This prevents a hard-coded fallback from hiding
future manifest changes.

Validation:

- `python -m unittest autoresearch.tests.test_guards` — 9 passed
- `python -m unittest autoresearch.tests.test_runner_groups` — 37 passed
- full `autoresearch/tests` discovery — 344 passed
- source conformance — no new violations

This PR fixes the `KeyError: 'ci_level'` crash only. The separate RSS telemetry
question documented in #57 remains open and is not weakened or bypassed here.
