### PR TITLE
Rotate large shared columns across hardware pages

### DIFF
--- a/autoresearch/submissions/2026-07-22-large-column-page-rotation/delta.json
+++ b/autoresearch/submissions/2026-07-22-large-column-page-rotation/delta.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "5bf964b78643",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "xlarge",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/prover/pcs/columns/preparation.zig": "sha256:94eb8fe9977767a5c7a9da80d07de525a2c22c0bafe2908a72bf2834105a9bad"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "326283c413e0ee35c459349ff39ad0aaa85d72845d0b60c58d28ea3f46b502ab",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-22-large-column-page-rotation/note.md
+++ b/autoresearch/submissions/2026-07-22-large-column-page-rotation/note.md
@@ -1,0 +1,106 @@
+# Rotate large shared columns across hardware pages
+
+## Model and harness
+
+GPT-5 Codex optimized candidate `bf7cf1849130` against exact predecessor
+`5bf964b78643` on an Apple M5 Max. The repository CLI was updated before the
+search. Final evidence uses harness `8d9c30a5778c`, ReleaseFast CPU and Metal
+products, paired S3 proof transactions, independent verification, and the
+pinned correctness oracle.
+
+Metal uses the production source-JIT path on this host. Embedded MSL is
+compiled by the macOS Metal runtime before timed samples; no Xcode offline
+compiler is present or required. Every profiled Metal proof remained device-
+accelerated with 26 dispatches at xlarge, 28 at huge, and zero CPU fallbacks.
+
+## Hypothesis
+
+Profiles explained why Metal had not pulled far ahead of CPU. At huge, Metal
+reduced main-trace commitment from roughly 184 ms on CPU to about 91 ms, but
+the hybrid prover then spent about 403 ms evaluating composition on the host.
+That stage walks each row across 100 column-major arrays produced in unified
+memory by Metal.
+
+The already-promoted layout used a 64-byte skew after each power-of-two column.
+That rotates cache-line sets, but an 8 MiB logical column still advances the
+virtual address by an exact power-of-two number of pages. Most simultaneous
+streams therefore retain repeated page/TLB geometry.
+
+```text
+Metal LDE output (unified memory)
+            │
+            ▼
+before: [column N words][64 B]          repeated page geometry
+after:  [column N words][16 KiB + 64 B] page + cache-line rotation
+            │
+            └────────► existing CPU AIR row traversal, no gather/copy
+```
+
+This is conflict-avoiding array padding/page coloring: it preserves every
+logical column slice while changing only physical base addresses. On this
+Apple-silicon host, both `getconf PAGESIZE` and `hw.pagesize` report 16,384
+bytes. For 100 columns the extra storage is only about 1.55 MiB.
+
+## Changes
+
+For groups with at least 64 columns and at least 2^18 M31 values (1 MiB) per
+extended column, the physical stride is now:
+
+```text
+logical_column_words + hardware_page_words + 16 M31 words
+```
+
+Smaller columns keep the predecessor's 64-byte skew exactly. The first broad
+version applied page padding to every 64+-column group. Although Metal huge
+improved 12.67%, Blake regressed 8–10% and Poseidon 12–16% because a 16 KiB pad
+was material at those small sizes. The cost-model gate restores their prior
+layout while selecting xlarge's 2 MiB and huge's 8 MiB extended columns.
+
+No shader, buffer binding, dispatch, synchronization, ownership, proof order,
+or AOT ABI changes. Metal-produced columns remain retained through their
+existing commitment-tree owners and are consumed as the same contiguous
+logical slices.
+
+## Results
+
+| board / class | predecessor median | candidate median | paired R (95% CI) | improvement |
+| --- | ---: | ---: | ---: | ---: |
+| CPU xlarge `wf_log18x100` | 165.947 ms | 146.031 ms | 0.878534 [0.864409, 0.889791] | 12.15% |
+| CPU huge `wf_log20x100` | 687.070 ms | 601.631 ms | 0.878685 [0.875646, 0.883551] | 12.13% |
+| Metal xlarge `mwf_log18x100` | 160.028 ms | 139.680 ms | 0.867736 [0.844552, 0.874057] | 13.23% |
+| Metal huge `mwf_log20x100` | 565.486 ms | 495.138 ms | 0.880262 [0.868619, 0.888441] | 11.97% |
+
+Request-time ratios are 0.920004, 0.919739, 0.916035, and 0.927620 in table
+order. Peak-RSS ratios are 1.003347, 0.995143, 1.003128, and 1.001007; energy
+ratios are 0.933821, 0.934418, 0.901533, and 0.902716. Proof sizes remain
+exactly 74,328 bytes at xlarge and 86,383 bytes at huge.
+
+All four verdicts pass G1–G5 and all 13 regression guards. Every timed proof
+verified, cross-arm digests were byte-identical in every round, and the pinned
+oracle accepted all four objective workloads.
+
+## Profiling attribution and rejected alternatives
+
+Three alternated profiled huge screens isolated the effect. CPU composition
+moved from 327–330 ms to 270–272 ms; Metal composition moved from 363–371 ms
+to 286–289 ms. Metal main-trace commitment stayed around 93–94 ms, so the win
+is specifically the host AIR fan-in over GPU-produced unified memory rather
+than a change in GPU arithmetic or dispatch count.
+
+A smaller synthetic probe using a 4 KiB displacement moved only about 1%; it
+had accidentally modeled one quarter of this host's hardware page. The full
+implementation's 16 KiB displacement and paired complete proofs supplied the
+decisive evidence. Raising the CPU combined-column ceiling did not admit the
+617-column RISC-V tree and was neutral on its already-admitted 188-column tree,
+so that change was reverted. A row-major transpose or full gather would add an
+800 MiB pass and break existing column-slice consumers; unsafe workload-
+specific GPU type inference was rejected because the editable AIR vtable does
+not expose a typed constraint program.
+
+## Caveats and next architecture step
+
+The win deliberately targets megabyte-scale, 64+-column groups. Narrow and
+small-domain shapes retain the predecessor layout. This repairs the dominant
+shared-memory boundary but does not move composition arithmetic onto Metal:
+doing that safely requires an explicit typed constraint IR or GPU-evaluable AIR
+interface rather than guessing through an opaque callback.

--- a/autoresearch/submissions/2026-07-22-large-column-page-rotation/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-22-large-column-page-rotation/transcripts/session-01.md
@@ -1,0 +1,268 @@
+# Autoresearch session 01 — RISC-V and scale portfolio
+
+## Session start
+
+The session began from promoted `main` at `e346656`, then ran the mandatory
+`stwo-perf update` from a clean checkout. The update fast-forwarded to
+`5bf964b78643`, which contains the backend restart fix from PR #70. Two
+pre-existing untracked Metal notes were temporarily stashed and restored with
+their original SHA-256 digests (`81263c43...81f3` and `7654c629...2bd`). They
+are prior-research inputs, not candidate changes.
+
+The objective is another complete autoresearch cycle: establish a fresh local
+suite baseline before editing, profile the largest and longest workloads with
+special priority on the live RISC-V board, implement only a mechanism supported
+by measured attribution, run paired S3 verdicts for every moved board/class,
+submit, and drive the PR through CI and promotion.
+
+All five repository skills were loaded before the baseline:
+
+- `match-algorithmic-problems` for any material algorithm replacement;
+- `zig-profiling` and `metal-profiling` for S1 attribution before edits;
+- `metal-performance-design` plus its required common-patterns reference for
+  resource, ownership, ABI, dispatch, and architecture decisions; and
+- `submission-transcripts` for contemporaneous reasoning and rejected ideas.
+
+No source edit or performance claim has been made yet.
+
+## Fresh full-suite baseline (before edits)
+
+The repository inventory alone does not time workloads, so all three
+ReleaseFast products were built and every manifest-owned scored row was run
+locally with one verified warmup and one verified sample. This is diagnostic
+grounding, not promotion evidence. Native CPU and Metal proofs were
+byte-identical for every class, Metal reported zero CPU fallbacks, and all 20
+RISC-V artifacts verified.
+
+Native prove medians (ms):
+
+| class | CPU | Metal | Metal dispatches | proof digest prefix |
+| --- | ---: | ---: | ---: | --- |
+| small | 1.526 | 6.919 | 18 | `91741aec9568` |
+| wide | 7.164 | 12.189 | 22 | `57a7d291eb8a` |
+| deep | 4.733 | 9.593 | 24 | `d63a2c928461` |
+| xlarge | 167.371 | 163.914 | 26 | `f845568c1459` |
+| huge | 683.905 | 587.854 | 28 | `e6609d0564a4` |
+
+The full RISC-V basket took 10.111 s small, 16.845 s wide, and 20.121 s deep
+when program request times are summed. Proving accounts for 9.615 s, 14.938 s,
+and 17.841 s respectively. The slowest row is SHA2-2048 at 4.104 s total:
+3.377 s proving, 0.617 s witness generation, and 0.091 s verification. Tiny
+eight-step ALU/declared-region programs still take about 1.59 s, with roughly
+1.50 s in proving. This rules out guest execution as the general bottleneck
+and motivates profiling shared prover/PCS infrastructure first, while the
+crypto-heavy deep tail also warrants a separate witness-generation check.
+
+The Native results show the previously promoted skewed arena has closed the
+xlarge CPU/Metal gap and made Metal the huge leader. Small Native classes are
+still dispatch-economics dominated, but the objective prioritizes the longest
+coordinates: RISC-V deep/wide and Native huge/xlarge.
+
+## User steering and first architectural profile
+
+The user explicitly challenged the small Metal/CPU gap and authorized a deeper
+Metal architecture change. That concern is supported by the profile rather
+than dismissed as generic GPU overhead. On huge wide Fibonacci, profiled CPU
+prove was 705 ms and Metal 642 ms. Metal substantially accelerates stages that
+actually run on device—main-trace commit 184 -> 91 ms and FRI 87 -> 39 ms—but
+composition evaluation is 403 ms on the Metal product versus 341 ms on CPU.
+It is 63% of Metal prove time. Metal uses 28 dispatches with zero fallback, so
+the dominant gap is a host AIR stage between otherwise accelerated epochs.
+
+The current type-erased component callback exposes only a whole-domain scalar
+operation. Prior transcripts independently rejected a generic GPU rewrite:
+the wide-Fibonacci recurrence lives in locked `src/examples`, the generic AIR
+derive/vtable is also outside the editable surface, and identifying recurrence
+semantics from an opaque context or trace shape would be unsound. A future
+upstream interface should expose typed/batched constraint programs, but this
+submission cannot weaken the editable-path contract to obtain that result.
+
+The latest promoted arena already made a large architectural gain by placing
+the 100 shared evaluation columns at `power_of_two_bytes + 64` byte strides.
+That rotates cache-line set geometry. At huge, however, each logical column is
+8 MiB: the 64-byte pad changes the virtual page only once per 64 columns, so
+most of the 100 simultaneous streams retain a 2048-page stride and repeated
+translation-set geometry. The next falsifiable layout experiment is an odd
+page stride plus one cache line. I initially modeled a 4 KiB page here; the
+real Apple-silicon host page was subsequently measured as 16 KiB. The live
+implementation uses `std.heap.pageSize()`, so its actual pad is 16,384+64
+bytes and adds about 1.55 MiB for 100 columns.
+The CPU combined-arena upper bound is also currently 256 columns; RISC-V
+reports 132 opcode plus 485 infrastructure columns, so raising the bound to
+512 is the direct test of whether the same conflict-avoidance architecture
+removes part of its fixed proving floor.
+
+Real-device capability evidence: Apple M5 Max, 32 KiB maximum threadgroup
+memory, 1024 maximum threads/threadgroup, 55.66 GB recommended working set,
+unified memory. No optional Metal feature or new command is required by the
+layout experiment.
+
+A three-second whole-process sample of RISC-V SHA2-2048 additionally found
+`quotient_tile_executor.execute` as the largest active top-of-stack frame
+(1036 samples), with Merkle leaves, circle extension, constraint evaluation,
+and witness ingestion behind it. `__ulock_wait2` counts are mostly idle pool
+threads and are not treated as useful work. This makes quotient execution a
+second candidate if the storage sweep is falsified.
+
+## Problem-match and Metal design brief: translation-safe shared columns
+
+```text
+Task and required semantics:
+  Place column-major M31 evaluations so the existing row-wise AIR evaluator,
+  Metal commitment kernels, FRI aliases, and openings observe identical
+  logical slices and proof order.
+
+Inputs, scale, encoding, model:
+  Native huge: 100 columns x 2^21 M31 evaluations after blowup (8 MiB/column).
+  RISC-V: observed 132 opcode and 485 infrastructure columns across small
+  quotient domains. Apple M5 Max UMA; cost model is cache-line and DTLB/set
+  transfers plus unchanged arithmetic.
+
+Constraints and structure:
+  Each public column remains contiguous and original length; backing metadata
+  is private to preparation/backend boundaries. Proof bytes, row order,
+  dispatch order, AOT ABI, and completion ownership are invariant.
+
+Candidate canonical matches:
+  1. conflict-avoiding array padding/page coloring (exact layout transform);
+  2. row-major transpose (exact, but breaks column-slice consumers);
+  3. typed GPU constraint program (best long-term compute mapping, but locked
+     AIR/vtable interface cannot describe it safely in this submission);
+  4. tiled gather before composition (exact but adds a full 800 MiB pass).
+
+Chosen variant and mapping:
+  Conflict-avoiding padding of concurrent power-of-two streams. Change the
+  physical stride from N+16 M31 words to N+(page_words+16), and let CPU groups
+  through 512 columns use the existing combined arena. Logical recovery is
+  identity slicing from the padded backing.
+
+Complexity and limits:
+  Work remains O(rows*columns). On this 16 KiB-page host, native 100-column
+  storage overhead is ~1.55 MiB; a 485-column group adds <8 MiB. No extra pass
+  or in-flight copy.
+
+End-to-end prediction and falsifier:
+  Huge composition should fall by >=10% if translation conflicts remain;
+  xlarge and all guards should remain neutral or improve. RISC-V class time
+  should move if its 485-column groups enter the combined path. Reject if
+  composition does not move, RSS crosses its gate, any proof changes, or a
+  guard regresses.
+
+Metal resource/ownership plan:
+  The existing shared evaluation arena remains GPU-produced and retained by
+  commitment-tree owners through last use. Only offsets/size change. Existing
+  command completion remains the CPU ownership boundary before composition.
+  No new buffer class, encoder, pipeline, binding, wait, or feature fallback.
+
+Validation:
+  S1 live-field skew sweep, profiled huge CPU/Metal stages, full Native proof
+  parity, exact RISC-V artifacts, ReleaseFast tests, AOT/source-JIT gates, then
+  paired S3 only for classes whose diagnostics move.
+```
+
+## S1 result: page coloring is nearly neutral
+
+The isolated live-field harness used the repository's `M31`/`QM31` types,
+100 columns, a power-of-two logical stride, 16,384 sampled rows, and the same
+98-term recurrence/secure-accumulation shape as the wide AIR. Five measured
+rounds of two iterations gave:
+
+| physical pad | median ns/op | min ns/op | instructions/op | cycles/op | IPC |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 16 M31 words (64 B) | 1.254 | 1.103 | 42.16 | 5.052 | 8.344 |
+| 1040 M31 words (4 KiB+64 B probe) | 1.241 | 1.131 | 42.16 | 5.016 | 8.405 |
+
+The approximately 1% median change was too small to support the predicted
+translation-conflict mechanism at that displacement. The later `getconf
+PAGESIZE`/`hw.pagesize` check returned 16,384 bytes: S1 had tested a quarter
+page, while the repository implementation correctly used the real page size.
+That mismatch explains why the full implementation produced a much larger
+signal and is retained as an explicit experimental correction.
+
+## S3 diagnostic screen: full-domain geometry confirms the mechanism
+
+Contrary to the deliberately smaller S1 harness, three alternated predecessor /
+candidate huge runs showed a repeatable full-proof improvement. The larger
+domain and real commitment/evaluator lifetime are therefore essential to the
+effect:
+
+| backend | predecessor prove range | candidate prove range | predecessor composition | candidate composition |
+| --- | ---: | ---: | ---: | ---: |
+| CPU | 679.18–679.87 ms | 600.15–608.98 ms | 327.30–330.03 ms | 269.90–271.60 ms |
+| Metal | 585.82–591.76 ms | 503.26–513.61 ms | 363.25–370.89 ms | 285.69–289.10 ms |
+
+Every run produced the canonical huge digest
+`e6609d0564a47192212bec7973e2660c2eea88bef90c573c3df09569cc3c7e86`.
+Metal retained 28 dispatches and zero CPU fallbacks. Its main-trace commitment
+remained about 93–94 ms, isolating the gain to the host AIR traversal over
+GPU-produced unified-memory columns. Candidate peak physical footprint was
+within roughly 2 MiB of the predecessor in paired runs.
+
+The separate CPU maximum-column experiment did not actually admit the
+617-column RISC-V tree (and the already-admitted 188-column interaction tree
+was neutral). Two paired ALU diagnostics were 1570.3/1571.7 ms predecessor
+versus 1564.7/1579.4 ms candidate with identical artifacts, so that constant
+is reverted. Only the evidenced physical-stride change remains.
+
+## First official Metal huge verdict and guard-driven scale boundary
+
+The five-round official S3 Metal huge objective was significant at ratio
+0.8733, 95% CI [0.8640, 0.8832], 575.979 ms predecessor versus 507.800 ms
+candidate. G1, G2, G3, and resource/request checks passed, but G4 correctly
+rejected the broad page-padding policy: Blake guards regressed 8–10% and
+Poseidon guards 12–16%. Those shapes have small physical columns, so a fixed
+16 KiB pad is a large fraction of useful storage and defeats locality.
+
+The refinement follows the measured cost model rather than naming AIRs:
+columns below 2^18 M31 words retain the already-promoted 64-byte skew exactly;
+only groups with at least 64 columns and at least 1 MiB of useful data per
+column receive the page-plus-line rotation. This leaves every failing guard's
+layout identical to the predecessor while selecting xlarge (2 MiB extended
+columns) and huge (8 MiB extended columns). The official verdict is discarded
+and will be regenerated with all guards.
+
+## Final official verdicts
+
+The scale-gated layout produced four clean, significant S3 verdicts against
+exact predecessor `5bf964b78643` at candidate `bf7cf1849130`:
+
+| board / class | predecessor | candidate | ratio (95% CI) | improvement |
+| --- | ---: | ---: | ---: | ---: |
+| CPU xlarge | 165.947 ms | 146.031 ms | 0.878534 [0.864409, 0.889791] | 12.15% |
+| CPU huge | 687.070 ms | 601.631 ms | 0.878685 [0.875646, 0.883551] | 12.13% |
+| Metal xlarge | 160.028 ms | 139.680 ms | 0.867736 [0.844552, 0.874057] | 13.23% |
+| Metal huge | 565.486 ms | 495.138 ms | 0.880262 [0.868619, 0.888441] | 11.97% |
+
+All four pass G1–G5, all 13 regression guards, request-time gates, resource
+budgets, cross-arm proof equality, and the pinned oracle. Proof sizes remain
+74,328 bytes at xlarge and 86,383 bytes at huge. Metal diagnostic runs retain
+26/28 dispatches for xlarge/huge and zero CPU fallback.
+
+The first two Metal-xlarge suites were not claimed: the objective was already
+significant, but unchanged tiny Fibonacci guards exceeded their CI budget.
+Subsequent clean sequential evidence passed without a source change. This is
+recorded rather than hiding the retry.
+
+The resulting dataflow is:
+
+```text
+Metal LDE writes contiguous logical columns into unified memory
+                         │
+                         ▼
+  before: stride N + 64 B
+          cache-line index rotates; most page/TLB geometry repeats
+
+  large:  stride N + 16 KiB + 64 B
+          page index rotates ───────┐
+          cache-line index rotates ─┴─► CPU AIR row fan-in de-aliased
+                         │
+                         ▼
+           identical logical slices, commitments, and proof bytes
+```
+
+This explains why Metal was only modestly ahead of CPU: the benchmark is a
+hybrid prover, and huge composition remained a CPU traversal over 100
+GPU-produced unified-memory columns. The GPU-owned stages were accelerated,
+but the host traversal dominated. This change removes a large memory-system
+penalty at that boundary; a future larger step would require a typed AIR
+constraint representation that can safely execute composition itself on GPU.

--- a/autoresearch/submissions/2026-07-22-large-column-page-rotation/verdict-core_metal-huge.json
+++ b/autoresearch/submissions/2026-07-22-large-column-page-rotation/verdict-core_metal-huge.json
@@ -1,0 +1,409 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "8d9c30a5778c",
+  "repo_commit": "bf7cf1849130",
+  "predecessor_commit": "5bf964b78643",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_metal",
+    "workload_class": "huge",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 1.6
+    }
+  },
+  "search_health": {
+    "schema_version": 1,
+    "decision": {
+      "schema_version": 1,
+      "board": "core_metal",
+      "workload_class": "huge",
+      "trailing_window": 8,
+      "trailing_evidence_count": 1,
+      "trailing_median_gradient_snr": 2.7945331422588597,
+      "gradient_snr_threshold": 2.0,
+      "configured_rounds": 5,
+      "auto_boost_rounds": 5,
+      "maximum_rounds": 25,
+      "target_rounds": 5,
+      "workload_count": 1,
+      "class_wall_deadline_seconds": 1200.0,
+      "estimated_seconds_per_round": 14.440788941597566,
+      "deadline_round_limit": 83,
+      "auto_boost_applied": false,
+      "auto_boost_reason": "trailing_median_at_or_above_threshold",
+      "recorded_before_measurement": true
+    },
+    "decision_sha256": "sha256:47c7eda933a20c41bca93b5cb79c4cdc4face28ba99673218add3345e4033039",
+    "actual_rounds": 5,
+    "actual_rounds_per_workload": {
+      "mwf_log20x100": 5
+    },
+    "objective_wall_seconds": 18.81972700008191,
+    "measurement_wall_seconds": 49.54579383309465,
+    "measurement_wall_hours": 0.013762720509192958,
+    "gradient_snr": null,
+    "credited_ln_improvement": null,
+    "credited_ln_improvement_per_measurement_hour": null,
+    "credit_status": "pending_ledger_adjudication",
+    "decision_record": "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/search-health-decision.json"
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned correctness oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "native mechanism telemetry policy unchanged"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.2988 vs targeted budget x1.02; matrix row upper CIs 1/1 within budget x1.05; regression guards 13/13 within budget; request ratios 1/1 present rows within budget x1.05; resource vectors 1/1 within named budgets"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "mwf_log20x100": {
+        "r": 0.880262,
+        "ci": [
+          0.868619,
+          0.888441
+        ],
+        "rounds": 5,
+        "a_median_ms": 565.486292,
+        "b_median_ms": 495.137958,
+        "request_ratio": 0.92762,
+        "rss_ratio": 1.001007,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.902716,
+            "ci": [
+              0.899152,
+              0.909376
+            ],
+            "observations": 5,
+            "candidate": 9.81969072
+          },
+          "peak_rss_mib": {
+            "ratio": 1.001007,
+            "ci": [
+              1.000869,
+              1.001126
+            ],
+            "observations": 5,
+            "candidate": 1646.5331954956055
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 86383.0
+          }
+        },
+        "mechanism_verified": null,
+        "proof_bytes": 86383,
+        "measurement_seconds": 18.797635,
+        "resources_complete": null
+      }
+    },
+    "R_geomean": 0.880262,
+    "portfolio": {
+      "ci_method": "independent_workload_round_bootstrap_percentile_v1",
+      "ci_level": 0.95,
+      "bootstrap_iterations": 4000,
+      "seed": 423517478,
+      "ci": [
+        0.868619,
+        0.888441
+      ],
+      "prove_ms_method": "geometric_mean_candidate_workload_medians_ms_v1",
+      "b_median_ms_geomean": 495.137958,
+      "proof_bytes_method": "rounded_geometric_mean_candidate_proof_bytes_v1",
+      "proof_bytes": 86383,
+      "measurement_seconds": 18.797635,
+      "measurement_rounds": 5
+    },
+    "theta": 0.01,
+    "aa_dispersion": 0.004282,
+    "significant": true,
+    "neutral": false,
+    "promotion_significance": {
+      "eligible": true,
+      "method": "independent_workload_round_bootstrap_percentile_v1",
+      "reason": "prove-time objective uses the deterministic workload portfolio CI"
+    },
+    "resource_portfolio": {
+      "peak_rss_mib": {
+        "ratio_geomean": 1.0010069560146908,
+        "upper_ci_geomean": 1.001125635974093,
+        "candidate_geomean": 1646.533195495605
+      },
+      "energy_j": {
+        "ratio_geomean": 0.9027164901130639,
+        "upper_ci_geomean": 0.9093760385500721,
+        "candidate_geomean": 9.819690720000002
+      },
+      "proof_bytes": {
+        "ratio_geomean": 1.0,
+        "upper_ci_geomean": 1.0,
+        "candidate_geomean": 86382.99999999994
+      }
+    }
+  },
+  "tiebreakers": {
+    "rss_ratio": 1.001007,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": 9.819690720000002,
+    "proof_bytes": 86382.99999999994
+  },
+  "holdout": null,
+  "guards": {
+    "guard_blake_10x10": {
+      "r": 1.00771,
+      "ci": [
+        0.99387,
+        1.03036
+      ],
+      "rounds": 6,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "4153acd6e32a98b9d240730062f7fa35e2e31eca915f01c179337f04d409cbd2"
+    },
+    "guard_blake_12x16": {
+      "r": 0.976154,
+      "ci": [
+        0.973508,
+        0.977354
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "70e516957d2d38ed78214bfda5b0b2bdfe41f1c93439fb68e124bfef096fbc9f"
+    },
+    "guard_plonk_14": {
+      "r": 0.985724,
+      "ci": [
+        0.967625,
+        1.00714
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf"
+    },
+    "guard_plonk_16": {
+      "r": 1.009165,
+      "ci": [
+        0.997195,
+        1.015342
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "cfb36bf17fb3526bf1bdd9401fb885fd91ca46b9982fee1ca5fad33a1d574b72"
+    },
+    "guard_poseidon_10": {
+      "r": 1.007641,
+      "ci": [
+        0.979522,
+        1.035621
+      ],
+      "rounds": 12,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "af33240da8e7947362fdf7e78d306f2e11cb2e3df7e1b6f498a6e86ac3ae7b1b"
+    },
+    "guard_poseidon_13": {
+      "r": 0.980273,
+      "ci": [
+        0.965631,
+        0.989772
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "f196835da5d4a155c6311bafb44335c2863cc028879d69a7ae53b802321200f1"
+    },
+    "guard_sm_14": {
+      "r": 0.999811,
+      "ci": [
+        0.980808,
+        1.023845
+      ],
+      "rounds": 7,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "488fadeeb4e5d76b6fc0a9c10ab258bab6673de8e912ae5de927561650920b37"
+    },
+    "guard_sm_16": {
+      "r": 1.004046,
+      "ci": [
+        0.982568,
+        1.0407
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "88ec35ee88a05ce0a5db4b6cb063f4cf7824ee65284db0908a62a9362879af73"
+    },
+    "guard_wf_10x8": {
+      "r": 0.955345,
+      "ci": [
+        0.898166,
+        1.015341
+      ],
+      "rounds": 12,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700"
+    },
+    "guard_wf_14x32": {
+      "r": 0.988659,
+      "ci": [
+        0.985548,
+        0.99323
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374"
+    },
+    "guard_wf_16x64": {
+      "r": 0.997801,
+      "ci": [
+        0.982647,
+        1.03064
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "42086545b7a170c5868afcc390f83d964e06d528e2d1039420fc6bfd7a6aac74"
+    },
+    "guard_xor_14": {
+      "r": 0.97716,
+      "ci": [
+        0.950149,
+        1.009259
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "35bb35714e10888c786a71ccdfe31d2b9b4651c567fac5ba4c9543bc247cad80"
+    },
+    "guard_xor_16": {
+      "r": 1.00656,
+      "ci": [
+        0.997264,
+        1.033602
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "56163b8ea3d877b3b9bf15753b7c0175d4a6ead493640eef8210c59ba7e5215c"
+    }
+  },
+  "rust_oracle": [
+    {
+      "workload": "mwf_log20x100",
+      "verified": true,
+      "oracle": "pinned-rust-stwo",
+      "artifact_sha256": "8a66bd21ec4076cde6d887ec1a10f034b34a8597e28643f57aae14dbd9cbf00e"
+    }
+  ],
+  "skipped_groups": [],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "mwf_log20x100": {
+        "round_ratios": [
+          0.891736,
+          0.880398,
+          0.861859,
+          0.875379,
+          0.885146
+        ],
+        "proof_digest": "e6609d0564a47192212bec7973e2660c2eea88bef90c573c3df09569cc3c7e86",
+        "request_ratio": 0.92762,
+        "rss_ratio": 1.001007,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.902716,
+            "ci": [
+              0.899152,
+              0.909376
+            ],
+            "observations": 5,
+            "candidate": 9.81969072
+          },
+          "peak_rss_mib": {
+            "ratio": 1.001007,
+            "ci": [
+              1.000869,
+              1.001126
+            ],
+            "observations": 5,
+            "candidate": 1646.5331954956055
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 86383.0
+          }
+        },
+        "report_sha256s": [
+          "f0138d3825f68b33e39ce448a7c6a095b73f17f78841c773d101b8a39e03e446",
+          "8faf7afa44d137bec2130e3f99fcfc5cc6a4efe0c647888ea5d949946f01c002",
+          "7f91e87310a10c8a381049fc9a63a539db61b0a573c71ed7d32711b02e7630ed",
+          "6b6e2704a32f3470cb4d8b167c712ae388c17640bedfdc4777f9b4bb55c4763a",
+          "37275227cb4b5a44771af676bdc18c6b72780a471a414a422b0084ad3bf09f37",
+          "f6748dfb7293d0a56b589c57acb3d38d45a3b700534dda5ded04fcfb765d4b13",
+          "2707d670a3f1c7e1273d2a424f7b16ebf8c60b06da12c04d5d5bfd5b49699bef",
+          "439aa93ca1b4fa8ee6e487606959bd5f9f48a811c90fba5d5722dbad026c7da7",
+          "73271800a48480fd152de15c6228d1a2b36c2f755309cd580d9a93a838aa404a",
+          "838ffb8da723eeed6fc6887d14a32d4be45e9e3f8d1a4c5b67221d0d15f61fc8"
+        ],
+        "mechanism_verified": null,
+        "resources_complete": null
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log20x100.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log20x100.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log20x100.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log20x100.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log20x100.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log20x100.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log20x100.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log20x100.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log20x100.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log20x100.b5.json"
+    ]
+  }
+}

--- a/autoresearch/submissions/2026-07-22-large-column-page-rotation/verdict-core_metal-xlarge.json
+++ b/autoresearch/submissions/2026-07-22-large-column-page-rotation/verdict-core_metal-xlarge.json
@@ -1,0 +1,429 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "8d9c30a5778c",
+  "repo_commit": "bf7cf1849130",
+  "predecessor_commit": "5bf964b78643",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_metal",
+    "workload_class": "xlarge",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 3.32
+    }
+  },
+  "search_health": {
+    "schema_version": 1,
+    "decision": {
+      "schema_version": 1,
+      "board": "core_metal",
+      "workload_class": "xlarge",
+      "trailing_window": 8,
+      "trailing_evidence_count": 2,
+      "trailing_median_gradient_snr": 25.895975706770116,
+      "gradient_snr_threshold": 2.0,
+      "configured_rounds": 9,
+      "auto_boost_rounds": 5,
+      "maximum_rounds": 25,
+      "target_rounds": 9,
+      "workload_count": 1,
+      "class_wall_deadline_seconds": 900.0,
+      "estimated_seconds_per_round": 11.106371741706973,
+      "deadline_round_limit": 81,
+      "auto_boost_applied": false,
+      "auto_boost_reason": "trailing_median_at_or_above_threshold",
+      "recorded_before_measurement": true
+    },
+    "decision_sha256": "sha256:cf01b072c2e982c8edde63814cf0b708e9af89c33cc1c5d76accfd35e8c9d711",
+    "actual_rounds": 9,
+    "actual_rounds_per_workload": {
+      "mwf_log18x100": 9
+    },
+    "objective_wall_seconds": 22.79133108293172,
+    "measurement_wall_seconds": 43.252036958001554,
+    "measurement_wall_hours": 0.012014454710555986,
+    "gradient_snr": null,
+    "credited_ln_improvement": null,
+    "credited_ln_improvement_per_measurement_hour": null,
+    "credit_status": "pending_ledger_adjudication",
+    "decision_record": "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/search-health-decision.json"
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned correctness oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "native mechanism telemetry policy unchanged"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.3308 vs targeted budget x1.02; matrix row upper CIs 1/1 within budget x1.05; regression guards 13/13 within budget; request ratios 1/1 present rows within budget x1.05; resource vectors 1/1 within named budgets"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "mwf_log18x100": {
+        "r": 0.867736,
+        "ci": [
+          0.844552,
+          0.874057
+        ],
+        "rounds": 9,
+        "a_median_ms": 160.028041,
+        "b_median_ms": 139.67998,
+        "request_ratio": 0.916035,
+        "rss_ratio": 1.003128,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.901533,
+            "ci": [
+              0.898153,
+              0.905344
+            ],
+            "observations": 9,
+            "candidate": 5.959912028
+          },
+          "peak_rss_mib": {
+            "ratio": 1.003128,
+            "ci": [
+              1.003022,
+              1.0034
+            ],
+            "observations": 9,
+            "candidate": 518.7046585083008
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 74328.0
+          }
+        },
+        "mechanism_verified": null,
+        "proof_bytes": 74328,
+        "measurement_seconds": 22.734779,
+        "resources_complete": null
+      }
+    },
+    "R_geomean": 0.867736,
+    "portfolio": {
+      "ci_method": "independent_workload_round_bootstrap_percentile_v1",
+      "ci_level": 0.95,
+      "bootstrap_iterations": 4000,
+      "seed": 2651074401,
+      "ci": [
+        0.844552,
+        0.874057
+      ],
+      "prove_ms_method": "geometric_mean_candidate_workload_medians_ms_v1",
+      "b_median_ms_geomean": 139.679979,
+      "proof_bytes_method": "rounded_geometric_mean_candidate_proof_bytes_v1",
+      "proof_bytes": 74328,
+      "measurement_seconds": 22.734779,
+      "measurement_rounds": 9
+    },
+    "theta": 0.018954,
+    "aa_dispersion": 0.009477,
+    "significant": true,
+    "neutral": false,
+    "promotion_significance": {
+      "eligible": true,
+      "method": "independent_workload_round_bootstrap_percentile_v1",
+      "reason": "prove-time objective uses the deterministic workload portfolio CI"
+    },
+    "resource_portfolio": {
+      "peak_rss_mib": {
+        "ratio_geomean": 1.0031275345862707,
+        "upper_ci_geomean": 1.0033997026237609,
+        "candidate_geomean": 518.7046585083007
+      },
+      "energy_j": {
+        "ratio_geomean": 0.9015332477481421,
+        "upper_ci_geomean": 0.9053436907848593,
+        "candidate_geomean": 5.959912027999999
+      },
+      "proof_bytes": {
+        "ratio_geomean": 1.0,
+        "upper_ci_geomean": 1.0,
+        "candidate_geomean": 74328.00000000003
+      }
+    }
+  },
+  "tiebreakers": {
+    "rss_ratio": 1.003128,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": 5.959912027999999,
+    "proof_bytes": 74328.00000000003
+  },
+  "holdout": null,
+  "guards": {
+    "guard_blake_10x10": {
+      "r": 1.006325,
+      "ci": [
+        0.96733,
+        1.022265
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "4153acd6e32a98b9d240730062f7fa35e2e31eca915f01c179337f04d409cbd2"
+    },
+    "guard_blake_12x16": {
+      "r": 0.996607,
+      "ci": [
+        0.975563,
+        1.024693
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "70e516957d2d38ed78214bfda5b0b2bdfe41f1c93439fb68e124bfef096fbc9f"
+    },
+    "guard_plonk_14": {
+      "r": 0.992634,
+      "ci": [
+        0.984842,
+        1.010767
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf"
+    },
+    "guard_plonk_16": {
+      "r": 1.000042,
+      "ci": [
+        0.99103,
+        1.012318
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "cfb36bf17fb3526bf1bdd9401fb885fd91ca46b9982fee1ca5fad33a1d574b72"
+    },
+    "guard_poseidon_10": {
+      "r": 0.993463,
+      "ci": [
+        0.963945,
+        1.028132
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "af33240da8e7947362fdf7e78d306f2e11cb2e3df7e1b6f498a6e86ac3ae7b1b"
+    },
+    "guard_poseidon_13": {
+      "r": 1.021771,
+      "ci": [
+        0.988898,
+        1.036441
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "f196835da5d4a155c6311bafb44335c2863cc028879d69a7ae53b802321200f1"
+    },
+    "guard_sm_14": {
+      "r": 1.004973,
+      "ci": [
+        0.994593,
+        1.018636
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "488fadeeb4e5d76b6fc0a9c10ab258bab6673de8e912ae5de927561650920b37"
+    },
+    "guard_sm_16": {
+      "r": 1.005255,
+      "ci": [
+        0.989761,
+        1.018486
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "88ec35ee88a05ce0a5db4b6cb063f4cf7824ee65284db0908a62a9362879af73"
+    },
+    "guard_wf_10x8": {
+      "r": 0.941736,
+      "ci": [
+        0.853138,
+        1.002357
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700"
+    },
+    "guard_wf_14x32": {
+      "r": 0.976326,
+      "ci": [
+        0.955115,
+        1.003823
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374"
+    },
+    "guard_wf_16x64": {
+      "r": 0.973895,
+      "ci": [
+        0.970003,
+        0.982151
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "42086545b7a170c5868afcc390f83d964e06d528e2d1039420fc6bfd7a6aac74"
+    },
+    "guard_xor_14": {
+      "r": 1.017404,
+      "ci": [
+        1.003362,
+        1.036345
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "35bb35714e10888c786a71ccdfe31d2b9b4651c567fac5ba4c9543bc247cad80"
+    },
+    "guard_xor_16": {
+      "r": 0.995942,
+      "ci": [
+        0.986316,
+        0.999979
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "56163b8ea3d877b3b9bf15753b7c0175d4a6ead493640eef8210c59ba7e5215c"
+    }
+  },
+  "rust_oracle": [
+    {
+      "workload": "mwf_log18x100",
+      "verified": true,
+      "oracle": "pinned-rust-stwo",
+      "artifact_sha256": "49f9555c8a3d6d1f47045a7a22caf961745d503174d840b8e21a414aaf74cfb4"
+    }
+  ],
+  "skipped_groups": [],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "mwf_log18x100": {
+        "round_ratios": [
+          0.863937,
+          0.876438,
+          0.871534,
+          0.876579,
+          0.812526,
+          0.862167,
+          0.869413,
+          0.858808,
+          0.87753
+        ],
+        "proof_digest": "f845568c14599a08c16a14bf255b2e1938df3df27cfdbf961d06f663909ced8f",
+        "request_ratio": 0.916035,
+        "rss_ratio": 1.003128,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.901533,
+            "ci": [
+              0.898153,
+              0.905344
+            ],
+            "observations": 9,
+            "candidate": 5.959912028
+          },
+          "peak_rss_mib": {
+            "ratio": 1.003128,
+            "ci": [
+              1.003022,
+              1.0034
+            ],
+            "observations": 9,
+            "candidate": 518.7046585083008
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 74328.0
+          }
+        },
+        "report_sha256s": [
+          "f4a54f7e050257b84f008ed742cfada08b569e05a9f00fbecc1b001d904f31b3",
+          "ac3959a06bc140b05fc85af3ce59be37548726571254941ab5b7b4d7b4508c12",
+          "4dc68106b009a561e2e36daf6b59927d4d2558cf64ad91a77e7f726d0fc210e1",
+          "71dba4824bb2c531d29ba6ec831ff3760f06fb11539aabb2de2dd7160afc5cdb",
+          "cb83ecf4a37c382cd62e3a961b4f6488d763ed6d3cb01a5a732593481146eee1",
+          "5736f802615279535ed60ac74125484e088143026ad05ba781f20aed5b2294e5",
+          "d1abd69f9330cbe46dc5a3109974ebd56b72a4e8cc498596a333be20226a5d48",
+          "eaf7210c483efe46e0eadc6d9d81e830e1176735ec4a433ac986b7edfb598077",
+          "c53c2968413a1c50b28a1d738c5e72f0553e57590328f03ec11b005998893b1f",
+          "e473556f28902cfa94ed77f15ceff1bf7dc08530ced3d684db3c9ee66664b5ed",
+          "124a087112b7cf7f147f5383cb63b65081515a42cb676a6c550f79378ac1cb2c",
+          "62eb393b7d59fdcd2ae6c61a20c11aadea7a4f0fd6e05db1d0ecf4caa5e37d05",
+          "fb22f0bbb349739239b917bc180919c52a08acaf3b41598b78dcb95f98500d2e",
+          "e235d02afa53806ba7c7c23b0e3321bf7f386835cb7793ee5414f7e6f0bab77c",
+          "fea94f8d8d03fe5c18e4cc453471e7add634148b22f50ce3c5d80721ebaf54d9",
+          "5cc9ed8b5f5cbdc9127d4c1f6f2bee5599ec3deb3f1806bd8988d7db296e85e2",
+          "09cdf4d032bc57481307d622aff8547379cdcfbef61db7ee2992323c3c2fd1f8",
+          "61e5cbf25e3328cad15fc34dbb2478672db276fb0544113376768c40323e9d6c"
+        ],
+        "mechanism_verified": null,
+        "resources_complete": null
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log18x100.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log18x100.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log18x100.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log18x100.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log18x100.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log18x100.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log18x100.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log18x100.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log18x100.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log18x100.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log18x100.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log18x100.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log18x100.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log18x100.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log18x100.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log18x100.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log18x100.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/mwf_log18x100.b9.json"
+    ]
+  }
+}

--- a/autoresearch/submissions/2026-07-22-large-column-page-rotation/verdict-huge.json
+++ b/autoresearch/submissions/2026-07-22-large-column-page-rotation/verdict-huge.json
@@ -1,0 +1,399 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "8d9c30a5778c",
+  "repo_commit": "bf7cf1849130",
+  "predecessor_commit": "5bf964b78643",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "huge",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 1.85
+    }
+  },
+  "search_health": {
+    "schema_version": 1,
+    "decision": {
+      "schema_version": 1,
+      "board": "core_cpu",
+      "workload_class": "huge",
+      "trailing_window": 8,
+      "trailing_evidence_count": 2,
+      "trailing_median_gradient_snr": 3.855326860214538,
+      "gradient_snr_threshold": 2.0,
+      "configured_rounds": 5,
+      "auto_boost_rounds": 5,
+      "maximum_rounds": 25,
+      "target_rounds": 5,
+      "workload_count": 1,
+      "class_wall_deadline_seconds": 1200.0,
+      "estimated_seconds_per_round": 10.703308415319771,
+      "deadline_round_limit": 112,
+      "auto_boost_applied": false,
+      "auto_boost_reason": "trailing_median_at_or_above_threshold",
+      "recorded_before_measurement": true
+    },
+    "decision_sha256": "sha256:ffa403a12d7d4e401b2532006c0ac0fb8d76f925b35bd994a3153b3caf0c0cde",
+    "actual_rounds": 3,
+    "actual_rounds_per_workload": {
+      "wf_log20x100": 3
+    },
+    "objective_wall_seconds": 12.890254124999046,
+    "measurement_wall_seconds": 37.62840383301955,
+    "measurement_wall_hours": 0.010452334398060986,
+    "gradient_snr": null,
+    "credited_ln_improvement": null,
+    "credited_ln_improvement_per_measurement_hour": null,
+    "credit_status": "pending_ledger_adjudication",
+    "decision_record": "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/search-health-decision.json"
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned correctness oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "native mechanism telemetry policy unchanged"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.6924 vs targeted budget x1.02; matrix row upper CIs 1/1 within budget x1.05; regression guards 13/13 within budget; request ratios 1/1 present rows within budget x1.05; resource vectors 1/1 within named budgets"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log20x100": {
+        "r": 0.878685,
+        "ci": [
+          0.875646,
+          0.883551
+        ],
+        "rounds": 3,
+        "a_median_ms": 687.070125,
+        "b_median_ms": 601.6305,
+        "request_ratio": 0.919739,
+        "rss_ratio": 0.995143,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.934418,
+            "ci": [
+              0.931947,
+              0.939538
+            ],
+            "observations": 3,
+            "candidate": 34.36708467
+          },
+          "peak_rss_mib": {
+            "ratio": 0.995143,
+            "ci": [
+              0.989346,
+              1.000084
+            ],
+            "observations": 3,
+            "candidate": 1661.2832412719727
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 86383.0
+          }
+        },
+        "mechanism_verified": null,
+        "proof_bytes": 86383,
+        "measurement_seconds": 12.877592,
+        "resources_complete": null
+      }
+    },
+    "R_geomean": 0.878685,
+    "portfolio": {
+      "ci_method": "independent_workload_round_bootstrap_percentile_v1",
+      "ci_level": 0.95,
+      "bootstrap_iterations": 4000,
+      "seed": 3539062217,
+      "ci": [
+        0.875646,
+        0.883551
+      ],
+      "prove_ms_method": "geometric_mean_candidate_workload_medians_ms_v1",
+      "b_median_ms_geomean": 601.6305,
+      "proof_bytes_method": "rounded_geometric_mean_candidate_proof_bytes_v1",
+      "proof_bytes": 86383,
+      "measurement_seconds": 12.877592,
+      "measurement_rounds": 3
+    },
+    "theta": 0.012526,
+    "aa_dispersion": 0.006263,
+    "significant": true,
+    "neutral": false,
+    "promotion_significance": {
+      "eligible": true,
+      "method": "independent_workload_round_bootstrap_percentile_v1",
+      "reason": "prove-time objective uses the deterministic workload portfolio CI"
+    },
+    "resource_portfolio": {
+      "peak_rss_mib": {
+        "ratio_geomean": 0.9951430744024758,
+        "upper_ci_geomean": 1.0000842975005715,
+        "candidate_geomean": 1661.2832412719724
+      },
+      "energy_j": {
+        "ratio_geomean": 0.9344181356731824,
+        "upper_ci_geomean": 0.93953767058369,
+        "candidate_geomean": 34.367084670000004
+      },
+      "proof_bytes": {
+        "ratio_geomean": 1.0,
+        "upper_ci_geomean": 1.0,
+        "candidate_geomean": 86382.99999999994
+      }
+    }
+  },
+  "tiebreakers": {
+    "rss_ratio": 0.995143,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": 34.367084670000004,
+    "proof_bytes": 86382.99999999994
+  },
+  "holdout": null,
+  "guards": {
+    "guard_blake_10x10": {
+      "r": 0.993249,
+      "ci": [
+        0.986759,
+        0.995785
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "4153acd6e32a98b9d240730062f7fa35e2e31eca915f01c179337f04d409cbd2"
+    },
+    "guard_blake_12x16": {
+      "r": 0.991325,
+      "ci": [
+        0.967292,
+        1.015663
+      ],
+      "rounds": 6,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "70e516957d2d38ed78214bfda5b0b2bdfe41f1c93439fb68e124bfef096fbc9f"
+    },
+    "guard_plonk_14": {
+      "r": 1.016196,
+      "ci": [
+        0.995095,
+        1.04083
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf"
+    },
+    "guard_plonk_16": {
+      "r": 1.006141,
+      "ci": [
+        0.988526,
+        1.027941
+      ],
+      "rounds": 6,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "cfb36bf17fb3526bf1bdd9401fb885fd91ca46b9982fee1ca5fad33a1d574b72"
+    },
+    "guard_poseidon_10": {
+      "r": 0.999955,
+      "ci": [
+        0.997879,
+        1.001965
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "af33240da8e7947362fdf7e78d306f2e11cb2e3df7e1b6f498a6e86ac3ae7b1b"
+    },
+    "guard_poseidon_13": {
+      "r": 0.996186,
+      "ci": [
+        0.993414,
+        0.997383
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "f196835da5d4a155c6311bafb44335c2863cc028879d69a7ae53b802321200f1"
+    },
+    "guard_sm_14": {
+      "r": 1.01029,
+      "ci": [
+        0.98169,
+        1.02024
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "488fadeeb4e5d76b6fc0a9c10ab258bab6673de8e912ae5de927561650920b37"
+    },
+    "guard_sm_16": {
+      "r": 0.993535,
+      "ci": [
+        0.989332,
+        1.000302
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "88ec35ee88a05ce0a5db4b6cb063f4cf7824ee65284db0908a62a9362879af73"
+    },
+    "guard_wf_10x8": {
+      "r": 0.987593,
+      "ci": [
+        0.962053,
+        1.004627
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700"
+    },
+    "guard_wf_14x32": {
+      "r": 1.014915,
+      "ci": [
+        0.994989,
+        1.023923
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374"
+    },
+    "guard_wf_16x64": {
+      "r": 1.025788,
+      "ci": [
+        0.99766,
+        1.047319
+      ],
+      "rounds": 7,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "42086545b7a170c5868afcc390f83d964e06d528e2d1039420fc6bfd7a6aac74"
+    },
+    "guard_xor_14": {
+      "r": 0.986394,
+      "ci": [
+        0.955559,
+        1.005531
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "35bb35714e10888c786a71ccdfe31d2b9b4651c567fac5ba4c9543bc247cad80"
+    },
+    "guard_xor_16": {
+      "r": 0.991084,
+      "ci": [
+        0.990188,
+        0.991714
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "56163b8ea3d877b3b9bf15753b7c0175d4a6ead493640eef8210c59ba7e5215c"
+    }
+  },
+  "rust_oracle": [
+    {
+      "workload": "wf_log20x100",
+      "verified": true,
+      "oracle": "pinned-rust-stwo",
+      "artifact_sha256": "8a66bd21ec4076cde6d887ec1a10f034b34a8597e28643f57aae14dbd9cbf00e"
+    }
+  ],
+  "skipped_groups": [],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "wf_log20x100": {
+        "round_ratios": [
+          0.87777,
+          0.875646,
+          0.883551
+        ],
+        "proof_digest": "e6609d0564a47192212bec7973e2660c2eea88bef90c573c3df09569cc3c7e86",
+        "request_ratio": 0.919739,
+        "rss_ratio": 0.995143,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.934418,
+            "ci": [
+              0.931947,
+              0.939538
+            ],
+            "observations": 3,
+            "candidate": 34.36708467
+          },
+          "peak_rss_mib": {
+            "ratio": 0.995143,
+            "ci": [
+              0.989346,
+              1.000084
+            ],
+            "observations": 3,
+            "candidate": 1661.2832412719727
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 86383.0
+          }
+        },
+        "report_sha256s": [
+          "ff473325abc30e4742a4bc1df06eac58c97edc64c0a81edeada24d8c3c606840",
+          "14cc79ccdc08a6f347c5a4ee1173ad8d4d3cdfbc45f17ed94d0cc4d94eff1aa3",
+          "58bd2c5d4dba6619d38c77e9b93a7c48d1399b1fa06bc1e9b5cd46dd6376f1cb",
+          "a0e2c419a1e28f0b0f10eebe061cbc2c8d74d6da6511e584ac37fa80915dc59a",
+          "7fe5d630689c7b521dd0b2cc7f81b4f99fcb29e4564fd222e0b2ab078487ec2e",
+          "037abc9afc2db7a74e3a6fde2dc923fe78647300316c2b409c2f1f7098a555ab"
+        ],
+        "mechanism_verified": null,
+        "resources_complete": null
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/wf_log20x100.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/wf_log20x100.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/wf_log20x100.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/wf_log20x100.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/wf_log20x100.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/wf_log20x100.b3.json"
+    ]
+  }
+}

--- a/autoresearch/submissions/2026-07-22-large-column-page-rotation/verdict.json
+++ b/autoresearch/submissions/2026-07-22-large-column-page-rotation/verdict.json
@@ -1,0 +1,409 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "8d9c30a5778c",
+  "repo_commit": "bf7cf1849130",
+  "predecessor_commit": "5bf964b78643",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "xlarge",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 2.74
+    }
+  },
+  "search_health": {
+    "schema_version": 1,
+    "decision": {
+      "schema_version": 1,
+      "board": "core_cpu",
+      "workload_class": "xlarge",
+      "trailing_window": 8,
+      "trailing_evidence_count": 1,
+      "trailing_median_gradient_snr": 54.70979791697888,
+      "gradient_snr_threshold": 2.0,
+      "configured_rounds": 9,
+      "auto_boost_rounds": 5,
+      "maximum_rounds": 25,
+      "target_rounds": 9,
+      "workload_count": 1,
+      "class_wall_deadline_seconds": 900.0,
+      "estimated_seconds_per_round": 6.460835233214311,
+      "deadline_round_limit": 139,
+      "auto_boost_applied": false,
+      "auto_boost_reason": "trailing_median_at_or_above_threshold",
+      "recorded_before_measurement": true
+    },
+    "decision_sha256": "sha256:80b5f41242860f574016b8e8623b789e8bd2ff4fcd0fb42c5f37b16e974234cd",
+    "actual_rounds": 5,
+    "actual_rounds_per_workload": {
+      "wf_log18x100": 5
+    },
+    "objective_wall_seconds": 12.84975462500006,
+    "measurement_wall_seconds": 35.625035334029235,
+    "measurement_wall_hours": 0.009895843148341453,
+    "gradient_snr": null,
+    "credited_ln_improvement": null,
+    "credited_ln_improvement_per_measurement_hour": null,
+    "credit_status": "pending_ledger_adjudication",
+    "decision_record": "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/search-health-decision.json"
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned correctness oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "native mechanism telemetry policy unchanged"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.6442 vs targeted budget x1.02; matrix row upper CIs 1/1 within budget x1.05; regression guards 13/13 within budget; request ratios 1/1 present rows within budget x1.05; resource vectors 1/1 within named budgets"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log18x100": {
+        "r": 0.878534,
+        "ci": [
+          0.864409,
+          0.889791
+        ],
+        "rounds": 5,
+        "a_median_ms": 165.946583,
+        "b_median_ms": 146.030792,
+        "request_ratio": 0.920004,
+        "rss_ratio": 1.003347,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.933821,
+            "ci": [
+              0.932647,
+              0.934781
+            ],
+            "observations": 5,
+            "candidate": 20.244200745
+          },
+          "peak_rss_mib": {
+            "ratio": 1.003347,
+            "ci": [
+              0.986102,
+              1.004511
+            ],
+            "observations": 5,
+            "candidate": 422.14158630371094
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 74328.0
+          }
+        },
+        "mechanism_verified": null,
+        "proof_bytes": 74328,
+        "measurement_seconds": 12.827272,
+        "resources_complete": null
+      }
+    },
+    "R_geomean": 0.878534,
+    "portfolio": {
+      "ci_method": "independent_workload_round_bootstrap_percentile_v1",
+      "ci_level": 0.95,
+      "bootstrap_iterations": 4000,
+      "seed": 1801149624,
+      "ci": [
+        0.864409,
+        0.889791
+      ],
+      "prove_ms_method": "geometric_mean_candidate_workload_medians_ms_v1",
+      "b_median_ms_geomean": 146.030792,
+      "proof_bytes_method": "rounded_geometric_mean_candidate_proof_bytes_v1",
+      "proof_bytes": 74328,
+      "measurement_seconds": 12.827272,
+      "measurement_rounds": 5
+    },
+    "theta": 0.031004,
+    "aa_dispersion": 0.015502,
+    "significant": true,
+    "neutral": false,
+    "promotion_significance": {
+      "eligible": true,
+      "method": "independent_workload_round_bootstrap_percentile_v1",
+      "reason": "prove-time objective uses the deterministic workload portfolio CI"
+    },
+    "resource_portfolio": {
+      "peak_rss_mib": {
+        "ratio_geomean": 1.0033470154040645,
+        "upper_ci_geomean": 1.0045113984532037,
+        "candidate_geomean": 422.1415863037109
+      },
+      "energy_j": {
+        "ratio_geomean": 0.93382141923921,
+        "upper_ci_geomean": 0.9347812377859945,
+        "candidate_geomean": 20.244200745000004
+      },
+      "proof_bytes": {
+        "ratio_geomean": 1.0,
+        "upper_ci_geomean": 1.0,
+        "candidate_geomean": 74328.00000000003
+      }
+    }
+  },
+  "tiebreakers": {
+    "rss_ratio": 1.003347,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": 20.244200745000004,
+    "proof_bytes": 74328.00000000003
+  },
+  "holdout": null,
+  "guards": {
+    "guard_blake_10x10": {
+      "r": 1.000451,
+      "ci": [
+        0.998094,
+        1.002998
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "4153acd6e32a98b9d240730062f7fa35e2e31eca915f01c179337f04d409cbd2"
+    },
+    "guard_blake_12x16": {
+      "r": 1.017455,
+      "ci": [
+        1.002618,
+        1.046781
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "70e516957d2d38ed78214bfda5b0b2bdfe41f1c93439fb68e124bfef096fbc9f"
+    },
+    "guard_plonk_14": {
+      "r": 1.000238,
+      "ci": [
+        0.987213,
+        1.014473
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf"
+    },
+    "guard_plonk_16": {
+      "r": 0.99449,
+      "ci": [
+        0.971796,
+        1.012073
+      ],
+      "rounds": 6,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "cfb36bf17fb3526bf1bdd9401fb885fd91ca46b9982fee1ca5fad33a1d574b72"
+    },
+    "guard_poseidon_10": {
+      "r": 0.998786,
+      "ci": [
+        0.996129,
+        1.004847
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "af33240da8e7947362fdf7e78d306f2e11cb2e3df7e1b6f498a6e86ac3ae7b1b"
+    },
+    "guard_poseidon_13": {
+      "r": 0.999983,
+      "ci": [
+        0.998234,
+        1.000672
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "f196835da5d4a155c6311bafb44335c2863cc028879d69a7ae53b802321200f1"
+    },
+    "guard_sm_14": {
+      "r": 1.018294,
+      "ci": [
+        0.991558,
+        1.044614
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "488fadeeb4e5d76b6fc0a9c10ab258bab6673de8e912ae5de927561650920b37"
+    },
+    "guard_sm_16": {
+      "r": 0.983063,
+      "ci": [
+        0.952416,
+        1.013313
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "88ec35ee88a05ce0a5db4b6cb063f4cf7824ee65284db0908a62a9362879af73"
+    },
+    "guard_wf_10x8": {
+      "r": 1.000078,
+      "ci": [
+        0.990976,
+        1.023877
+      ],
+      "rounds": 6,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700"
+    },
+    "guard_wf_14x32": {
+      "r": 1.0161,
+      "ci": [
+        0.991618,
+        1.038727
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374"
+    },
+    "guard_wf_16x64": {
+      "r": 0.968828,
+      "ci": [
+        0.943207,
+        0.992662
+      ],
+      "rounds": 6,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "42086545b7a170c5868afcc390f83d964e06d528e2d1039420fc6bfd7a6aac74"
+    },
+    "guard_xor_14": {
+      "r": 1.018707,
+      "ci": [
+        0.995976,
+        1.043877
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "35bb35714e10888c786a71ccdfe31d2b9b4651c567fac5ba4c9543bc247cad80"
+    },
+    "guard_xor_16": {
+      "r": 0.982635,
+      "ci": [
+        0.96771,
+        1.003206
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "56163b8ea3d877b3b9bf15753b7c0175d4a6ead493640eef8210c59ba7e5215c"
+    }
+  },
+  "rust_oracle": [
+    {
+      "workload": "wf_log18x100",
+      "verified": true,
+      "oracle": "pinned-rust-stwo",
+      "artifact_sha256": "49f9555c8a3d6d1f47045a7a22caf961745d503174d840b8e21a414aaf74cfb4"
+    }
+  ],
+  "skipped_groups": [],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "wf_log18x100": {
+        "round_ratios": [
+          0.864846,
+          0.893206,
+          0.886376,
+          0.878534,
+          0.863971
+        ],
+        "proof_digest": "f845568c14599a08c16a14bf255b2e1938df3df27cfdbf961d06f663909ced8f",
+        "request_ratio": 0.920004,
+        "rss_ratio": 1.003347,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.933821,
+            "ci": [
+              0.932647,
+              0.934781
+            ],
+            "observations": 5,
+            "candidate": 20.244200745
+          },
+          "peak_rss_mib": {
+            "ratio": 1.003347,
+            "ci": [
+              0.986102,
+              1.004511
+            ],
+            "observations": 5,
+            "candidate": 422.14158630371094
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 74328.0
+          }
+        },
+        "report_sha256s": [
+          "424fe63d4da16aaf3e3541a47bf672339f01b9256c5a5848ea1948ae21bb8518",
+          "492bb7f20702f5aaf6d0533ce06fa452ebe01d8271298d4f657bdf0d5ab5ff21",
+          "34c83e18daee4c7316750813123e6d034fafc40ff34b90e23c2624db99d6bd08",
+          "c439449cc6d3a010c0169bf199cfb979ccca670e95edb26f49e1489ccb5fbb50",
+          "e3a20f67f25dfd8b19fbb7207f5cc6954c75386f1c372b910b460f3b7d7694e7",
+          "fe66a54314b66404e7186d9604108068456283af491b69c2556fc329547a906d",
+          "afc1e684e79d1a9ff710c6dadbf898f624f97835016059dfd2c675521fbd20d8",
+          "3e791f87efd01fb3eba10252e2081d42afacabec1afa31f33782451bcb115c13",
+          "c73d633e4f5e3db8e3dda760a9d7525e63350718f38166cc3b86be7d1f9e80f5",
+          "250364de332e232c10d664360da58ac8a1b60861aea8d3c33d5d1931f54d1bf7"
+        ],
+        "mechanism_verified": null,
+        "resources_complete": null
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/wf_log18x100.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/wf_log18x100.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/wf_log18x100.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/wf_log18x100.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/wf_log18x100.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/wf_log18x100.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/wf_log18x100.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/wf_log18x100.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/wf_log18x100.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-metal-next/autoresearch/.runs/latest/wf_log18x100.b5.json"
+    ]
+  }
+}

--- a/src/prover/pcs/columns/preparation.zig
+++ b/src/prover/pcs/columns/preparation.zig
@@ -262,10 +262,12 @@ fn prepareColumnsCombinedForBackend(
         };
         const extended_start: usize = 0;
         // AIR evaluators walk a row across columns. An exact power-of-two
-        // column stride aliases cache and translation structures; one cache
-        // line of skew rotates both while preserving ordinary column slices.
+        // column stride aliases cache and translation structures. Large
+        // columns amortize an odd-page rotation; retain the cheaper cache-line
+        // rotation for small columns where a page of padding is material.
+        const page_rotate = column_count >= 64 and extended_domain.size() >= (1 << 18);
         const extended_stride = extended_domain.size() +
-            @as(usize, if (column_count >= 64) 16 else 0);
+            @as(usize, if (page_rotate) page_words + 16 else if (column_count >= 64) 16 else 0);
         const extended_span = try std.math.add(
             usize,
             try std.math.mul(usize, column_count - 1, extended_stride),


### PR DESCRIPTION
Page-colors megabyte-scale shared column arenas using one hardware-page plus one cache-line of skew, preserving the prior 64-byte layout for small columns. Paired S3 verdicts show 11.97–13.23% improvements across CPU/Metal xlarge/huge; all four pass G1–G5, all 13 guards, proof parity, oracle, request-time, and resource gates. Full reasoning and rejected broad-policy attempt are included in the submission transcript.