### PR TITLE
Batch wide AIR composition across CPU lanes

### DIFF
--- a/autoresearch/submissions/2026-07-22-pr6-batched-cpu-composition/delta.json
+++ b/autoresearch/submissions/2026-07-22-pr6-batched-cpu-composition/delta.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "a77e59d43ec1",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "huge",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/backends/cpu_scalar/mod.zig": "sha256:72ee4873b6251c506c719da81aa1ccb3fd057ec8bee3ba6d46550480f4a6ff81",
+    "src/backends/cpu_scalar/secure_composition.zig": "sha256:5566a273c10efc5c82a8b444f6f71029a8c1fa75ad17bd3344bcb5d5dc156b5e"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "7d9642ea37a2ca35a748511a67b80d80c0a785d7ea91cc81e02cebd49cd47e45",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-22-pr6-batched-cpu-composition/note.md
+++ b/autoresearch/submissions/2026-07-22-pr6-batched-cpu-composition/note.md
@@ -1,0 +1,35 @@
+# Batched wide AIR composition across CPU lanes
+
+## Model and harness
+
+GPT-5 Codex used `stwo-perf` harness `4c483c015b6e` on the Apple M5 Max host. The clean ReleaseFast candidate is `fe58e5786e38` over promoted predecessor `a77e59d43ec1`. The promotion-grade scope is S3: complete verified proof transactions, paired counterbalanced processes, full affected guard portfolio, and pinned Rust Stwo oracle.
+
+## Hypothesis
+
+The pre-change stage profile showed that the single-component width-100 AIR spent 278.356 ms of a 636.020 ms log20 proof in a serial composition-domain loop. Existing generic parallelism works across components and therefore cannot help this workload. ClementWalter/stwo PR #6's `BatchCpuDomainEvaluator` supplied the exact canonical match: evaluate consecutive rows in SIMD batches and partition independent rows across worker chunks. The predicted falsifier was a composition stage still above 100 ms, missing NEON codegen, or any full-domain/reference mismatch.
+
+## Changes
+
+The new CPU-backend hook:
+
+- admits only a conservative one-component, no-preprocessed, constant-stride recurrence shape with at least 64 columns and trace log >=16;
+- evaluates four consecutive rows with the live packed M31 operations and partitions disjoint row intervals over the existing bounded work pool;
+- rolls recurrence squares forward, avoiding the generic loop's repeated square of every interior state;
+- preserves random-coefficient order, the two canonical coset denominator halves, coordinate layout, and every transcript-visible value;
+- evaluates the complete generic and candidate domains on first excluded warmup and permanently admits the vtable only after byte equality; every other AIR stays on the generic path.
+
+Only `src/backends/cpu_scalar/**` changes. No AIR, protocol, benchmark, oracle, resource admission, proof codec, Metal backend, or locked path changes.
+
+## Results
+
+The governed CPU `huge` width-100/log20 prove median falls from 623.322 ms to 370.501 ms. The paired ratio is **0.595877** with 95% CI **[0.593967, 0.596739]**: 40.4% less prove time, or 1.68x faster. All three A-B-B-A rounds win.
+
+The full request ratio is 0.751006 even though input generation is intentionally unchanged. Proof size is exactly 86,383 bytes (ratio 1.0). Peak-RSS ratio is 1.003655 with upper CI 1.014365; energy ratio is 0.996702 with upper CI 1.003280.
+
+Every timed proof independently verified, cross-arm canonical bytes were identical, and the pinned Rust Stwo oracle accepted the objective. All 13 affected AIR guards passed. In particular, the width-64/log16 guard improved to ratio 0.540885, CI [0.521426, 0.552034]; every unrelated Blake, Plonk, Poseidon, state-machine, small/wide Fibonacci, and XOR guard remained below its 1.05 upper-CI budget.
+
+The post-change profile measures composition evaluation at 18.974 ms, a 14.7x stage reduction. A live-source `stwo-prof` assembly check reports 66.0% NEON in the packed hot symbol, so the SIMD claim is codegen-backed. Direct ten-warmup/seven-sample probes measured log16 at 23.971 ms and log18 at 85.231 ms, with all proofs verified and byte-stable. ReleaseFast prover/native-product/downstream test closures pass.
+
+## Caveats
+
+The result is intentionally CPU-specific and does not claim a Metal movement; the preceding merged PR #74 carries the Metal recurrence gain. Log16 now clears the user's PR6-margin target, while log18 and log20 still require subsequent FFT/commit improvements to meet every all-point target. The local claimed verdict passes G1-G5, but the central locked judge remains the promotion authority.

--- a/autoresearch/submissions/2026-07-22-pr6-batched-cpu-composition/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-22-pr6-batched-cpu-composition/transcripts/session-01.md
@@ -1,0 +1,43 @@
+# Session 01 — PR6 all-point CPU/Metal architecture
+
+## Objective and inherited result
+
+The user asked for the largest architectural improvement, with special emphasis on explaining why Metal was not substantially faster than CPU, submitting as soon as a significant solution exists, and then pursuing all-point supremacy over ClementWalter/stwo PR #6. The immediately preceding iteration delivered PR #74: width-100 AIR composition now runs on Metal, reducing log18 and log20 proof medians by 2.71x and 2.81x with byte-identical oracle-valid proofs and zero fallbacks. PR #74 merged green and was promoted into the benchmark ledger.
+
+This session starts from promoted main `a77e59d43ec1` on an isolated branch. The complete repository benchmark suite and five repository research skills were read/exercised before source edits. The current step deliberately combines a PR6-derived CPU batching transfer with a Metal command-epoch architecture so independent gains can exceed the governed threshold and move more than one point.
+
+## Grounding measurements
+
+The source-identical baseline ran ten warmups and seven independently verified samples at width 100, logs 14/16/18/20, on CPU and Metal. Every local proof verified; CPU and Metal canonical bytes matched; Metal reported zero fallbacks. Direct native-tuned CPU prove medians were 11.553, 40.651, 150.273, and 631.078 ms. Metal prove medians were 13.110, 44.722, 49.880, and 177.420 ms.
+
+At CPU log20, a stage profile attributed 278.356 ms of 636.020 ms proving to composition evaluation. The generic implementation parallelizes across components, but wide Fibonacci has exactly one component, so the dominant row loop remains serial. The pinned PR6 source contains the exact matching `BatchCpuDomainEvaluator`: SIMD batches of consecutive rows, split into parallel row chunks.
+
+At Metal log20, a stage profile measured 171.888 ms prove. Main-trace commit was 96.627 ms. The circle LDE used ~47.0 ms GPU but blocked for 60.4-64.2 ms; the immediately following Merkle used ~7.2 ms GPU and blocked for 21.5-33.1 ms. Composition was already down to 5.087 ms. This rejects further composition-kernel tuning as the next Metal priority and identifies the LDE/Merkle command boundary as the architecture target.
+
+## Architectural reasoning before edits
+
+CPU mapping: preserve the opaque generic AIR as the oracle and install a backend-only recurrence hook. Conservatively recognize the public trace shape, batch four consecutive rows with packed M31 operations, partition rows into bounded cache-sized chunks on the existing work pool, and compare the complete first candidate domain byte-for-byte with the reference evaluator before admitting that vtable. This is an exact transfer of PR6's row batching, adapted to Zig's packed field types and the repository's locked AIR boundary.
+
+Metal mapping: the LDE result already resides in the shared arena consumed by resident Merkle. There is no semantic CPU use between those operations. Prepared LDE and Merkle plans and a caller-owned command epoch already exist, so the intended architecture is one command buffer with program-ordered LDE then Merkle encoders and one final synchronous wait. This keeps GPU work and dispatches identical while deleting one submission and one completion boundary.
+
+Rejected alternatives:
+
+- A locked AIR/vtable row-range edit would provide a cleaner generic CPU interface but violates the manifest.
+- Parallelizing only across components cannot help the measured one-component workload.
+- More Metal recurrence tuning cannot materially move the 171.9 ms request because that stage is now ~5 ms.
+- A new shader fusion would carry register/occupancy and ABI risk while the trace first points to host submission economics.
+- Returning before Merkle completion would violate the synchronous root boundary; the design waits once after the combined epoch.
+
+The required problem-match and Metal design briefs are stored beside this transcript. Each later source change, failed attempt, measurement, and rejected direction will be appended here before packaging.
+
+## First CPU implementation and result
+
+The editable CPU backend now installs a composition hook during its normal excluded warmup. The new implementation duplicates no AIR type: it recognizes only the conservative public shape already used by the oracle-valid Metal path, prepares transcript powers and the two canonical-domain denominators, and distributes packed row intervals over the existing global work pool. Each worker owns disjoint output rows. Within a row batch it keeps the squared recurrence states rolling, avoiding the reference loop's repeated square of every interior state, and accumulates the four QM31 coordinates as independent packed M31 vectors. Every unsupported shape returns to the reference evaluator.
+
+The first excluded warmup evaluated the complete candidate and generic domains and admitted the vtable only after byte equality. The first three measured log20 proofs were independently verified, 86,383 bytes, and retained canonical hash `e6609d0564a47192212bec7973e2660c2eea88bef90c573c3df09569cc3c7e86`.
+
+The log20 prove median moved from the 631.078 ms source-identical baseline to 366.311 ms: ratio 0.5805, 1.72x faster. A post-change stage profile measured composition evaluation at 18.974 ms versus 278.356 ms before, a 14.7x stage reduction. The remaining 372.361 ms proof was dominated by main-trace commit (168.584 ms) and FRI quotient build/commit (90.817 ms), proving that the intended bottleneck moved rather than work being omitted.
+
+Ten-warmup/seven-sample candidate checks measured log16 at 23.971 ms (baseline 40.651 ms, ratio 0.590) and log18 at 85.231 ms (baseline 150.273 ms, ratio 0.567). All fourteen timed proofs verified and retained their expected sizes/hashes. Log16 now clears the user's 30.12 ms PR6-margin target; log18 and log20 need subsequent FFT/commit work. This implementation is independently significant and proceeds to the full governed suite before the Metal epoch is stacked.
+
+The Zig profiling skill then checked actual code generation. An initial live aggregate-module import failed because the scratch harness did not recreate the repository's transitive named-module graph; that failure was retained rather than papered over. A second harness imported live `src/core/mod.zig` and exercised the exact packed M31 primitives. Its in-process counters measured 8.018 ns/op, 30.16 instructions/op, 26.52 cycles/op, and IPC 1.137; the optimized hot symbol contained 50 instructions with 66.0% NEON. This satisfies the repository rule that a vectorization claim requires assembly evidence.

--- a/autoresearch/submissions/2026-07-22-pr6-batched-cpu-composition/verdict.json
+++ b/autoresearch/submissions/2026-07-22-pr6-batched-cpu-composition/verdict.json
@@ -1,0 +1,399 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "4c483c015b6e",
+  "repo_commit": "fe58e5786e38",
+  "predecessor_commit": "a77e59d43ec1",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "huge",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 5.17
+    }
+  },
+  "search_health": {
+    "schema_version": 1,
+    "decision": {
+      "schema_version": 1,
+      "board": "core_cpu",
+      "workload_class": "huge",
+      "trailing_window": 8,
+      "trailing_evidence_count": 3,
+      "trailing_median_gradient_snr": 5.855135290109696,
+      "gradient_snr_threshold": 2.0,
+      "configured_rounds": 5,
+      "auto_boost_rounds": 5,
+      "maximum_rounds": 25,
+      "target_rounds": 5,
+      "workload_count": 1,
+      "class_wall_deadline_seconds": 1200.0,
+      "estimated_seconds_per_round": 12.108155639027245,
+      "deadline_round_limit": 99,
+      "auto_boost_applied": false,
+      "auto_boost_reason": "trailing_median_at_or_above_threshold",
+      "recorded_before_measurement": true
+    },
+    "decision_sha256": "sha256:47864de5c59721df00ec73cc423a3b7fba6496180f6e2c1ddf9b0ee587a88b99",
+    "actual_rounds": 3,
+    "actual_rounds_per_workload": {
+      "wf_log20x100": 3
+    },
+    "objective_wall_seconds": 11.949868667055853,
+    "measurement_wall_seconds": 30.881417917087674,
+    "measurement_wall_hours": 0.008578171643635465,
+    "gradient_snr": null,
+    "credited_ln_improvement": null,
+    "credited_ln_improvement_per_measurement_hour": null,
+    "credit_status": "pending_ledger_adjudication",
+    "decision_record": "/Users/theodorepender/code/auto-researching/ws-pr6-cpu-score/autoresearch/.runs/latest/search-health-decision.json"
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned correctness oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "native mechanism telemetry policy unchanged"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.4264 vs targeted budget x1.02; matrix row upper CIs 1/1 within budget x1.05; regression guards 13/13 within budget; request ratios 1/1 present rows within budget x1.05; resource vectors 1/1 within named budgets"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log20x100": {
+        "r": 0.595877,
+        "ci": [
+          0.593967,
+          0.596739
+        ],
+        "rounds": 3,
+        "a_median_ms": 623.322042,
+        "b_median_ms": 370.501041,
+        "request_ratio": 0.751006,
+        "rss_ratio": 1.003655,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.996702,
+            "ci": [
+              0.985607,
+              1.00328
+            ],
+            "observations": 3,
+            "candidate": 34.707902292
+          },
+          "peak_rss_mib": {
+            "ratio": 1.003655,
+            "ci": [
+              1.000047,
+              1.014365
+            ],
+            "observations": 3,
+            "candidate": 1646.861343383789
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 86383.0
+          }
+        },
+        "mechanism_verified": null,
+        "proof_bytes": 86383,
+        "measurement_seconds": 11.936549,
+        "resources_complete": null
+      }
+    },
+    "R_geomean": 0.595877,
+    "portfolio": {
+      "ci_method": "independent_workload_round_bootstrap_percentile_v1",
+      "ci_level": 0.95,
+      "bootstrap_iterations": 4000,
+      "seed": 3539062217,
+      "ci": [
+        0.593967,
+        0.596739
+      ],
+      "prove_ms_method": "geometric_mean_candidate_workload_medians_ms_v1",
+      "b_median_ms_geomean": 370.501041,
+      "proof_bytes_method": "rounded_geometric_mean_candidate_proof_bytes_v1",
+      "proof_bytes": 86383,
+      "measurement_seconds": 11.936549,
+      "measurement_rounds": 3
+    },
+    "theta": 0.012526,
+    "aa_dispersion": 0.006263,
+    "significant": true,
+    "neutral": false,
+    "promotion_significance": {
+      "eligible": true,
+      "method": "independent_workload_round_bootstrap_percentile_v1",
+      "reason": "prove-time objective uses the deterministic workload portfolio CI"
+    },
+    "resource_portfolio": {
+      "peak_rss_mib": {
+        "ratio_geomean": 1.0036554297141351,
+        "upper_ci_geomean": 1.0143654140567362,
+        "candidate_geomean": 1646.8613433837895
+      },
+      "energy_j": {
+        "ratio_geomean": 0.9967016302260316,
+        "upper_ci_geomean": 1.0032796705586635,
+        "candidate_geomean": 34.707902292
+      },
+      "proof_bytes": {
+        "ratio_geomean": 1.0,
+        "upper_ci_geomean": 1.0,
+        "candidate_geomean": 86382.99999999994
+      }
+    }
+  },
+  "tiebreakers": {
+    "rss_ratio": 1.003655,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": 34.707902292,
+    "proof_bytes": 86382.99999999994
+  },
+  "holdout": null,
+  "guards": {
+    "guard_blake_10x10": {
+      "r": 0.993837,
+      "ci": [
+        0.979748,
+        1.000775
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "4153acd6e32a98b9d240730062f7fa35e2e31eca915f01c179337f04d409cbd2"
+    },
+    "guard_blake_12x16": {
+      "r": 1.003399,
+      "ci": [
+        0.990546,
+        1.023878
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "70e516957d2d38ed78214bfda5b0b2bdfe41f1c93439fb68e124bfef096fbc9f"
+    },
+    "guard_plonk_14": {
+      "r": 1.007974,
+      "ci": [
+        0.981381,
+        1.025108
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf"
+    },
+    "guard_plonk_16": {
+      "r": 1.020489,
+      "ci": [
+        1.006806,
+        1.025311
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "cfb36bf17fb3526bf1bdd9401fb885fd91ca46b9982fee1ca5fad33a1d574b72"
+    },
+    "guard_poseidon_10": {
+      "r": 1.00196,
+      "ci": [
+        0.977459,
+        1.014378
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "af33240da8e7947362fdf7e78d306f2e11cb2e3df7e1b6f498a6e86ac3ae7b1b"
+    },
+    "guard_poseidon_13": {
+      "r": 0.998851,
+      "ci": [
+        0.996441,
+        1.005173
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "f196835da5d4a155c6311bafb44335c2863cc028879d69a7ae53b802321200f1"
+    },
+    "guard_sm_14": {
+      "r": 0.968338,
+      "ci": [
+        0.964367,
+        0.97942
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "488fadeeb4e5d76b6fc0a9c10ab258bab6673de8e912ae5de927561650920b37"
+    },
+    "guard_sm_16": {
+      "r": 0.960761,
+      "ci": [
+        0.959199,
+        0.962635
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "88ec35ee88a05ce0a5db4b6cb063f4cf7824ee65284db0908a62a9362879af73"
+    },
+    "guard_wf_10x8": {
+      "r": 0.99138,
+      "ci": [
+        0.94953,
+        1.028172
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700"
+    },
+    "guard_wf_14x32": {
+      "r": 1.01436,
+      "ci": [
+        0.974177,
+        1.044252
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374"
+    },
+    "guard_wf_16x64": {
+      "r": 0.540885,
+      "ci": [
+        0.521426,
+        0.552034
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "42086545b7a170c5868afcc390f83d964e06d528e2d1039420fc6bfd7a6aac74"
+    },
+    "guard_xor_14": {
+      "r": 0.993698,
+      "ci": [
+        0.984939,
+        1.018374
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "35bb35714e10888c786a71ccdfe31d2b9b4651c567fac5ba4c9543bc247cad80"
+    },
+    "guard_xor_16": {
+      "r": 0.99867,
+      "ci": [
+        0.970631,
+        1.011462
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "56163b8ea3d877b3b9bf15753b7c0175d4a6ead493640eef8210c59ba7e5215c"
+    }
+  },
+  "rust_oracle": [
+    {
+      "workload": "wf_log20x100",
+      "verified": true,
+      "oracle": "pinned-rust-stwo",
+      "artifact_sha256": "8a66bd21ec4076cde6d887ec1a10f034b34a8597e28643f57aae14dbd9cbf00e"
+    }
+  ],
+  "skipped_groups": [],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "wf_log20x100": {
+        "round_ratios": [
+          0.593967,
+          0.596401,
+          0.596739
+        ],
+        "proof_digest": "e6609d0564a47192212bec7973e2660c2eea88bef90c573c3df09569cc3c7e86",
+        "request_ratio": 0.751006,
+        "rss_ratio": 1.003655,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.996702,
+            "ci": [
+              0.985607,
+              1.00328
+            ],
+            "observations": 3,
+            "candidate": 34.707902292
+          },
+          "peak_rss_mib": {
+            "ratio": 1.003655,
+            "ci": [
+              1.000047,
+              1.014365
+            ],
+            "observations": 3,
+            "candidate": 1646.861343383789
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 86383.0
+          }
+        },
+        "report_sha256s": [
+          "c385b479de262c85c01bd80a78790e96427ffa4bacc7e45ec579aca47e6a5809",
+          "d069d15862c61b35f9d94653a77a71f05e88460645793e7215e619cba219a49f",
+          "f6eb2181c7bd38b4f08a709e030befa2aaa17173e360e7ce7f6c21db1746c1a7",
+          "81d0ac815dba0877777abf75ac495acc96b46cc9f2465d2cbd2566b022ab9cb0",
+          "daf7142ec37dcc9f7cd115d451ebe443cff0b490fcf514aa923109dc01c0ec6c",
+          "b4ad772682c5400a408f773542587a8a31d90218a64c21ba07f03498b935f5c8"
+        ],
+        "mechanism_verified": null,
+        "resources_complete": null
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-pr6-cpu-score/autoresearch/.runs/latest/wf_log20x100.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-cpu-score/autoresearch/.runs/latest/wf_log20x100.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-cpu-score/autoresearch/.runs/latest/wf_log20x100.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-cpu-score/autoresearch/.runs/latest/wf_log20x100.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-cpu-score/autoresearch/.runs/latest/wf_log20x100.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-cpu-score/autoresearch/.runs/latest/wf_log20x100.b3.json"
+    ]
+  }
+}

--- a/src/backends/cpu_scalar/mod.zig
+++ b/src/backends/cpu_scalar/mod.zig
@@ -21,6 +21,7 @@ const fields_mod = @import("stwo_core").fields;
 const core_fri = @import("stwo_core").fri;
 const circle = @import("stwo_core").circle;
 const lifted_merkle = @import("stwo_prover_impl").vcs_lifted.prover;
+const secure_composition = @import("secure_composition.zig");
 
 const M31 = m31_mod.M31;
 const CM31 = cm31_mod.CM31;
@@ -34,6 +35,12 @@ pub const CpuBackend = struct {
     pub const combined_commit_min_columns: usize = 65;
     pub const combined_commit_max_columns: usize = 256;
     pub const combined_base_in_place = true;
+
+    /// Installs CPU-only semantic accelerators before excluded benchmark
+    /// warmups. Unsupported AIRs retain the generic evaluator.
+    pub fn warmup() !void {
+        secure_composition.install();
+    }
 
     // ---------------------------------------------------------------
     // ColumnOps

--- a/src/backends/cpu_scalar/secure_composition.zig
+++ b/src/backends/cpu_scalar/secure_composition.zig
@@ -1,0 +1,264 @@
+//! SIMD- and row-parallel secure-composition evaluation for admitted CPU AIRs.
+
+const std = @import("std");
+const constraints = @import("stwo_core").constraints;
+const m31 = @import("stwo_core").fields.m31;
+const qm31 = @import("stwo_core").fields.qm31;
+const canonic = @import("stwo_core").poly.circle.canonic;
+const prover = @import("stwo_prover_impl");
+
+const M31 = m31.M31;
+const QM31 = qm31.QM31;
+const PackedM31 = m31.PackedM31;
+const ComponentProver = prover.air.component_prover.ComponentProver;
+const Trace = prover.air.component_prover.Trace;
+const SecureColumnByCoords = prover.secure_column.SecureColumnByCoords;
+
+// Keep short/small proofs on the reference loop: their fan-out cost is a
+// meaningful fraction of the whole request. This admits trace logs >= 16.
+const min_eval_log_size: u32 = 17;
+const validation_unknown: u8 = 0;
+const validation_accepted: u8 = 1;
+const validation_rejected: u8 = 2;
+var validation_mutex: std.Thread.Mutex = .{};
+var validation_vtable: ?*const prover.air.component_prover.ComponentProverVTable = null;
+var recurrence_validation: u8 = validation_unknown;
+
+pub fn install() void {
+    prover.air.component_prover.installBackendCompositionEvaluationHook(
+        evaluateLargeRecurrenceComposition,
+    );
+}
+
+const RecurrenceShape = struct {
+    first_column: [*]const M31,
+    row_count: usize,
+    column_count: usize,
+    column_stride: usize,
+    constraint_count: usize,
+    eval_log_size: u32,
+};
+
+const PackedPower = struct {
+    coordinates: [qm31.SECURE_EXTENSION_DEGREE]PackedM31,
+};
+
+const Worker = struct {
+    first_column: [*]const M31,
+    outputs: [qm31.SECURE_EXTENSION_DEGREE][*]M31,
+    powers: []const PackedPower,
+    denominator_inverses: [2]PackedM31,
+    row_count: usize,
+    column_count: usize,
+    column_stride: usize,
+    row_start: usize,
+    row_end: usize,
+
+    fn run(self: *Worker) void {
+        const half = self.row_count / 2;
+        var row = self.row_start;
+        while (row < self.row_end) : (row += m31.PACK_WIDTH) {
+            var a = m31.loadPacked(self.first_column + row);
+            var b = m31.loadPacked(self.first_column + self.column_stride + row);
+            var a_squared = m31.mulPacked(a, a);
+            var b_squared = m31.mulPacked(b, b);
+            var accumulators: [qm31.SECURE_EXTENSION_DEGREE]PackedM31 = .{
+                @splat(0), @splat(0), @splat(0), @splat(0),
+            };
+
+            var column: usize = 2;
+            while (column < self.column_count) : (column += 1) {
+                const c = m31.loadPacked(self.first_column + column * self.column_stride + row);
+                const expected = m31.addPacked(a_squared, b_squared);
+                const recurrence = m31.subPacked(c, expected);
+                const power = self.powers[self.column_count - 1 - column];
+                inline for (0..qm31.SECURE_EXTENSION_DEGREE) |coordinate| {
+                    accumulators[coordinate] = m31.addPacked(
+                        accumulators[coordinate],
+                        m31.mulPacked(recurrence, power.coordinates[coordinate]),
+                    );
+                }
+                a = b;
+                b = c;
+                a_squared = b_squared;
+                if (column + 1 < self.column_count) b_squared = m31.mulPacked(c, c);
+            }
+
+            const denominator = self.denominator_inverses[@intFromBool(row >= half)];
+            inline for (0..qm31.SECURE_EXTENSION_DEGREE) |coordinate| {
+                m31.storePacked(
+                    self.outputs[coordinate] + row,
+                    m31.mulPacked(accumulators[coordinate], denominator),
+                );
+            }
+        }
+    }
+};
+
+fn evaluateLargeRecurrenceComposition(
+    allocator: std.mem.Allocator,
+    components: []const ComponentProver,
+    random_coeff: QM31,
+    trace: *const Trace,
+) !?SecureColumnByCoords {
+    const shape = recurrenceShape(components, trace) orelse return null;
+    if (validationStatus(components[0].vtable) == validation_rejected) return null;
+
+    const powers = try prover.air.accumulation.generateSecurePowers(
+        allocator,
+        random_coeff,
+        shape.constraint_count,
+    );
+    defer allocator.free(powers);
+    const packed_powers = try allocator.alloc(PackedPower, powers.len);
+    defer allocator.free(packed_powers);
+    for (powers, packed_powers) |power, *packed_power| {
+        const coordinates = power.toM31Array();
+        inline for (0..qm31.SECURE_EXTENSION_DEGREE) |coordinate| {
+            packed_power.coordinates[coordinate] = m31.splatPacked(coordinates[coordinate]);
+        }
+    }
+
+    const eval_domain = canonic.CanonicCoset.new(shape.eval_log_size).circleDomain();
+    const trace_coset = canonic.CanonicCoset.new(shape.eval_log_size - 1).coset();
+    const denominator_scalars = [2]M31{
+        try constraints.cosetVanishing(M31, trace_coset, eval_domain.at(0)).inv(),
+        try constraints.cosetVanishing(M31, trace_coset, eval_domain.at(1)).inv(),
+    };
+    const denominators = [2]PackedM31{
+        m31.splatPacked(denominator_scalars[0]),
+        m31.splatPacked(denominator_scalars[1]),
+    };
+
+    var output = try SecureColumnByCoords.uninitialized(allocator, shape.row_count);
+    errdefer output.deinit(allocator);
+    var output_pointers: [qm31.SECURE_EXTENSION_DEGREE][*]M31 = undefined;
+    inline for (0..qm31.SECURE_EXTENSION_DEGREE) |coordinate| {
+        output_pointers[coordinate] = output.columns[coordinate].ptr;
+    }
+
+    const pool = prover.work_pool.getGlobalPool();
+    const requested_workers = if (pool) |active| active.workerCount() else 1;
+    const packed_rows = shape.row_count / m31.PACK_WIDTH;
+    const worker_count = @min(requested_workers, packed_rows);
+    const workers = try allocator.alloc(Worker, worker_count);
+    defer allocator.free(workers);
+    for (workers, 0..) |*worker, index| {
+        const start_batch = packed_rows * index / worker_count;
+        const end_batch = packed_rows * (index + 1) / worker_count;
+        worker.* = .{
+            .first_column = shape.first_column,
+            .outputs = output_pointers,
+            .powers = packed_powers,
+            .denominator_inverses = denominators,
+            .row_count = shape.row_count,
+            .column_count = shape.column_count,
+            .column_stride = shape.column_stride,
+            .row_start = start_batch * m31.PACK_WIDTH,
+            .row_end = end_batch * m31.PACK_WIDTH,
+        };
+    }
+
+    if (pool) |active| {
+        var wait_group = std.Thread.WaitGroup{};
+        for (workers[1..]) |*worker| active.spawnWg(&wait_group, Worker.run, .{worker});
+        Worker.run(&workers[0]);
+        wait_group.wait();
+    } else {
+        Worker.run(&workers[0]);
+    }
+
+    if (validationStatus(components[0].vtable) == validation_accepted) return output;
+
+    // The public shape is deliberately insufficient as a type identity. The
+    // first excluded warmup proves the specialized semantics over every row.
+    var expected = try referenceComposition(allocator, components, random_coeff, trace);
+    if (!secureColumnsEqual(output, expected)) {
+        setValidationStatus(components[0].vtable, validation_rejected);
+        output.deinit(allocator);
+        return expected;
+    }
+    expected.deinit(allocator);
+    setValidationStatus(components[0].vtable, validation_accepted);
+    return output;
+}
+
+fn recurrenceShape(components: []const ComponentProver, trace: *const Trace) ?RecurrenceShape {
+    if (components.len != 1 or trace.polys.items.len != 2) return null;
+    const component = components[0];
+    if (trace.polys.items[0].len != 0) return null;
+    const columns = trace.polys.items[1];
+    if (columns.len < 64 or component.nConstraints() != columns.len - 2) return null;
+    const eval_log_size = component.maxConstraintLogDegreeBound();
+    if (eval_log_size < min_eval_log_size or eval_log_size >= @bitSizeOf(usize)) return null;
+    const row_count = @as(usize, 1) << @intCast(eval_log_size);
+    if (row_count % m31.PACK_WIDTH != 0) return null;
+    for (columns) |column| {
+        if (column.log_size != eval_log_size or column.values.len != row_count) return null;
+    }
+
+    const first_address = @intFromPtr(columns[0].values.ptr);
+    const second_address = @intFromPtr(columns[1].values.ptr);
+    if (second_address <= first_address) return null;
+    const stride_bytes = second_address - first_address;
+    if (stride_bytes % @sizeOf(M31) != 0) return null;
+    const column_stride = stride_bytes / @sizeOf(M31);
+    if (column_stride < row_count) return null;
+    for (columns, 0..) |column, index| {
+        const offset = std.math.mul(usize, index, stride_bytes) catch return null;
+        const expected = std.math.add(usize, first_address, offset) catch return null;
+        if (@intFromPtr(column.values.ptr) != expected) return null;
+    }
+    return .{
+        .first_column = columns[0].values.ptr,
+        .row_count = row_count,
+        .column_count = columns.len,
+        .column_stride = column_stride,
+        .constraint_count = columns.len - 2,
+        .eval_log_size = eval_log_size,
+    };
+}
+
+fn validationStatus(vtable: *const prover.air.component_prover.ComponentProverVTable) u8 {
+    validation_mutex.lock();
+    defer validation_mutex.unlock();
+    return if (validation_vtable == vtable) recurrence_validation else validation_unknown;
+}
+
+fn setValidationStatus(
+    vtable: *const prover.air.component_prover.ComponentProverVTable,
+    status: u8,
+) void {
+    validation_mutex.lock();
+    defer validation_mutex.unlock();
+    validation_vtable = vtable;
+    recurrence_validation = status;
+}
+
+fn referenceComposition(
+    allocator: std.mem.Allocator,
+    components: []const ComponentProver,
+    random_coeff: QM31,
+    trace: *const Trace,
+) !SecureColumnByCoords {
+    var accumulator = try prover.air.accumulation.DomainEvaluationAccumulator.init(
+        allocator,
+        random_coeff,
+        components[0].maxConstraintLogDegreeBound(),
+        components[0].nConstraints(),
+    );
+    defer accumulator.deinit();
+    try components[0].evaluateConstraintQuotientsOnDomain(trace, &accumulator);
+    return accumulator.finalize();
+}
+
+fn secureColumnsEqual(lhs: SecureColumnByCoords, rhs: SecureColumnByCoords) bool {
+    inline for (0..qm31.SECURE_EXTENSION_DEGREE) |coordinate| {
+        if (!std.mem.eql(
+            u8,
+            std.mem.sliceAsBytes(lhs.columns[coordinate]),
+            std.mem.sliceAsBytes(rhs.columns[coordinate]),
+        )) return false;
+    }
+    return true;
+}


### PR DESCRIPTION
Transfers PR6-style row batching into the CPU backend while preserving the locked AIR boundary through conservative shape admission and a full first-warmup semantic differential check.

Claimed huge CPU verdict: ratio 0.595877, 95% CI [0.593967, 0.596739], 623.322 ms to 370.501 ms. All timed proofs verify, canonical bytes match the pinned Rust oracle, proof size is unchanged, and all 13 affected AIR guards pass.

The post-change log20 composition stage is 18.974 ms versus 278.356 ms before. ReleaseFast prover, native CPU product, and downstream module closures pass locally.