### PR TITLE
Metal: remove mid-size recurrence composition cliff

### DIFF
--- a/autoresearch/submissions/2026-07-22-metal-mid-size-recurrence-crossover/delta.json
+++ b/autoresearch/submissions/2026-07-22-metal-mid-size-recurrence-crossover/delta.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "0d7f457364e7",
+  "declared_objective": {
+    "board": "core_metal",
+    "workload_class": "wide",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/backends/metal/runtime/secure_composition.zig": "sha256:0969439dc923f0d0a4eaa286b34348655b52d3939f8811a14b3a9f308b239cff"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "1f34cad4060ac5a162794cceca56da85e372a401d91d00a9fcb505372540db44",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-22-metal-mid-size-recurrence-crossover/note.md
+++ b/autoresearch/submissions/2026-07-22-metal-mid-size-recurrence-crossover/note.md
@@ -1,0 +1,23 @@
+# Admit mid-size recurrence composition to Metal
+
+## Model and harness
+
+GPT-5 Codex performed the investigation on promoted main `0d7f457364e7` using the repository's updated `stwo-perf` CLI, source-JIT Metal runtime, stage profiler, focused ReleaseFast tests, ReleaseSafe aggregate closure, canonical proof hashing, independent verification, and the pinned Rust Stwo oracle. The claimed verdict is an immutable S3 A-B-B-A comparison of candidate `1078cd89c393` against that predecessor on `core_metal/wide`.
+
+## Hypothesis
+
+The surprising log16 x 100 result (46.252 ms, slightly slower than log18) was an admission cliff, not a GPU throughput limit. Stage profiling attributed 20.355 ms to composition evaluation. Both secure IFFT and recurrence composition used one log19 crossover, causing the log17 constraint domain for a log16 trace to run through the generic CPU evaluator even though the exact same recurrence AIR and existing Metal kernel were already validated at larger domains.
+
+## Changes
+
+Split the shared threshold into independent policy constants. Secure IFFT remains at log19. The existing recurrence-composition Metal path now admits evaluation domains from log15 when the shape has at least 32 columns. No shader source, pipeline, binding, proof format, protocol parameter, or synchronization contract changed. The first newly admitted warmup still computes the complete generic domain and byte-compares all four secure-field coordinates; any mismatch or runtime failure retains the generic path.
+
+## Results
+
+The governed log14 x 32 objective improved from 7.502 ms to 4.830 ms: ratio 0.637985, 95% CI [0.610409, 0.649143], with all 15 independent rounds winning. Request ratio was 0.675248, energy ratio 0.647543 (upper CI 0.666793), RSS ratio 0.999372 (upper CI 0.999517), and proof size remained 41,840 bytes. Every timed proof verified, cross-arm proof digests were byte-identical, the pinned Rust oracle passed, and Metal reported zero CPU fallbacks.
+
+The architectural effect generalizes across the intended crossover: log14 x 100 improved from 12.407 to 7.749 ms (37.5%), log16 x 100 from 46.252 to 27.103 ms (41.4%), and profiled log14 x 32 composition evaluation fell from 2.348 to 0.309 ms (7.6x). Focused prover/native CPU/native Metal/AOT/downstream tests and ReleaseSafe aggregate closure passed.
+
+## Caveats
+
+The submitted objective verdict used `--guards none`; the locked judge still runs its mandatory guard matrix. Two additional local `--guards all` diagnostics each passed 12/13 guards. Only the structurally unaffected log10 x 8 latency canary missed because its center ratios were approximately neutral (1.0126 and 1.0003) while sub-millisecond variance widened the upper CIs above 1.05. All other guards passed, including newly admitted wide-Fibonacci shapes. Source-JIT initialization is excluded from post-warmup timing, matching the declared Metal runtime policy; authenticated AOT CI uses the unchanged kernel ABI.

--- a/autoresearch/submissions/2026-07-22-metal-mid-size-recurrence-crossover/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-22-metal-mid-size-recurrence-crossover/transcripts/session-01.md
@@ -1,0 +1,59 @@
+# Session 01: Metal recurrence crossover
+
+Model: GPT-5 Codex
+
+## Objective
+
+Find and submit the largest safe Metal-backend improvement after promoted main `0d7f457364e7`, prioritizing the wide-Fibonacci points that remained unexpectedly slow on GPU.
+
+## Grounding measurements
+
+The promoted source-JIT Metal matrix, each with ten warmups and seven verified samples, measured:
+
+- log14 x 100: 12.407 ms prove
+- log16 x 100: 46.252 ms prove
+- log18 x 100: 45.555 ms prove
+- log20 x 100: 162.357 ms prove
+
+The inversion between log16 and log18 was the useful anomaly. A profiled log16 proof spent 20.355 ms of 52.055 ms in composition evaluation. Reading `secure_composition.zig` showed that secure IFFT and recurrence composition shared a log19 admission threshold. A log16 trace evaluates constraints over log17, so it fell back to the generic CPU evaluator; log18 crossed the threshold and used the existing Metal recurrence kernel.
+
+## Design and experiment
+
+The existing recurrence kernel is an exact match for the one-component wide-Fibonacci AIR and already performs a full-domain candidate-versus-generic byte comparison on its first excluded warmup. The change split the two unrelated crossovers:
+
+- secure IFFT remains at log19;
+- recurrence composition is admitted at evaluation log15 and at least 32 columns.
+
+No MSL, bindings, pipeline ABI, protocol parameter, proof layout, or synchronization contract changed. Unsupported shapes still use the generic evaluator, and failed first-use validation fail-closes to it.
+
+The first experiment used log17 / 64 columns. It reduced log16 x 100 to 27.215 ms and composition to 1.362 ms. Profiling the adjacent generic log14 shapes found 2.348 ms at width32 and 4.348 ms at width100 in the same evaluator, so the final threshold was tested at log15 / 32 columns before being retained.
+
+## Results
+
+Local ten-warmup/seven-sample results preserved canonical hashes, verified every proof, and reported zero CPU fallbacks:
+
+- log14 x 32: 6.466 ms prove before the formal clean run; profiled composition 2.348 -> 0.309 ms (7.6x stage speedup)
+- log14 x 100: 12.407 -> 7.749 ms (0.625 ratio)
+- log16 x 100: 46.252 -> 27.103 ms (0.586 ratio)
+- log20 x 100 adjacent check: 143.888 ms, canonical hash unchanged
+
+Focused prover, native CPU product, native Metal lifecycle, Metal AOT/probe, downstream, and ReleaseSafe aggregate closure builds all passed.
+
+The immutable S3 `core_metal/wide` submission verdict compared candidate `1078cd89c393` with predecessor `0d7f457364e7` for 15 A-B-B-A rounds:
+
+- prove ratio 0.637985, 95% CI [0.610409, 0.649143]
+- predecessor median 7.502 ms; candidate median 4.830 ms
+- request ratio 0.675248
+- energy ratio 0.647543; upper CI 0.666793
+- RSS ratio 0.999372; upper CI 0.999517
+- proof size 41,840 bytes on both arms
+- proof digest `57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374`
+- all timed samples verified; cross-arm bytes matched; pinned Rust Stwo oracle passed
+
+## Guard diagnostic
+
+Two separate full 13-guard advisory runs passed 12/13. The only failure was the tiny log10 x 8 wide-Fibonacci latency canary, whose recurrence shape is explicitly ineligible for this change. Its center ratios were 1.012599 and 1.000346, but its noisy upper confidence bounds were 1.100122 and 1.212112. Every other guard, including the affected log14 x 32 and log16 x 64 recurrence shapes, passed. The submitted objective verdict is fully green and the locked judge will rerun the mandatory full matrix.
+
+## Conclusion
+
+The optimization removes an accidental CPU admission cliff rather than introducing a new algorithm. The GPU now receives the embarrassingly parallel recurrence work at the mid-size domains where it is already strongly profitable, while first-use differential validation preserves the generic implementation as the semantic authority.

--- a/autoresearch/submissions/2026-07-22-metal-mid-size-recurrence-crossover/verdict.json
+++ b/autoresearch/submissions/2026-07-22-metal-mid-size-recurrence-crossover/verdict.json
@@ -1,0 +1,315 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "2b0be386f6ea",
+  "repo_commit": "1078cd89c393",
+  "predecessor_commit": "0d7f457364e7",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_metal",
+    "workload_class": "wide",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 1.91
+    }
+  },
+  "search_health": {
+    "schema_version": 1,
+    "decision": {
+      "schema_version": 1,
+      "board": "core_metal",
+      "workload_class": "wide",
+      "trailing_window": 8,
+      "trailing_evidence_count": 0,
+      "trailing_median_gradient_snr": null,
+      "gradient_snr_threshold": 2.0,
+      "configured_rounds": 15,
+      "auto_boost_rounds": 5,
+      "maximum_rounds": 25,
+      "target_rounds": 15,
+      "workload_count": 1,
+      "class_wall_deadline_seconds": 600.0,
+      "estimated_seconds_per_round": null,
+      "deadline_round_limit": null,
+      "auto_boost_applied": false,
+      "auto_boost_reason": "insufficient_trailing_evidence",
+      "recorded_before_measurement": true
+    },
+    "decision_sha256": "sha256:0359a1e32f82e6e356f9068271e968f4b16bd2310bf1d1ca66837e4c315e01aa",
+    "actual_rounds": 15,
+    "actual_rounds_per_workload": {
+      "mwf_log14x32": 15
+    },
+    "objective_wall_seconds": 5.896280499990098,
+    "measurement_wall_seconds": 6.124200375052169,
+    "measurement_wall_hours": 0.0017011667708478246,
+    "gradient_snr": null,
+    "credited_ln_improvement": null,
+    "credited_ln_improvement_per_measurement_hour": null,
+    "credit_status": "pending_ledger_adjudication",
+    "decision_record": "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/search-health-decision.json"
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned correctness oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "native mechanism telemetry policy unchanged"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.6148 vs targeted budget x1.02; matrix row upper CIs 1/1 within budget x1.05; request ratios 1/1 present rows within budget x1.05; resource vectors 1/1 within named budgets"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "mwf_log14x32": {
+        "r": 0.637985,
+        "ci": [
+          0.610409,
+          0.649143
+        ],
+        "rounds": 15,
+        "a_median_ms": 7.502,
+        "b_median_ms": 4.83025,
+        "request_ratio": 0.675248,
+        "rss_ratio": 0.999372,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.647543,
+            "ci": [
+              0.644009,
+              0.666793
+            ],
+            "observations": 15,
+            "candidate": 0.383886603
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999372,
+            "ci": [
+              0.993177,
+              0.999517
+            ],
+            "observations": 15,
+            "candidate": 161.65711975097656
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 41840.0
+          }
+        },
+        "mechanism_verified": null,
+        "proof_bytes": 41840,
+        "measurement_seconds": 5.766266,
+        "resources_complete": null
+      }
+    },
+    "R_geomean": 0.637985,
+    "portfolio": {
+      "ci_method": "independent_workload_round_bootstrap_percentile_v1",
+      "ci_level": 0.95,
+      "bootstrap_iterations": 4000,
+      "seed": 130079637,
+      "ci": [
+        0.610409,
+        0.649457
+      ],
+      "prove_ms_method": "geometric_mean_candidate_workload_medians_ms_v1",
+      "b_median_ms_geomean": 4.83025,
+      "proof_bytes_method": "rounded_geometric_mean_candidate_proof_bytes_v1",
+      "proof_bytes": 41840,
+      "measurement_seconds": 5.766266,
+      "measurement_rounds": 15
+    },
+    "theta": 0.038838,
+    "aa_dispersion": 0.019419,
+    "significant": true,
+    "neutral": false,
+    "promotion_significance": {
+      "eligible": true,
+      "method": "independent_workload_round_bootstrap_percentile_v1",
+      "reason": "prove-time objective uses the deterministic workload portfolio CI"
+    },
+    "resource_portfolio": {
+      "peak_rss_mib": {
+        "ratio_geomean": 0.9993719386036022,
+        "upper_ci_geomean": 0.9995170507952202,
+        "candidate_geomean": 161.6571197509765
+      },
+      "energy_j": {
+        "ratio_geomean": 0.6475425723758123,
+        "upper_ci_geomean": 0.666793430317168,
+        "candidate_geomean": 0.383886603
+      },
+      "proof_bytes": {
+        "ratio_geomean": 1.0,
+        "upper_ci_geomean": 1.0,
+        "candidate_geomean": 41840.00000000004
+      }
+    }
+  },
+  "tiebreakers": {
+    "rss_ratio": 0.999372,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": 0.383886603,
+    "proof_bytes": 41840.00000000004
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "mwf_log14x32",
+      "verified": true,
+      "oracle": "pinned-rust-stwo",
+      "artifact_sha256": "d32393fe3b1f9abbc4795d87c3b3316e06111f014ec30f0635f13ec0ff0587f9"
+    }
+  ],
+  "skipped_groups": [],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "mwf_log14x32": {
+        "round_ratios": [
+          0.539223,
+          0.565936,
+          0.636262,
+          0.634949,
+          0.618982,
+          0.662652,
+          0.656575,
+          0.653611,
+          0.641424,
+          0.640618,
+          0.654883,
+          0.630188,
+          0.679303,
+          0.606975,
+          0.648122
+        ],
+        "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374",
+        "request_ratio": 0.675248,
+        "rss_ratio": 0.999372,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.647543,
+            "ci": [
+              0.644009,
+              0.666793
+            ],
+            "observations": 15,
+            "candidate": 0.383886603
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999372,
+            "ci": [
+              0.993177,
+              0.999517
+            ],
+            "observations": 15,
+            "candidate": 161.65711975097656
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 41840.0
+          }
+        },
+        "report_sha256s": [
+          "f35fb580501930b9858641b36daa628563398155ab3a7c74951992fbbd068bb1",
+          "4c8f3f068702e3b141519d019c4e1e8dfe46a64b1878bcb69ea1085bce0e1ca8",
+          "8596876d62e0bddf4a82d6b56a54864f6cd171b688b7c87d3e1f6be6bcbe5d47",
+          "92aad8f7778bcb198764211d64f9e2e2c00afb8da7794c32e2cf2732a3758fb6",
+          "e41fc1df4918b88d9155871080249f6637e8024ecf3907000e74f314967ee59f",
+          "430452126ac8c29811bfb1910052e52e822341d4df04be971522bc8423254052",
+          "8d2f6fdeff9ea714255744e9d27c3f45cf136a3acee3087e82ab7c0d5e949257",
+          "3164120d01a329eefb656a674a3da0c0516e786018837b20fa05ed942d57325e",
+          "c15ecb71016a337d7ec13a896f16ea6c9c40dbff5f450b45c2cf28b72a4c0734",
+          "badc7b3f037feb34c86d23ebffd99203aa397a0433ec53adbe8aeb7ac2b62157",
+          "55f625ad81951f5be36e21471625ad1479c93908845755ca8c1eaf44e23975c3",
+          "482413f95abdc5a139b9a175f0e14357cd37334d5514eb332c0d2a1af5df384f",
+          "46f153d7cd3d9a4fb3efe0b1416eb8de7e0b3b474289677e5e6be92081e55927",
+          "4118b857963bc1e033fcb6694ffcb10b2c95f4b9026660a07d9ecfbb74de1eb9",
+          "f8d6de4f4d26989429087957c048c184a38e5c330e2722d807b79adf28fa86c5",
+          "0fc0a44a70348e764841595c4d391a5ab685783242e61177dfa4e9bdbbee0de8",
+          "81ac1c75e3a965f3e611be04b732beb5d65b875903b5038a381e013dc1c2511a",
+          "e4a65c2767057850d37715bd30b2500b6a41905d819c05ae054d3fddc05692cb",
+          "d66923b53020d6277e66092f295ff3b325523907facf9fcb54be209a9bfa976d",
+          "0af63736dbc7066107e8b45e59050d212df26a17e9ff960ec19cb291a0b84d63",
+          "962cafcb613ac92d80dc9596f05d45bd36fff15d60e70748f28dbed32bbd3bd1",
+          "edb32cd35c2522fbaa6377c3804498d5d7eaadb952aeb3cacffe880ecc567b05",
+          "939528e848779599053470cb599f19a413e0f5f5415becc8e70c0532fa60b775",
+          "4a42997af8ea003564873df8dcf3f2eb1c89c83119589a847144a8f34782cf0b",
+          "bf8fa53da3ddee46b2b8bec65db4c0c79b72922e2af923581b2b79e774dbad17",
+          "1eeeb952c43b753854ab98acfe286d4330ab94550285d0cbefe636eb210346f5",
+          "240ca275bc58d8e9aff5886103395926d19cb1bdd42464ef0e3d0c8b3010850f",
+          "642ee5399e5a018779a8473ef752c73a9394735f108312078774e1757d99b3c8",
+          "3fd4d67a106412de26caa1ac9ca9136a9d29a9ac5f74173200414ff1bd5dec35",
+          "9cdbfa4833d3d1bf1628fdb0d4a4f4c1dcfd4355704ddd6df03a7dff0cd95b04"
+        ],
+        "mechanism_verified": null,
+        "resources_complete": null
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.b7.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.a8.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.b8.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.a9.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.b9.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.a10.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.b10.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.a11.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.b11.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.a12.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.b12.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.a13.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.b13.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.a14.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.b14.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.a15.json",
+      "/Users/theodorepender/code/auto-researching/ws-pr6-metal-after-epoch/autoresearch/.runs/latest/mwf_log14x32.b15.json"
+    ]
+  }
+}

--- a/src/backends/metal/runtime/secure_composition.zig
+++ b/src/backends/metal/runtime/secure_composition.zig
@@ -19,7 +19,9 @@ const ComponentProver = prover_air.component_prover.ComponentProver;
 const Trace = prover_air.component_prover.Trace;
 const SecureColumnByCoords = prover.secure_column.SecureColumnByCoords;
 const TwiddleTree = prover_poly.twiddles.TwiddleTree([]const M31);
-const min_log_size: u32 = 19;
+const min_secure_ifft_log_size: u32 = 19;
+const min_recurrence_log_size: u32 = 15;
+const min_recurrence_columns: usize = 32;
 const validation_unknown: u8 = 0;
 const validation_accepted: u8 = 1;
 const validation_rejected: u8 = 2;
@@ -30,7 +32,7 @@ var recurrence_validation: u8 = validation_unknown;
 pub fn install() void {
     prover_poly.circle.secure_poly.installBackendCircleIfftHook(
         interpolateLargeSecureComposition,
-        min_log_size,
+        min_secure_ifft_log_size,
     );
     prover_air.component_prover.installBackendCompositionEvaluationHook(
         evaluateLargeRecurrenceComposition,
@@ -43,7 +45,7 @@ fn interpolateLargeSecureComposition(
     domain: CircleDomain,
     twiddle_tree: TwiddleTree,
 ) !bool {
-    if (domain.logSize() < min_log_size) return false;
+    if (domain.logSize() < min_secure_ifft_log_size) return false;
     var lease = shared_runtime.acquireExisting() catch return false;
     defer lease.deinit();
     _ = try lease.runtime.transformCircle(
@@ -137,9 +139,9 @@ fn recurrenceShape(components: []const ComponentProver, trace: *const Trace) ?Re
     const component = components[0];
     if (trace.polys.items[0].len != 0) return null;
     const columns = trace.polys.items[1];
-    if (columns.len < 64 or component.nConstraints() != columns.len - 2) return null;
+    if (columns.len < min_recurrence_columns or component.nConstraints() != columns.len - 2) return null;
     const eval_log_size = component.maxConstraintLogDegreeBound();
-    if (eval_log_size < min_log_size or eval_log_size >= @bitSizeOf(usize)) return null;
+    if (eval_log_size < min_recurrence_log_size or eval_log_size >= @bitSizeOf(usize)) return null;
     const row_count = @as(usize, 1) << @intCast(eval_log_size);
     for (columns) |column| {
         if (column.log_size != eval_log_size or column.values.len != row_count) return null;


### PR DESCRIPTION
Admits the already validated Metal recurrence-composition path at evaluation log15 for shapes with at least 32 columns, while keeping secure-IFFT admission at log19. No shader, ABI, protocol, or proof-format change.

Governed core_metal/wide result: 0.637985 prove ratio, 95% CI [0.610409, 0.649143], 15 rounds; request 0.675248; energy 0.647543; RSS 0.999372; proof bytes unchanged; pinned Rust oracle passed; zero CPU fallbacks.

Local 10+7 checks: log14x100 12.407 to 7.749 ms and log16x100 46.252 to 27.103 ms. Focused prover/native CPU/native Metal/AOT/downstream and aggregate ReleaseSafe closure all pass.

Two advisory full-guard runs passed 12/13; only the structurally unaffected log10x8 canary had a neutral center ratio with a noisy upper CI. The required locked judge rerun remains authoritative.