### PR TITLE
perf(prover): strength-reduce lifted quotient runs

### DIFF
--- a/autoresearch/submissions/2026-07-22-2026-07-22-riscv-lifted-run-strength-reduction/delta.json
+++ b/autoresearch/submissions/2026-07-22-2026-07-22-riscv-lifted-run-strength-reduction/delta.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "9095ecec918f",
+  "declared_objective": {
+    "board": "riscv",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/prover/pcs/quotient_tile_executor.zig": "sha256:22b4e0e42d95fb2601daf59e6f2399c0b9daedc175655594c055aace5ed1a0d5"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "625350ed0124d71846b1f11769c7dd4c6cf32d6a8a58e3771733ab08c10a5c01",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-22-2026-07-22-riscv-lifted-run-strength-reduction/note.md
+++ b/autoresearch/submissions/2026-07-22-2026-07-22-riscv-lifted-run-strength-reduction/note.md
@@ -1,0 +1,103 @@
+# Strength-reduce repeated lifted quotient runs
+
+## Model and harness
+
+Model: GPT-5 Codex. The repository-resident `stwo-perf` harness ran on the
+designated Apple M5 Max in ReleaseFast mode. The claimed S3 `riscv/deep`
+comparison used immutable candidate `3084fe1985db` and current-main predecessor
+`9095ecec918f`, round-level A-B-B-A ordering, verified proof artifacts, complete
+mechanism telemetry, and the pinned Stark-V correctness oracle.
+
+The first local run completed objective sampling but exposed a harness bug when
+automatic guards were expanded: thirteen Native AIR guards were parsed as
+RISC-V workloads and rejected for lacking the RISC-V-only `{admission}` token.
+That attempt and all of its raw reports were archived. The clean objective run
+was repeated with local guard expansion disabled; repository product gates were
+run separately, and the submission still requires the remote judged guard
+matrix before promotion.
+
+## Hypothesis
+
+A fresh seven-row deep baseline put 17.22 of 19.35 aggregate request seconds in
+proving. A verified three-second macOS sample of SHA2-2048 attributed 3,261
+active samples to `quotient_tile_executor.execute`, versus 738 in packed Merkle
+leaf updates and 717 in `memmove`. The quotient executor was the dominant shared
+prover frame.
+
+For every non-direct lifted column, the source index is
+`((position >> shift) << 1) + (position & 1)`. A structural `2^shift`-row run
+therefore repeats one even/odd source pair, yet the scalar loop recomputed four
+M31 coefficient products on every row. The hypothesis was that loop-invariant
+product hoisting plus packed alternating broadcasts would remove most of that
+arithmetic without changing contribution order, scratch bounds, proof bytes,
+or protocol behavior. The falsifiers were any scalar differential mismatch,
+proof-byte drift, oracle rejection, resource regression, or a portfolio result
+below 3%.
+
+## Changes
+
+The quotient tile executor now routes every structurally non-direct input view
+through a run-wise accumulator. For each source run and each of four extension
+coordinates, it computes the even and odd M31 products once, builds two packed
+alternating vectors, and adds them directly into the existing output-stationary
+numerator planes. Misaligned boundaries and final lanes retain a scalar tail.
+
+This reduces multiplication work per contribution from four products per output
+row to eight products per source run—an approximately `2^(shift-1)` reduction—
+while leaving additions and their order unchanged. It creates no combined
+matrix, no second pass, no workload-name or size special case, and no new Metal
+dispatch, synchronization, residency, or ABI state. Direct views retain their
+existing packed path. A differential test covers shifts 2, 3, and 7 and aligned
+and misaligned tile starts.
+
+Alternatives rejected during design were a packed gather/multiply loop, which
+kept the same field-operation count; full combined-column materialization,
+which violated the bounded-memory design and added large traffic; and
+cross-column coefficient aggregation, which introduced grouping/audit
+complexity. The selected design is the narrowest general strength reduction.
+
+## Results
+
+The clean claimed verdict is a statistically significant improvement with
+portfolio proving-time ratio **0.724575**, 95% CI **[0.723189, 0.726258]**.
+That is 27.5% lower proving latency / 1.38x throughput. The verified-request
+ratio geometric mean is **0.753773**, or 24.6% lower request latency.
+
+| workload | prove ratio | 95% CI | main prove | candidate prove | request ratio |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| xorshift PRNG | 0.7268 | [0.7241, 0.7314] | 2006.1 ms | 1456.3 ms | 0.7383 |
+| iterative Fibonacci | 0.7690 | [0.7655, 0.7742] | 2119.9 ms | 1622.7 ms | 0.7790 |
+| Euclidean GCD | 0.7397 | [0.7366, 0.7448] | 2097.8 ms | 1552.9 ms | 0.7542 |
+| multi-shard ADDI | 0.7607 | [0.7542, 0.7670] | 2105.7 ms | 1602.5 ms | 0.7727 |
+| SHA2-512 | 0.6693 | [0.6686, 0.6695] | 2759.2 ms | 1847.2 ms | 0.7262 |
+| SHA2-1024 | 0.6996 | [0.6959, 0.7041] | 3103.9 ms | 2160.1 ms | 0.7458 |
+| SHA2-2048 | 0.7120 | [0.7116, 0.7131] | 3394.4 ms | 2415.6 ms | 0.7616 |
+
+Every individual row wins; no average conceals a regression. Energy has a
+0.53736 portfolio ratio (upper CI 0.54104), peak RSS is 0.99978x (upper CI
+1.00103), and proof size is exactly 1.0x for every workload. Candidate peak RSS
+ranges from 1,265 to 1,499 MiB.
+
+## Correctness and validation
+
+Every timed sample verified. Cross-arm proof digests are byte-identical in
+every round, all seven mechanism-telemetry records are present and stable, and
+the pinned Stark-V correctness oracle accepted 7/7 workloads. Format, source
+conformance, the aggregate ReleaseFast test root, the focused scalar lifting
+differential, RISC-V CPU product closure, Native CPU product closure, and the
+device-only Native Metal lifecycle all pass. Metal independently verifies its
+proof and reports no CPU fallback.
+
+## Caveats
+
+This is a claimed local result; only the judge's rerun counts. Local automatic
+guard expansion is absent from the verdict because of the recorded cross-board
+parser defect, so promotion must remain conditional on the remote judged guard
+matrix. The source change is shared and product correctness is green, but no
+unmeasured Native performance claim is made here.
+
+This result materially improves the RISC-V prover and reinforces the resident
+Metal pipeline architecture, but it does not complete the exact PR6 workload,
+cold-process, log22, and judged-evidence contract.
+
+**PR6 Supremacy: not achieved.**

--- a/autoresearch/submissions/2026-07-22-2026-07-22-riscv-lifted-run-strength-reduction/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-22-2026-07-22-riscv-lifted-run-strength-reduction/transcripts/session-01.md
@@ -1,0 +1,211 @@
+# Autoresearch session 01 — largest RISC-V portfolio
+
+## Objective and session contract
+
+This iteration begins immediately after the AdvSIMD M31/FFT-tail submission
+merged as PR #80. The standing objective is a repeated improvement -> claimed
+verdict -> PR -> green CI -> merge loop, prioritizing the largest and longest
+coordinates and especially the live RISC-V board. A result must preserve the
+Native CPU, Metal, and RISC-V correctness and resource portfolios; a narrow
+kernel result is not a submission.
+
+The canonical checkout was updated from `354da109` to `9095ecec`, including
+the recorded PR #80 promotion. Two pre-existing untracked Metal research notes
+were moved aside during the fast-forward and restored unchanged afterward.
+
+All five repository skills were loaded before measurement. Zig profiling is
+the primary evidence route for this CPU/shared-prover iteration. Algorithm
+matching gates any material replacement; Metal profiling and performance
+design constrain shared changes so they preserve the compute-only Metal path;
+the transcript is being captured contemporaneously. The Metal common-patterns
+reference was read completely. Its render-only branch does not apply because
+the prover contains no render pass.
+
+## Prior evidence reviewed
+
+The two most relevant promoted sessions are the cache-skewed shared-column
+arena and the later hardware-page rotation. They established that large Native
+composition was dominated by simultaneous column-major streams, but their
+attempt to raise the combined-column ceiling did not admit the 617-column
+RISC-V tree and was neutral on the existing 188-column tree. That experiment
+was reverted. A whole-process SHA2-2048 sample instead identified
+`quotient_tile_executor.execute` as the largest active top-of-stack frame,
+followed by Merkle leaves, circle extension, constraint evaluation, and witness
+ingestion. This iteration starts there rather than repeating the rejected
+column-ceiling hypothesis.
+
+No candidate source has been edited yet.
+
+## Fresh current-main baseline
+
+Current main `9095ecec` was built as the ReleaseFast `stwo-zig` product and all
+seven deep RISC-V rows were run locally with one verified warmup and one timed
+sample. The checkout reported dirty only because of the two preserved untracked
+research notes; the executable and source commit are fixed. Every release-gated
+artifact verified and was deterministic relative to its statement.
+
+| workload | request | proving | witness | verification |
+| --- | ---: | ---: | ---: | ---: |
+| xorshift PRNG | 2.119 s | 2.018 s | 0.012 s | 0.079 s |
+| iterative Fibonacci | 2.216 s | 2.113 s | 0.015 s | 0.081 s |
+| Euclidean GCD | 2.242 s | 2.122 s | 0.030 s | 0.081 s |
+| multi-shard ADDI | 2.173 s | 2.067 s | 0.012 s | 0.084 s |
+| SHA2-512 | 3.236 s | 2.721 s | 0.417 s | 0.089 s |
+| SHA2-1024 | 3.523 s | 3.015 s | 0.403 s | 0.089 s |
+| SHA2-2048 | 3.844 s | 3.165 s | 0.572 s | 0.087 s |
+
+The portfolio sums to about 19.35 seconds request and 17.22 seconds proving.
+Even the simple programs spend roughly 2.0--2.1 seconds proving, confirming a
+large shared-prover floor. SHA2 witness generation matters locally but cannot
+explain the whole portfolio.
+
+## Stage and stack attribution
+
+The legacy compatibility profiler, run at the matching functional parameters,
+reported approximate SHA2-2048 proving stages: FRI quotient build/commit 1.129
+s, interaction commit 0.772 s, composition evaluation 0.709 s, main commit
+0.152 s, preprocessed commit 0.084 s, and sampled values 0.034 s. Its standalone
+verification ended in `LogupSumNonZero`, so these numbers are diagnostic only,
+not correctness evidence.
+
+A three-second macOS sampler was then attached to the release-gated product,
+which completed and verified normally. Collapsing all threads by top frame gave:
+
+| active frame | samples |
+| --- | ---: |
+| quotient tile executor | 3,261 |
+| packed Merkle leaf updates | 738 |
+| `memmove` | 717 |
+| RISC-V LogUp pair constraints | 443 |
+| SIMD Blake compression | 329 |
+| fused circle-transform tails | 266 |
+| parallel-four Blake compression | 234 |
+| Poseidon2 full-round constraint evaluation | 211 |
+
+Idle worker waits were excluded from useful work. The quotient executor is
+therefore the first target, with Merkle/memory movement as the next independent
+axis. The current direct bounded path already performs a tile-wide denominator
+batch inversion and four-row finalization, so the next question is whether its
+column-contribution traversal is doing redundant passes or using a poor layout.
+
+## Run-wise lifted-column strength reduction
+
+The non-direct quotient input view maps each output position with
+`((position >> shift) << 1) + (position & 1)`. Therefore every structural
+`2^shift`-row run repeats one even/odd source pair. The former scalar loop
+nevertheless repeated four M31 coefficient products at every output row.
+
+The candidate preserves the existing output-stationary numerator planes and
+the exact contribution order, but computes each run's even and odd products
+once for all four extension coordinates. It broadcasts those alternating
+values through packed additions and retains a scalar boundary/tail. This is
+ordinary loop-invariant code motion plus strength reduction: it applies to all
+non-direct lifted views, is selected only from structural properties, adds no
+materialized matrix or pass, and changes no Metal ABI, synchronization, proof,
+or protocol behavior. A focused test covers shifts 2, 3, and 7 with aligned and
+misaligned tile boundaries and compares every output coordinate to the scalar
+lifting formula. The ReleaseFast prover closure passes.
+
+The first release-gated SHA2-2048 screen used one verified warmup and one timed
+sample. Request time fell from the fresh-main 3.843537 s anchor to 2.912426 s,
+a 0.7578 ratio (24.2% lower latency / 1.32x throughput). Proving fell from
+3.165494 s to 2.243519 s, a 0.7087 ratio (29.1% lower / 1.41x throughput).
+The statement SHA-256 remained
+`6bc61b060cd26d38c7d620dc6b3f17829221d310b498e7c7c8e63a01f3e97e88`,
+the transcript state remained
+`4ca8cf9f10ca8322420b8cec1bdcd426958ca06ad6371878c3ddbcbc2da5fac8`,
+and the verified artifact remained
+`e4ca968ae654b848c59c7911db5ce07e9a5aa96eb6af452b970f8ab1e3ce4b76`.
+Peak physical footprint was 1,569,556,952 bytes. This is a diagnostic dirty-tree
+screen, not the final verdict; the next step is the whole deep portfolio and a
+clean predecessor/candidate measurement.
+
+The complete seven-row diagnostic screen then verified every release-gated
+artifact with one warmup and one sample per row:
+
+| workload | main request | candidate request | ratio | candidate proving |
+| --- | ---: | ---: | ---: | ---: |
+| xorshift PRNG | 2.119153 s | 1.529049 s | 0.7215 | 1.433835 s |
+| iterative Fibonacci | 2.216116 s | 1.668222 s | 0.7528 | 1.568753 s |
+| Euclidean GCD | 2.241568 s | 1.603262 s | 0.7152 | 1.491254 s |
+| multi-shard ADDI | 2.172536 s | 1.643628 s | 0.7566 | 1.544502 s |
+| SHA2-512 | 3.236005 s | 2.285702 s | 0.7063 | 1.748794 s |
+| SHA2-1024 | 3.522512 s | 2.536996 s | 0.7202 | 2.062210 s |
+| SHA2-2048 | 3.843537 s | 2.947624 s | 0.7669 | 2.301461 s |
+
+The request-time geometric-mean ratio is approximately 0.733. Every row wins,
+so no portfolio average hides a loss. SHA2-2048 repeated within ordinary
+single-sample host variance (2.912--2.948 s request) while retaining its exact
+artifact digest. These remain screens; the source is frozen only after format,
+conformance, and test roots pass, and the submission claim will use the clean
+counterbalanced runner verdict.
+
+## First official-run harness failure
+
+The first clean `s3/riscv/deep` invocation reached regression-guard expansion
+but exited before producing a verdict. The CLI selected thirteen ordinary
+Native AIR guards, beginning with `guard_blake_10x10`, then incorrectly applied
+the RISC-V workload parser to them and rejected the first row because its
+command did not contain the RISC-V-only `{admission}` placeholder. Exact error:
+`guard_blake_10x10: RISC-V workload command lacks the required {admission}
+token`. This is a board/guard classification defect in the local runner, not a
+candidate proof, test, or benchmark failure. No output will be represented as a
+verdict. The objective lane is rerun with local guard expansion disabled;
+submission-side judged guards remain mandatory, and relevant Native/Metal and
+RISC-V correctness products are run separately before promotion.
+
+The generated `.runs/latest` directory from that failure contained the full
+objective A/B reports and proof artifacts. It was moved intact into the session
+evidence directory as `failed-auto-guard-run`; nothing was deleted. A later
+`stwo-perf sync` unexpectedly detached the candidate worktree at current main.
+The committed source was not lost: branch `autoresearch/riscv-quotient-layout`
+still pointed to `3084fe1`. The worktree was switched back to that branch,
+verified clean, and product setup rebound all identities before rerunning.
+
+## Clean official result
+
+The repeated S3 objective run used clean candidate `3084fe1985db` and clean
+predecessor `9095ecec918f`. Every timed sample verified, cross-arm proof digests
+were byte-identical in every round, mechanism telemetry was present and stable
+for 7/7 rows, and the pinned Stark-V oracle accepted 7/7 artifacts.
+
+| workload | prove ratio | 95% CI | rounds | predecessor | candidate | request ratio |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| xorshift PRNG | 0.726846 | [0.724060, 0.731443] | 3 | 2006.122 ms | 1456.325 ms | 0.738316 |
+| iterative Fibonacci | 0.768963 | [0.765468, 0.774236] | 3 | 2119.912 ms | 1622.725 ms | 0.778959 |
+| Euclidean GCD | 0.739743 | [0.736568, 0.744811] | 3 | 2097.813 ms | 1552.882 ms | 0.754235 |
+| multi-shard ADDI | 0.760715 | [0.754239, 0.766993] | 5 | 2105.685 ms | 1602.519 ms | 0.772699 |
+| SHA2-512 | 0.669270 | [0.668619, 0.669534] | 3 | 2759.161 ms | 1847.157 ms | 0.726183 |
+| SHA2-1024 | 0.699600 | [0.695874, 0.704104] | 3 | 3103.856 ms | 2160.110 ms | 0.745798 |
+| SHA2-2048 | 0.712002 | [0.711626, 0.713093] | 3 | 3394.397 ms | 2415.601 ms | 0.761626 |
+
+The proving-time portfolio ratio is 0.724575 with bootstrap 95% CI
+[0.723189, 0.726258], and the verified-request ratio geometric mean is
+0.753773. Energy falls to 0.537364x with upper CI 0.541043. Peak RSS is
+0.999782x with upper CI 1.001021. Proof bytes are exactly unchanged for every
+row. Candidate geometric-mean proving time is 1780.298 ms and total accepted
+measurement time is 223.818 seconds over 23 workload rounds.
+
+## Final validation and submission boundary
+
+`zig build fmt source-conformance test -Doptimize=ReleaseFast` passes, including
+the 365-source aggregate closure and focused lifted-run differential. The clean
+candidate then passes `test-riscv-cpu-product`, `test-native-cpu-product`, and
+`test-native-metal`: RISC-V closes over 340 sources; Native CPU over 198; Native
+Metal over 240 and completes a device-only proof plus independent verification
+with no fallback. All products embed clean commit `3084fe1` and tree
+`2ae9ce544e9c0dd990d0254b33b9503ea36cd4aa`.
+
+The submission claims only the significant `riscv/deep` improvement. The local
+verdict is advisory and lacks automatic guards solely because of the recorded
+runner classification bug; remote judged guards remain a hard promotion gate.
+The exact PR6 matrix, both timing boundaries, log22 evidence, and authenticated
+judge verdict are incomplete.
+
+**PR6 Supremacy: not achieved.**
+
+The first packaging invocation was rejected before writing repository files
+because the note used the headings `Profile and hypothesis` and `Architecture`
+instead of the schema's literal required `Hypothesis` and `Changes` headings.
+The underlying content was unchanged; the headings were corrected and the
+validator was rerun.

--- a/autoresearch/submissions/2026-07-22-2026-07-22-riscv-lifted-run-strength-reduction/verdict.json
+++ b/autoresearch/submissions/2026-07-22-2026-07-22-riscv-lifted-run-strength-reduction/verdict.json
@@ -1,0 +1,940 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "a83513e14102",
+  "repo_commit": "3084fe1985db",
+  "predecessor_commit": "9095ecec918f",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "riscv",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 6.62
+    }
+  },
+  "search_health": {
+    "schema_version": 1,
+    "decision": {
+      "schema_version": 1,
+      "board": "riscv",
+      "workload_class": "deep",
+      "trailing_window": 8,
+      "trailing_evidence_count": 0,
+      "trailing_median_gradient_snr": null,
+      "gradient_snr_threshold": 2.0,
+      "configured_rounds": 5,
+      "auto_boost_rounds": 5,
+      "maximum_rounds": 25,
+      "target_rounds": 5,
+      "workload_count": 7,
+      "class_wall_deadline_seconds": 600.0,
+      "estimated_seconds_per_round": null,
+      "deadline_round_limit": null,
+      "auto_boost_applied": false,
+      "auto_boost_reason": "insufficient_trailing_evidence",
+      "recorded_before_measurement": true
+    },
+    "decision_sha256": "sha256:ee9fb5f8e6147f840f964898b86460d6b3781cf0de8b4e52b006c3d257f6fbed",
+    "actual_rounds": 23,
+    "actual_rounds_per_workload": {
+      "riscv_fib_iter": 3,
+      "riscv_gcd_euclid": 3,
+      "riscv_multi_shard_addi": 5,
+      "riscv_sha2_1024b": 3,
+      "riscv_sha2_2048b": 3,
+      "riscv_sha2_512b": 3,
+      "riscv_xorshift_prng": 3
+    },
+    "objective_wall_seconds": 223.9229243749287,
+    "measurement_wall_seconds": 225.14115612499882,
+    "measurement_wall_hours": 0.06253921003472189,
+    "gradient_snr": null,
+    "credited_ln_improvement": null,
+    "credited_ln_improvement_per_measurement_hour": null,
+    "credit_status": "pending_ledger_adjudication",
+    "decision_record": "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/search-health-decision.json"
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned correctness oracle verified 7/7 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "RISC-V mechanism telemetry present, canonical, and semantically stable for 7/7 workloads"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.6896 vs targeted budget x1.02; matrix row upper CIs 7/7 within budget x1.05; request ratios 7/7 present rows within budget x1.05; resource vectors 7/7 within named budgets"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "riscv_xorshift_prng": {
+        "r": 0.726846,
+        "ci": [
+          0.72406,
+          0.731443
+        ],
+        "rounds": 3,
+        "a_median_ms": 2006.12225,
+        "b_median_ms": 1456.3245,
+        "request_ratio": 0.738316,
+        "rss_ratio": 0.999818,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.517829,
+            "ci": [
+              0.509045,
+              0.521931
+            ],
+            "observations": 3,
+            "candidate": 64.460880258
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999818,
+            "ci": [
+              0.999457,
+              1.00068
+            ],
+            "observations": 3,
+            "candidate": 1265.1270370483398
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 61123.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 61123,
+        "measurement_seconds": 22.035607,
+        "resources_complete": true
+      },
+      "riscv_fib_iter": {
+        "r": 0.768963,
+        "ci": [
+          0.765468,
+          0.774236
+        ],
+        "rounds": 3,
+        "a_median_ms": 2119.911916,
+        "b_median_ms": 1622.7245,
+        "request_ratio": 0.778959,
+        "rss_ratio": 1.000015,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.574689,
+            "ci": [
+              0.57182,
+              0.575768
+            ],
+            "observations": 3,
+            "candidate": 67.138318652
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000015,
+            "ci": [
+              0.99948,
+              1.000266
+            ],
+            "observations": 3,
+            "candidate": 1291.923843383789
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 60003.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 60003,
+        "measurement_seconds": 23.814151,
+        "resources_complete": true
+      },
+      "riscv_gcd_euclid": {
+        "r": 0.739743,
+        "ci": [
+          0.736568,
+          0.744811
+        ],
+        "rounds": 3,
+        "a_median_ms": 2097.812584,
+        "b_median_ms": 1552.881625,
+        "request_ratio": 0.754235,
+        "rss_ratio": 0.999704,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.543625,
+            "ci": [
+              0.536809,
+              0.54788
+            ],
+            "observations": 3,
+            "candidate": 64.094571118
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999704,
+            "ci": [
+              0.999097,
+              1.000232
+            ],
+            "observations": 3,
+            "candidate": 1278.6269912719727
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 62582.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 62582,
+        "measurement_seconds": 23.387465,
+        "resources_complete": true
+      },
+      "riscv_multi_shard_addi": {
+        "r": 0.760715,
+        "ci": [
+          0.754239,
+          0.766993
+        ],
+        "rounds": 5,
+        "a_median_ms": 2105.685041,
+        "b_median_ms": 1602.519084,
+        "request_ratio": 0.772699,
+        "rss_ratio": 0.999879,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.571247,
+            "ci": [
+              0.56581,
+              0.576875
+            ],
+            "observations": 5,
+            "candidate": 62.620814503
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999879,
+            "ci": [
+              0.999703,
+              1.00026
+            ],
+            "observations": 5,
+            "candidate": 1289.9551620483398
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 58117.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 58117,
+        "measurement_seconds": 39.363598,
+        "resources_complete": true
+      },
+      "riscv_sha2_512b": {
+        "r": 0.66927,
+        "ci": [
+          0.668619,
+          0.669534
+        ],
+        "rounds": 3,
+        "a_median_ms": 2759.160875,
+        "b_median_ms": 1847.1565,
+        "request_ratio": 0.726183,
+        "rss_ratio": 1.00014,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.502341,
+            "ci": [
+              0.498768,
+              0.507614
+            ],
+            "observations": 3,
+            "candidate": 83.489450845
+          },
+          "peak_rss_mib": {
+            "ratio": 1.00014,
+            "ci": [
+              0.9995,
+              1.00206
+            ],
+            "observations": 3,
+            "candidate": 1374.5647659301758
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 78496.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 78496,
+        "measurement_seconds": 34.157474,
+        "resources_complete": true
+      },
+      "riscv_sha2_1024b": {
+        "r": 0.6996,
+        "ci": [
+          0.695874,
+          0.704104
+        ],
+        "rounds": 3,
+        "a_median_ms": 3103.856417,
+        "b_median_ms": 2160.1095,
+        "request_ratio": 0.745798,
+        "rss_ratio": 1.00014,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.526975,
+            "ci": [
+              0.524501,
+              0.528764
+            ],
+            "observations": 3,
+            "candidate": 90.432475841
+          },
+          "peak_rss_mib": {
+            "ratio": 1.00014,
+            "ci": [
+              0.999343,
+              1.002177
+            ],
+            "observations": 3,
+            "candidate": 1428.1273803710938
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 76677.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 76677,
+        "measurement_seconds": 38.032848,
+        "resources_complete": true
+      },
+      "riscv_sha2_2048b": {
+        "r": 0.712002,
+        "ci": [
+          0.711626,
+          0.713093
+        ],
+        "rounds": 3,
+        "a_median_ms": 3394.397042,
+        "b_median_ms": 2415.600583,
+        "request_ratio": 0.761626,
+        "rss_ratio": 0.998776,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.528873,
+            "ci": [
+              0.526393,
+              0.53235
+            ],
+            "observations": 3,
+            "candidate": 98.607023839
+          },
+          "peak_rss_mib": {
+            "ratio": 0.998776,
+            "ci": [
+              0.993507,
+              1.001471
+            ],
+            "observations": 3,
+            "candidate": 1499.0331497192383
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 81115.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 81115,
+        "measurement_seconds": 43.02718,
+        "resources_complete": true
+      }
+    },
+    "R_geomean": 0.724575,
+    "portfolio": {
+      "ci_method": "independent_workload_round_bootstrap_percentile_v1",
+      "ci_level": 0.95,
+      "bootstrap_iterations": 4000,
+      "seed": 4042241451,
+      "ci": [
+        0.723189,
+        0.726258
+      ],
+      "prove_ms_method": "geometric_mean_candidate_workload_medians_ms_v1",
+      "b_median_ms_geomean": 1780.298098,
+      "proof_bytes_method": "rounded_geometric_mean_candidate_proof_bytes_v1",
+      "proof_bytes": 67692,
+      "measurement_seconds": 223.818323,
+      "measurement_rounds": 23
+    },
+    "theta": 0.012888,
+    "aa_dispersion": 0.006444,
+    "significant": true,
+    "neutral": false,
+    "promotion_significance": {
+      "eligible": true,
+      "method": "independent_workload_round_bootstrap_percentile_v1",
+      "reason": "prove-time objective uses the deterministic workload portfolio CI"
+    },
+    "resource_portfolio": {
+      "peak_rss_mib": {
+        "ratio_geomean": 0.999781529237516,
+        "upper_ci_geomean": 1.001020811535023,
+        "candidate_geomean": 1344.2821058494503
+      },
+      "energy_j": {
+        "ratio_geomean": 0.5373644915170899,
+        "upper_ci_geomean": 0.5410427814384295,
+        "candidate_geomean": 74.66134161208339
+      },
+      "proof_bytes": {
+        "ratio_geomean": 1.0,
+        "upper_ci_geomean": 1.0,
+        "candidate_geomean": 67691.6135391908
+      }
+    }
+  },
+  "tiebreakers": {
+    "rss_ratio": 0.999782,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": 74.66134161208339,
+    "proof_bytes": 67691.6135391908
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "riscv_xorshift_prng",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "973acdfb4f81b5a9920f4523ed4076b15fd65f465bc5bbf467184b9ac0c459b8",
+      "proof_sha256": "c32a74186749f640a1b5b2a558768e9f6e60bcd58bc30595411e1722d5ead0e9"
+    },
+    {
+      "workload": "riscv_fib_iter",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "d51ba91966efbc3a5ecdb017e521f9ac6f8ce83970b1ed2d12766039b7920262",
+      "proof_sha256": "100f0251e29fa5bbd58dfca387f52b776c0fa387ca0c2250a2f5534235bedc02"
+    },
+    {
+      "workload": "riscv_gcd_euclid",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "faf3ab057b126f8750d1c80420b40ea0623aa4ed1cab512d189144dec2ebbde9",
+      "proof_sha256": "7cfa5df8529186cc005ad38e86f5aae1fc0cb150a2d4c899a42bebac5f46778b"
+    },
+    {
+      "workload": "riscv_multi_shard_addi",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "f2a81bd9e6e1ac11951fdcdc20f15c816ee2f574c5c49fa0180161b470a9077f",
+      "proof_sha256": "4bf8ab22c5ebb506421203abfb2905b06d3f9cc39cd42fcd3899f288f98775a4"
+    },
+    {
+      "workload": "riscv_sha2_512b",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "6f51641fed40e562c2aafc3307bfe83812ed6440ef65a9445870f09d3cc7c39f",
+      "proof_sha256": "a5c7b4e54d0ba913b0ae1f58c77ea823826e0ba776a4a2673be2ab6dc3bcb74a"
+    },
+    {
+      "workload": "riscv_sha2_1024b",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "6c7f460a83887104f7439596c59385292f7949b7516d77b452be7b6328994805",
+      "proof_sha256": "63bbad02c8806622b99eba191ca9d1333ba77abd2f1486e2838525542d36cc50"
+    },
+    {
+      "workload": "riscv_sha2_2048b",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "66fba423adeec4302ac0e2b142d37ec5d5639c2cdae5c7d3d6a6f1aeaa2488ec",
+      "proof_sha256": "adaa94716e7010c04814b2b574b3b7cb788f76f31f8258ad2a737bae68f1b851"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "pr6_supremacy",
+      "reason": "PR6 Supremacy remains disabled until every exact workload port, log22 oracle vector, both timing boundaries, locked-M5 statistical gate, and authenticated judged verdict are complete."
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "riscv_xorshift_prng": {
+        "round_ratios": [
+          0.731443,
+          0.72594,
+          0.72406
+        ],
+        "proof_digest": "c32a74186749f640a1b5b2a558768e9f6e60bcd58bc30595411e1722d5ead0e9",
+        "request_ratio": 0.738316,
+        "rss_ratio": 0.999818,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.517829,
+            "ci": [
+              0.509045,
+              0.521931
+            ],
+            "observations": 3,
+            "candidate": 64.460880258
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999818,
+            "ci": [
+              0.999457,
+              1.00068
+            ],
+            "observations": 3,
+            "candidate": 1265.1270370483398
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 61123.0
+          }
+        },
+        "report_sha256s": [
+          "2a43ddd8027f977d19375a38ff83216770333e9731e5e5444294c0a2cf299085",
+          "fc42d01a897f76684f88097b6e7f339409dd482ae9c8b7f449e094880fad17a3",
+          "9cf6529097ab202ae9f8160890b3408d45c6179ec5f84a00d499095cb7d417fd",
+          "103bcc0c599be95d1cc7748064ec1b859ef733b3a5f24f9d8a09f25662988a84",
+          "e230387eaebd42b3e54c16cd1da430cb12897d7dc45ab33e9b1e743ccefc6a51",
+          "fc35b660e685cc4109f3ebc85ecbf6c422c3e8557305bf6942cf9c35bd5833ce"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_fib_iter": {
+        "round_ratios": [
+          0.768075,
+          0.765468,
+          0.774236
+        ],
+        "proof_digest": "100f0251e29fa5bbd58dfca387f52b776c0fa387ca0c2250a2f5534235bedc02",
+        "request_ratio": 0.778959,
+        "rss_ratio": 1.000015,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.574689,
+            "ci": [
+              0.57182,
+              0.575768
+            ],
+            "observations": 3,
+            "candidate": 67.138318652
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000015,
+            "ci": [
+              0.99948,
+              1.000266
+            ],
+            "observations": 3,
+            "candidate": 1291.923843383789
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 60003.0
+          }
+        },
+        "report_sha256s": [
+          "8d002b94f01e50c4f925dc1977b3efc2c5152ee780bf67b8cde886d89060f4fa",
+          "8156e31ca80a4e955592cec5435740dde6d9f683c80b482eb1077da31c1882e6",
+          "efbc4c1e930d477e1ce808fd3e9e6e79e715abcd18afaafde775606dbdf3b2b6",
+          "4d7832d84e716837e61cde85558191d2918bdd27b9f81806f16bfdc97c993fdd",
+          "ea3402ce94c03bcc77fa5dd8f6f00988f0aad21dc2c29c93ea5bc9ae65acfe74",
+          "d3138f2c7e5abd72342f180260b56bdabb1265b1f1c5ac1683aa23255e36e0c5"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_gcd_euclid": {
+        "round_ratios": [
+          0.744811,
+          0.738797,
+          0.736568
+        ],
+        "proof_digest": "7cfa5df8529186cc005ad38e86f5aae1fc0cb150a2d4c899a42bebac5f46778b",
+        "request_ratio": 0.754235,
+        "rss_ratio": 0.999704,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.543625,
+            "ci": [
+              0.536809,
+              0.54788
+            ],
+            "observations": 3,
+            "candidate": 64.094571118
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999704,
+            "ci": [
+              0.999097,
+              1.000232
+            ],
+            "observations": 3,
+            "candidate": 1278.6269912719727
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 62582.0
+          }
+        },
+        "report_sha256s": [
+          "e4e4c6a3ed666f0a8879778b1af5ab001dd30e1f17a066a2f1c8614d79b589fa",
+          "cce757f40153fd1d47d2b3aa58a239fe7439d667fef0d1f6c9c704c3a0b6485d",
+          "26aea9f2ed77ad252701295aadb6ebb70e2c4da202c28247ddc96fb11b4981fb",
+          "65f27d8f9ea6b4b6e14dae721f0b25a539386fc88e4ea646678f6da7f18f3b05",
+          "a004f0d7ca1c55885fc7c00ca710d4c6b583079c968db1f76a1b9239f52fdc6f",
+          "2b2d371dae3bf22efe49486b867bd4b237353ba8e6f12a8abdd02ae2824d5873"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_multi_shard_addi": {
+        "round_ratios": [
+          0.748091,
+          0.760883,
+          0.772942,
+          0.761044,
+          0.760387
+        ],
+        "proof_digest": "4bf8ab22c5ebb506421203abfb2905b06d3f9cc39cd42fcd3899f288f98775a4",
+        "request_ratio": 0.772699,
+        "rss_ratio": 0.999879,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.571247,
+            "ci": [
+              0.56581,
+              0.576875
+            ],
+            "observations": 5,
+            "candidate": 62.620814503
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999879,
+            "ci": [
+              0.999703,
+              1.00026
+            ],
+            "observations": 5,
+            "candidate": 1289.9551620483398
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 58117.0
+          }
+        },
+        "report_sha256s": [
+          "28a333708e7af38969adec8609b6f8a495b1f00313a787fcf78b0e8d53ec7f40",
+          "6331cd40fece032659a5fd452bf4655329f29e0df6d361bd68541ba3a102891d",
+          "694cabc420a7ccb23f07f7b66c1355260227d47bc406eb585501cee6835adbbc",
+          "a67acba3b7d560d2ae74cd3b89889224ae4274579f7f0cbd159979462fe5988e",
+          "f6060ba1961952f1827bab40409bb7ef763d80accec2c333f83da942fa67f7d4",
+          "585aae0135f380019acb939d1fea3cef2e6671a41f0d6c5155588a7f249c80cc",
+          "610ab91e7fba963b4890f92ff02c6b539e85f5e435be8fc55b8d32ee0e32ec46",
+          "753c445a00d366b4c1b5a4defd4ef7dd5824d443bee888b54b9a8ab51f87ccb9",
+          "b228d564e044e3fec312c841a320e8a6d81692b68e16a5aa01caae7bf705f597",
+          "d359807e2dc9493a96d554cc593a6cfa248282bcb3e62fe5cd56045553269546"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_sha2_512b": {
+        "round_ratios": [
+          0.669534,
+          0.668619,
+          0.669463
+        ],
+        "proof_digest": "a5c7b4e54d0ba913b0ae1f58c77ea823826e0ba776a4a2673be2ab6dc3bcb74a",
+        "request_ratio": 0.726183,
+        "rss_ratio": 1.00014,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.502341,
+            "ci": [
+              0.498768,
+              0.507614
+            ],
+            "observations": 3,
+            "candidate": 83.489450845
+          },
+          "peak_rss_mib": {
+            "ratio": 1.00014,
+            "ci": [
+              0.9995,
+              1.00206
+            ],
+            "observations": 3,
+            "candidate": 1374.5647659301758
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 78496.0
+          }
+        },
+        "report_sha256s": [
+          "bdcfea2d5dd83df59678f55d97471bf13952dcf953c9aee9ba7619b6ea1579b9",
+          "a1e10cb2d85532fe7a504f7ce9ddb8443a282db1bafc0d0f847452b406522480",
+          "7198c7c3715086286c052c74c81fb63cbb3641f1ba17cdc841fbc43dbab63a22",
+          "81c1a1fa43556ad849625701963d91b29f4a484a7ee9d1f1f0377b1d07eadff0",
+          "6da5ac242cca326d27b4d8af92884ab4fac38d5d7f6fba5448e982edacf877b5",
+          "564974c42421c39f8258c8eef380fd5fd3d23f1e6ff84b792ba63410738a058e"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_sha2_1024b": {
+        "round_ratios": [
+          0.695874,
+          0.69921,
+          0.704104
+        ],
+        "proof_digest": "63bbad02c8806622b99eba191ca9d1333ba77abd2f1486e2838525542d36cc50",
+        "request_ratio": 0.745798,
+        "rss_ratio": 1.00014,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.526975,
+            "ci": [
+              0.524501,
+              0.528764
+            ],
+            "observations": 3,
+            "candidate": 90.432475841
+          },
+          "peak_rss_mib": {
+            "ratio": 1.00014,
+            "ci": [
+              0.999343,
+              1.002177
+            ],
+            "observations": 3,
+            "candidate": 1428.1273803710938
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 76677.0
+          }
+        },
+        "report_sha256s": [
+          "ca67a1f662cc946706fe950459ae90c8ac612f2f88fc9ee7f72605c968e7ad23",
+          "f33cd3a10f724fcd496e94a1d49cdcf9d231c8c1c8678d525bea171d6a044341",
+          "eb036e8490021d87d621b27652bc77c14e9c3b385440961eaa222467c359f1fc",
+          "d239ea371c39f12ffabc4516eb3ddaeed2a153d7bbd34d5a2d8271b69b56b7ae",
+          "f4788bf83b4400d1d036a680adde0404215fcc47238f34016dc61c55dcf0695f",
+          "1ab10ffef083baf133d925667319c4b30e20bbb25b07427bfa3e0f8c7031effc"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_sha2_2048b": {
+        "round_ratios": [
+          0.711643,
+          0.713093,
+          0.711626
+        ],
+        "proof_digest": "adaa94716e7010c04814b2b574b3b7cb788f76f31f8258ad2a737bae68f1b851",
+        "request_ratio": 0.761626,
+        "rss_ratio": 0.998776,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.528873,
+            "ci": [
+              0.526393,
+              0.53235
+            ],
+            "observations": 3,
+            "candidate": 98.607023839
+          },
+          "peak_rss_mib": {
+            "ratio": 0.998776,
+            "ci": [
+              0.993507,
+              1.001471
+            ],
+            "observations": 3,
+            "candidate": 1499.0331497192383
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 81115.0
+          }
+        },
+        "report_sha256s": [
+          "1a196bc5e148b771880690122252b8a0fd66b9a1a671c8eb0321ebafe6273ea9",
+          "e3fc1ad1e9a2e3e3cce86e00e953d3d46ccd5a883bf636f328ba70ea829ce529",
+          "534875e9f2c73b3d4ab5c0ad4ceb0622bc70499610497401755535d90bc916c4",
+          "2beba8445ee812c93aeaad1dd974533686077719f620114b5529aa3271360329",
+          "6c5f1fc1452dc94bdd0c13c79c8a73833c2c2b0e9eb61eb4530b0bba6a4ac0be",
+          "67ac1aefb529342ac558bddd430206cbe7559f4862e6dfbc4ecca5b684ab421b"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_xorshift_prng.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_xorshift_prng.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_xorshift_prng.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_xorshift_prng.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_xorshift_prng.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_xorshift_prng.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_fib_iter.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_fib_iter.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_fib_iter.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_fib_iter.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_fib_iter.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_fib_iter.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_gcd_euclid.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_gcd_euclid.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_gcd_euclid.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_gcd_euclid.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_gcd_euclid.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_gcd_euclid.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_multi_shard_addi.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_multi_shard_addi.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_multi_shard_addi.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_multi_shard_addi.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_multi_shard_addi.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_multi_shard_addi.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_multi_shard_addi.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_multi_shard_addi.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_multi_shard_addi.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_multi_shard_addi.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_sha2_512b.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_sha2_512b.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_sha2_512b.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_sha2_512b.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_sha2_512b.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_sha2_512b.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_sha2_1024b.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_sha2_1024b.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_sha2_1024b.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_sha2_1024b.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_sha2_1024b.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_sha2_1024b.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_sha2_2048b.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_sha2_2048b.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_sha2_2048b.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_sha2_2048b.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_sha2_2048b.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-next/autoresearch/.runs/latest/riscv_sha2_2048b.b3.json"
+    ]
+  }
+}

--- a/src/prover/pcs/quotient_tile_executor.zig
+++ b/src/prover/pcs/quotient_tile_executor.zig
@@ -302,6 +302,18 @@ fn accumulateTile(work: *const Work, scratch: *Scratch, start: usize, row_count:
                 );
                 continue;
             }
+            if (!view.is_direct) {
+                accumulateLiftedRuns(
+                    scratch,
+                    view.values,
+                    view.shift_amt,
+                    start,
+                    row_count,
+                    contribution.batch_index,
+                    coefficients,
+                );
+                continue;
+            }
             for (0..row_count) |row| {
                 const position = start + row;
                 const source_index = ((position >> view.shift_amt) << 1) + (position & 1);
@@ -310,6 +322,69 @@ fn accumulateTile(work: *const Work, scratch: *Scratch, start: usize, row_count:
                     const numerator = scratch.numerator(contribution.batch_index, coordinate, row);
                     numerator.* = numerator.add(base.mul(coefficients[coordinate]));
                 }
+            }
+        }
+    }
+}
+
+/// Accumulates an implicitly lifted column without repeating its field
+/// products for every output row. A non-direct view repeats one even/odd source
+/// pair across each `2^shift_amt`-row run. Products are invariant within that
+/// run, so compute the two parity values once and broadcast packed additions
+/// into the output-stationary numerator planes.
+fn accumulateLiftedRuns(
+    scratch: *Scratch,
+    values: []const M31,
+    shift_amt: std.math.Log2Int(usize),
+    start: usize,
+    row_count: usize,
+    batch: usize,
+    coefficients: [qm31.SECURE_EXTENSION_DEGREE]M31,
+) void {
+    std.debug.assert(shift_amt >= 2);
+    const end = start + row_count;
+    var position = start;
+    while (position < end) {
+        const source_block = position >> shift_amt;
+        const block_end = @min(end, (source_block + 1) << shift_amt);
+        const source_index = source_block << 1;
+        std.debug.assert(source_index + 1 < values.len);
+
+        var products: [qm31.SECURE_EXTENSION_DEGREE][2]M31 = undefined;
+        var even_first: [qm31.SECURE_EXTENSION_DEGREE]m31.PackedM31 = undefined;
+        var odd_first: [qm31.SECURE_EXTENSION_DEGREE]m31.PackedM31 = undefined;
+        inline for (0..qm31.SECURE_EXTENSION_DEGREE) |coordinate| {
+            products[coordinate] = .{
+                values[source_index].mul(coefficients[coordinate]),
+                values[source_index + 1].mul(coefficients[coordinate]),
+            };
+            var even_lanes: [m31.PACK_WIDTH]u32 = undefined;
+            var odd_lanes: [m31.PACK_WIDTH]u32 = undefined;
+            inline for (0..m31.PACK_WIDTH) |lane| {
+                even_lanes[lane] = products[coordinate][lane & 1].v;
+                odd_lanes[lane] = products[coordinate][1 - (lane & 1)].v;
+            }
+            even_first[coordinate] = @bitCast(even_lanes);
+            odd_first[coordinate] = @bitCast(odd_lanes);
+        }
+
+        while (block_end - position >= m31.PACK_WIDTH) : (position += m31.PACK_WIDTH) {
+            const local_row = position - start;
+            inline for (0..qm31.SECURE_EXTENSION_DEGREE) |coordinate| {
+                const plane = batch * qm31.SECURE_EXTENSION_DEGREE + coordinate;
+                const numerators = scratch.numerators.ptr + plane * scratch.row_capacity + local_row;
+                const addend = if ((position & 1) == 0)
+                    even_first[coordinate]
+                else
+                    odd_first[coordinate];
+                m31.storePacked(numerators, m31.addPacked(m31.loadPacked(numerators), addend));
+            }
+        }
+        while (position < block_end) : (position += 1) {
+            const parity = position & 1;
+            inline for (0..qm31.SECURE_EXTENSION_DEGREE) |coordinate| {
+                const numerator = scratch.numerator(batch, coordinate, position - start);
+                numerator.* = numerator.add(products[coordinate][parity]);
             }
         }
     }
@@ -631,6 +706,36 @@ test "quotient tile input policy selects only the measured batched domain" {
     try std.testing.expect(!shouldUseBoundedInput(12));
     try std.testing.expect(shouldUseBoundedInput(13));
     try std.testing.expect(shouldUseBoundedInput(14));
+}
+
+test "lifted run accumulation matches scalar lifting across boundaries" {
+    var scratch = try Scratch.init(std.testing.allocator, 1, 37);
+    defer scratch.deinit(std.testing.allocator);
+    var values: [64]M31 = undefined;
+    for (&values, 0..) |*value, i| value.* = M31.fromCanonical(@intCast(i * 97 + 11));
+    const coefficients = [qm31.SECURE_EXTENSION_DEGREE]M31{
+        M31.fromCanonical(3), M31.fromCanonical(5),
+        M31.fromCanonical(7), M31.fromCanonical(11),
+    };
+    const Case = struct { shift: u6, start: usize, len: usize };
+    for ([_]Case{
+        .{ .shift = 2, .start = 0, .len = 37 },
+        .{ .shift = 3, .start = 3, .len = 31 },
+        .{ .shift = 7, .start = 5, .len = 29 },
+    }) |case| {
+        @memset(scratch.numerators, M31.zero());
+        accumulateLiftedRuns(&scratch, &values, case.shift, case.start, case.len, 0, coefficients);
+        for (0..case.len) |row| {
+            const position = case.start + row;
+            const source_index = ((position >> case.shift) << 1) + (position & 1);
+            inline for (0..qm31.SECURE_EXTENSION_DEGREE) |coordinate| {
+                try std.testing.expectEqual(
+                    values[source_index].mul(coefficients[coordinate]).v,
+                    scratch.numerator(0, coordinate, row).v,
+                );
+            }
+        }
+    }
 }
 
 test "packed finalize matches scalar finalizeRowQuotients for all batch counts" {


### PR DESCRIPTION
## Result

Strength-reduces structurally repeated non-direct quotient inputs by hoisting each run’s even/odd M31 products and broadcasting packed additions into the existing output-stationary numerator planes. No workload or size special casing, new materialization, protocol change, or Metal runtime state.

Claimed `riscv/deep` S3 verdict: proving-time portfolio ratio **0.724575**, 95% CI **[0.723189, 0.726258]**. All seven rows win (0.6693–0.7690), verified-request geomean is 0.753773, energy is 0.53736x, RSS is 0.99978x, and proof bytes are unchanged. Cross-arm proof bytes match; pinned Stark-V oracle accepts 7/7.

## Validation

- aggregate ReleaseFast tests, format, and source conformance
- focused lifted-run/scalar differential across shifts and misaligned boundaries
- RISC-V CPU product closure
- Native CPU product closure
- device-only Native Metal proof plus independent verification, zero fallback

Local automatic guard expansion exposed a runner classification bug (Native AIR guards parsed as RISC-V and rejected for missing `{admission}`), documented in the transcript. The claimed objective verdict was rerun cleanly without local guard expansion; CI/judged guards remain a hard promotion condition.

**PR6 Supremacy: not achieved.**