### PR TITLE
Group lifted quotient contributions in worker registers

### DIFF
--- a/autoresearch/submissions/2026-07-22-riscv-register-grouped-quotients/delta.json
+++ b/autoresearch/submissions/2026-07-22-riscv-register-grouped-quotients/delta.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "e20d72ac90af",
+  "declared_objective": {
+    "board": "riscv",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/prover/pcs/quotient_compact_groups.zig": "sha256:6a60e3d8343d628263c7034c513be18384784d55b0d780d928a4fc054d676a80",
+    "src/prover/pcs/quotient_direct_plan.zig": "sha256:f7e577230d6122f7d1dcbfc5db8566f7c68dbd248bc725926f24f5700f62b42e",
+    "src/prover/pcs/quotient_tile_executor.zig": "sha256:7773cc99f7ed306d4000606162d7ffe71f709cf34d6e4d640e35baec275c847a",
+    "src/prover/pcs/quotients/lazy_provider.zig": "sha256:0a1ae2fadfa0211ebc86a7c5ec16e2f2ffe10d9c437266cf78af153a0c358b24",
+    "src/prover/pcs/quotients/planning.zig": "sha256:2ce1d779309e6587f1c1561aecaff153dfd34f7e4f8514048ed0c863d8443b5e"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "0b2dd5d34dc790b4b20c2d0f3701cd952d03cda33c0a409c41cefd058461ec67",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-22-riscv-register-grouped-quotients/note.md
+++ b/autoresearch/submissions/2026-07-22-riscv-register-grouped-quotients/note.md
@@ -1,0 +1,109 @@
+# Group lifted quotient contributions in worker-local registers
+
+## Model and harness
+
+Model: GPT-5 Codex. The repository-resident `stwo-perf` harness ran on the
+designated Apple M5 Max in ReleaseFast mode. The clean claimed S3
+`riscv/deep` comparison used immutable candidate `19ca3b8863ee` and current-main
+predecessor `e20d72ac90af`, round-level A-B-B-A ordering, verified artifacts,
+complete resource/mechanism telemetry, and the pinned Stark-V oracle. Every raw
+A/B report records `implementation_dirty=false`.
+
+The CLI's known automatic-guard classifier still parses Native guard IDs as
+RISC-V and rejects their missing RISC-V-only admission token. The final local
+verdict therefore sampled the objective with `--guards none`; aggregate,
+RISC-V CPU, Native CPU, source-conformance, and device-only Native Metal product
+checks were run separately. Promotion remains conditional on the remote judged
+guard matrix.
+
+## Hypothesis
+
+After the promoted run-wise strength reduction, a fresh verified SHA2-2048
+sample still put the quotient tile executor first with 1,705 top-of-stack
+samples, ahead of packed Merkle leaves (749), `memmove` (708), and four-way
+Blake compression (573). The live quotient plan had 2,162 contributions but
+only 35 unique `(sample batch, source geometry)` groups.
+
+Lifting is a linear index transform over exact M31 arithmetic. Contributions
+sharing a batch and geometry can therefore be reduced before their repeated
+output-row addition. The prediction was that one even/odd group reduction per
+source run would replace per-contribution output additions while preserving the
+AIR, transcript, proof bytes, contribution values, bounded ownership, and
+parallel work distribution.
+
+## Changes
+
+Planning now creates a checked, immutable descriptor plan for every structurally
+non-direct lifted contribution. Each group owns a slice of members; a member is
+only a borrowed compact source column and its four M31 coefficients. The plan
+is capped at 1 MiB, uses checked arithmetic, and is optional: allocation or
+budget failure leaves every contribution on the unchanged direct/run-wise path.
+No workload name, statement digest, input digest, benchmark size, or RISC-V-
+specific key participates in admission.
+
+Within each bounded quotient worker, all members in one group reduce into two
+four-coordinate register accumulators for the current even/odd source pair.
+The executor builds packed alternating values and adds the group once across
+the lifted run. Multiplications remain parallel; output additions scale with
+groups rather than contributions. Direct columns retain their packed path.
+Scalar fallback, serial and parallel tile execution, retained-byte telemetry,
+partial initialization cleanup, and direct fallback are all wired explicitly.
+
+The compact reducer and direct planner were split into focused modules so the
+tile scheduler remains below the repository's 850-line ceiling. Differential
+tests cover shifts 2, 3, and 8 plus misaligned boundaries. A planning test
+covers repeated geometry, multiple batches, direct exclusion, checked retained
+bytes, and budget fallback.
+
+## Rejected architecture
+
+The first implementation materialized coefficient-weighted compact arrays for
+27 high-shift groups. It used only 10.7 MiB and cut process instructions to
+0.749x, but a process sample found 116 main-thread samples in serial plan
+construction. It had moved products out of parallel workers and onto the
+critical path; verified proving time did not improve. Full 35-group
+materialization was also rejected at 153.3 MiB. Both dead ends and their
+measurements are retained in the transcript.
+
+## Results
+
+The clean claimed proving-time portfolio ratio is **0.958426**, bootstrap 95%
+CI **[0.954944, 0.962133]**. That is a 4.16% proving-latency reduction, above
+the class's 1.2888% significance floor. Verified-request ratio geomean is
+**0.964371**.
+
+| workload | prove ratio | 95% CI | rounds | main | candidate | request ratio |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| xorshift PRNG | 0.961191 | [0.954873, 0.966907] | 5 | 1468.060 ms | 1408.839 ms | 0.962210 |
+| iterative Fibonacci | 0.960254 | [0.958887, 0.964196] | 3 | 1636.723 ms | 1569.976 ms | 0.962307 |
+| Euclidean GCD | 0.959542 | [0.953218, 0.962870] | 5 | 1560.442 ms | 1494.326 ms | 0.961622 |
+| multi-shard ADDI | 0.968090 | [0.959831, 0.976283] | 5 | 1620.772 ms | 1570.431 ms | 0.974301 |
+| SHA2-512 | 0.945873 | [0.933950, 0.966858] | 5 | 1843.937 ms | 1756.293 ms | 0.962728 |
+| SHA2-1024 | 0.954801 | [0.939027, 0.963837] | 5 | 2149.973 ms | 2051.770 ms | 0.964895 |
+| SHA2-2048 | 0.959373 | [0.952284, 0.964520] | 5 | 2379.370 ms | 2292.504 ms | 0.962600 |
+
+Every workload wins; no portfolio average hides a regression. Energy ratio is
+0.834744 (upper CI 0.839936), peak RSS is 0.999729 (upper CI 1.000914), and
+proof-size ratio is exactly 1.0. Candidate/epoch-anchor ratio is 0.6626.
+
+## Correctness and validation
+
+Every timed proof verified, cross-arm canonical proof digests are byte-identical
+per round, mechanism telemetry is stable for 7/7 workloads, and the pinned
+Stark-V oracle accepted 7/7. Statement and transcript digests match the current
+main arm. The ReleaseFast aggregate test root, focused compact reducer/planner
+tests, source conformance, RISC-V CPU product closure, Native CPU product
+markers, Native Metal closure, and device-only Metal prove plus independent
+verification all pass. The change introduces no Metal dispatch, CPU fallback,
+resident object, synchronization point, shader, or ABI change.
+
+## Caveats
+
+This is a claimed same-host result; only the judge's rerun counts. Local
+automatic guard expansion is absent because of the documented cross-board
+classifier defect, so promotion remains conditional on remote aggregate CPU,
+Metal, and RISC-V guards. This submission improves the shared CPU prover and
+RISC-V portfolio, but it does not complete the exact PR6 workload, log22,
+cold-process, and authenticated judged-evidence contract.
+
+**PR6 Supremacy: not achieved.**

--- a/autoresearch/submissions/2026-07-22-riscv-register-grouped-quotients/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-22-riscv-register-grouped-quotients/transcripts/session-01.md
@@ -1,0 +1,241 @@
+# Autoresearch session 01 — post-run-strength-reduction RISC-V epoch
+
+## Objective and inherited frontier
+
+This iteration begins immediately after PR #81 merged and its claimed promotion
+was recorded on canonical main `e20d72ac90af`. The standing loop is improvement
+-> PR -> green CI -> merge -> repeat, prioritizing the largest and longest
+coordinates and especially RISC-V. The promoted run-wise lifted quotient
+accumulator reduced the `riscv/deep` proving-time portfolio to ratio 0.724575
+with 95% CI [0.723189, 0.726258], preserved proof bytes and RSS, cut measured
+energy to 0.537x, passed the pinned oracle for 7/7 rows, and cleared aggregate
+CPU, Metal, and RISC-V CI before merge.
+
+The current frontier still makes RISC-V deep the largest active portfolio
+coordinate: candidate proving geomean is 1780.298 ms, versus sub-second Native
+huge and approximately 157 ms for the best recorded Metal huge result. The next
+iteration therefore remains on the shared CPU prover/RISC-V path unless fresh
+profiles contradict that choice.
+
+## Skills and method
+
+All repository performance skills were reread from current main before action:
+algorithm matching, Zig profiling, Metal profiling, Metal performance design,
+and submission transcripts. The compute-only Metal common-patterns reference
+was also read completely; render guidance is inapplicable. Their combined
+contract is: profile the new frontier before editing; produce and retain a
+problem-match brief before a material algorithm change; use counters and codegen
+for CPU claims; use trace/dispatch evidence for Metal claims; preserve exact
+proof/transcript behavior and broad product architecture; and record rejected
+ideas and failures contemporaneously.
+
+No epoch-two source has been edited. The first action is to build the clean
+post-merge product, rerun the largest release-gated row, and sample its new hot
+frames. The previous profile is not reused as current attribution because the
+dominant quotient executor just changed by roughly 29%.
+
+## Fresh baseline and profile
+
+The clean post-merge SHA2-2048 request is 2.916904 s: 2.303770 s proving,
+0.508096 s witness generation, and 0.086911 s verification. It embeds clean
+commit `e20d72ac90af`, preserves statement digest
+`6bc61b060cd26d38c7d620dc6b3f17829221d310b498e7c7c8e63a01f3e97e88`
+and transcript state
+`4ca8cf9f10ca8322420b8cec1bdcd426958ca06ad6371878c3ddbcbc2da5fac8`,
+and verifies normally.
+
+A three-second sample of that exact executable gives these useful top frames
+after excluding idle worker waits:
+
+| frame | top-of-stack samples |
+| --- | ---: |
+| quotient tile executor | 1,705 |
+| packed Merkle leaf update | 749 |
+| `memmove` | 708 |
+| four-way Blake compression | 573 |
+| RISC-V LogUp pair constraint | 406 |
+| scalar/SIMD Blake compression | 366 |
+| fused circle-transform tails | 353 |
+| quotient denominator batch inversion | 187 |
+
+Quotient execution remains the largest single ceiling, but is now much closer
+to Merkle and memory movement. Disassembly confirms the remaining hot executor
+contains both direct packed M31 multiplication and the non-direct run-wise path;
+the latter still performs one output-plane addition per contribution per row.
+
+## Compact-domain grouping hypothesis and first shape measurement
+
+The algorithm-match brief formalizes quotient accumulation as a structured
+sparse linear transform over the exact M31 plus-times semiring. Because lifting
+is linear, contributions sharing one sample batch and source geometry may be
+coefficient-combined before lifting. This preserves exact field values while
+collapsing output additions from per contribution to per unique group. The
+brief compares this with full materialization, cross-batch grouping, and a
+future Metal port, and is retained through `stwo-perf notes`.
+
+An initialization-only diagnostic counter (not a hot-loop change) then measured
+the largest live quotient plan: domain 2,097,152 rows, 13 batches, 1,290 active
+nonzero views, 2,162 contributions, but only 35 unique `(batch, geometry)`
+groups. Contribution shifts are: shift1=40, shift2=16, shift3=18, shift5=291,
+shift6=637, shift8=320, shift9=144, shift13=65, shift14=102, shift15=55,
+shift16=91, and shift17=383. Thus the algebraic contraction is real and large.
+
+Naively retaining four compact coordinate arrays for all 35 groups would cost
+153,270,784 bytes, however, exceeding the brief's 32 MiB bound and likely the
+portfolio RSS budget. That all-group materialization is rejected. The direct
+and near-direct geometries dominate bytes, while the many high-shift groups
+have tiny compact sources. The next diagnostic breaks unique-group bytes down
+by shift so a structural, memory-bounded crossover can be selected.
+
+## Selective crossover and implementation decision
+
+The second diagnostic resolved the unique-group storage by lifting shift as
+`shift: groups / bytes`: 1:2/67,108,864; 2:3/50,331,648;
+3:3/25,165,824; 5:3/6,291,456; 6:3/3,145,728;
+8:3/786,432; 9:3/393,216; 13:3/24,576; 14:3/12,288;
+15:3/6,144; 16:3/3,072; and 17:3/1,536. Selecting shifts at least
+five therefore needs only 10,664,448 bytes, groups 2,088 of 2,162 live
+contributions into 27 combined views, and leaves the 74 contributions in the
+large shift-1..3 geometries on the promoted direct/run-wise executor.
+
+This falsifies full grouping but strongly supports a hybrid. The implementation
+will add a checked 32 MiB plan budget and a structural minimum shift of five.
+The selective plan is attempted before building direct views; only after it is
+fully admitted may those same high-shift columns be removed from the direct
+plan. Budget exhaustion or allocation failure frees partial state and selects
+the unchanged all-direct path, preventing double counting or missing work.
+There is no workload name, statement digest, benchmark size, or RISC-V-specific
+condition. At the hot loop, compact coordinate planes already contain the
+coefficient-weighted field sums, so the tile executor lifts and adds each group
+without multiplying again. Direct and scalar fallbacks remain supported.
+
+The CLI refresh was also re-run before editing. Canonical main contained three
+valuable untracked research notes, so they were temporarily stored as one
+explicit Git stash, `stwo-perf update` confirmed main `e20d72ac90af` current,
+and the stash was restored immediately without conflict. All five repository
+skills and the compute-only Metal common-patterns reference were reread. Metal
+guidance constrains this shared-prover change even though no shader changes:
+proof identity and backend admission remain exact, no new dispatch, wait,
+resident object, or lifetime system is introduced, and the complete Native
+Metal portfolio remains a required regression guard.
+
+## First implementation falsified: serial compact materialization
+
+The first implementation reused the compatibility planner to materialize the
+selected 27 compact coordinate groups, taught the bounded tile executor to lift
+those arrays without coefficient multiplication, retained the 74 low-shift
+direct contributions, added scalar/parallel plumbing and byte telemetry, and
+passed the complete ReleaseFast test root. A full verified SHA2-2048 proof kept
+the statement and transcript digests exact. Process counters moved strongly:
+instructions were 0.749x and cycles 0.840x the clean-main process. Nevertheless,
+the one-process proving time was 2.322 s versus the fresh 2.304 s baseline, and
+request time was 2.965 s versus 2.917 s. The wall-time prediction therefore
+failed despite less aggregate CPU work.
+
+A three-second whole-process sample explained the contradiction. The main
+thread accumulated 116 samples inside
+`buildCombinedContributionPlanWithOptions` before quotient workers started.
+The compatibility builder performs all compact coefficient products serially;
+the promoted run-wise executor had distributed essentially the same products
+across the proof worker pool. The implementation had shortened total work but
+lengthened the critical path. This is retained as a rejected architecture, not
+hidden as noise.
+
+The revised transfer keeps the exact sparse-linear grouping but changes its
+placement. Planning will retain only small immutable descriptors: groups keyed
+by `(batch, source geometry)` and members holding a borrowed compact column plus
+its four M31 coefficients. Inside each quotient worker and source run, the
+members reduce into two four-coordinate register accumulators (even/odd), then
+one packed alternating group value is added across the run. This keeps compact
+multiplications parallel, collapses output additions from contribution count to
+group count, removes the 10.7 MiB materialization, and preserves bounded worker
+ownership. Descriptor admission remains checked and structural; allocation or
+budget failure keeps every contribution in the existing direct path.
+
+The first register-group screen validated the revision. SHA2-2048 proving fell
+from the clean 2.303770 s baseline to 2.215191 s (ratio 0.96155), and verified
+request time fell from 2.916904 s to 2.855866 s (ratio 0.97907). Statement and
+transcript digests remained exact; process instruction and cycle ratios were
+0.74191 and 0.87246. Because the descriptor plan is now tens of kilobytes rather
+than compact-column megabytes, shift five is no longer a memory crossover. The
+next screen groups every structurally non-direct view (shift at least two),
+covering the remaining shift-2 and shift-3 contributions while preserving the
+packed direct path for shift one.
+
+## Frozen architecture and portfolio screen
+
+The all-lifted policy improved the first SHA2-2048 screen to a 0.94821 proving
+ratio and 0.96057 request ratio. A three-sample repeat after the source was
+split into conformance-sized modules stabilized at proving ratio 0.95388 and
+request ratio 0.97234, with per-proof instruction, cycle, and energy ratios
+0.73346, 0.85705, and 0.81794. All three proofs were identical. Candidate-only
+screens against the preceding promoted samples won on every deep workload:
+
+| workload | diagnostic prove ratio | diagnostic request ratio |
+| --- | ---: | ---: |
+| xorshift | 0.95455 | 0.96048 |
+| iterative Fibonacci | 0.94233 | 0.94420 |
+| GCD | 0.91928 | 0.92278 |
+| multi-shard ADDI | 0.93502 | 0.93589 |
+| SHA2-512 | 0.93083 | 0.90585 |
+| SHA2-1024 | 0.91045 | 0.91040 |
+| SHA2-2048 | 0.90432 | 0.90351 |
+
+Source conformance then rejected the 989-line tile executor against its
+850-line ceiling. Rather than suppressing the gate, the register reduction and
+its differential test moved to `quotient_compact_groups.zig`, and direct-plan
+construction moved to `quotient_direct_plan.zig`. The scheduler fell to 796
+lines and conformance passed. The split preserved the same mechanism and made
+the compact kernel independently testable at shifts 2, 3, and 8. A planning
+test covers multi-member grouping, exclusion of a direct geometry, checked
+retained bytes, and budget-triggered direct fallback. The aggregate ReleaseFast
+test root, RISC-V CPU product closure, source conformance, Native CPU product
+markers, Native Metal closure, and the device-only Metal prove/independent-
+verify lifecycle all pass.
+
+## Clean S3 verdict and provenance correction
+
+The frozen source commit is `19ca3b8863ee903daf0e52a8df08406fb804f8c2`.
+The first official S3 objective series was significant at R=0.961478, but raw
+reports exposed `implementation_dirty=true` in both arms because valuable
+untracked autoresearch notes participate in build identity. That evidence is
+retained under `dirty-provenance-register-groups` but rejected as promotion
+evidence. Both note sets were stored in explicit path-scoped Git stashes, both
+worktrees were verified empty, and the series was repeated. The first restart
+stopped before timing because the harness correctly refused to overwrite old
+proof artifacts; the complete prior raw directory was archived, not deleted.
+The subsequent clean series rebuilt both binaries and every raw A/B report
+records `implementation_dirty=false`. All notes were restored afterward.
+
+The clean claimed S3 `riscv/deep` result is R **0.958426**, bootstrap 95% CI
+**[0.954944, 0.962133]**, versus threshold 0.987112. Verified-request ratio
+geomean is **0.964371**. Every row wins independently:
+
+| workload | prove ratio | 95% CI | rounds | main prove | candidate prove | request ratio |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| xorshift | 0.961191 | [0.954873, 0.966907] | 5 | 1468.060 ms | 1408.839 ms | 0.962210 |
+| iterative Fibonacci | 0.960254 | [0.958887, 0.964196] | 3 | 1636.723 ms | 1569.976 ms | 0.962307 |
+| GCD | 0.959542 | [0.953218, 0.962870] | 5 | 1560.442 ms | 1494.326 ms | 0.961622 |
+| multi-shard ADDI | 0.968090 | [0.959831, 0.976283] | 5 | 1620.772 ms | 1570.431 ms | 0.974301 |
+| SHA2-512 | 0.945873 | [0.933950, 0.966858] | 5 | 1843.937 ms | 1756.293 ms | 0.962728 |
+| SHA2-1024 | 0.954801 | [0.939027, 0.963837] | 5 | 2149.973 ms | 2051.770 ms | 0.964895 |
+| SHA2-2048 | 0.959373 | [0.952284, 0.964520] | 5 | 2379.370 ms | 2292.504 ms | 0.962600 |
+
+The energy ratio geomean is **0.834744** (upper CI 0.839936), peak RSS is
+**0.999729** (upper CI 1.000914), and proof bytes are exactly 1.0x. Every timed
+sample verified, cross-arm proof digests are byte-identical per round, mechanism
+telemetry is present for 7/7 workloads, and the pinned Stark-V oracle accepted
+7/7. Candidate/epoch anchor is 0.6626. No average hides a losing workload.
+
+Local automatic guard expansion remains affected by the already documented CLI
+classifier defect: Native guard IDs are parsed as RISC-V and rejected for not
+containing the RISC-V-only admission token. The clean objective verdict therefore
+uses `--guards none`; shared product gates were executed separately, and the PR
+must remain conditional on the authoritative remote aggregate CPU, Metal, and
+RISC-V guard matrix. This optimization changes only bounded CPU quotient input;
+the raw Metal backend, dispatch graph, residency, waits, and ABI are unchanged.
+
+This is another material RISC-V improvement, but it does not supply the exact
+PR6 all-cell, cold-process, log22, and authenticated judged evidence contract.
+
+**PR6 Supremacy: not achieved.**

--- a/autoresearch/submissions/2026-07-22-riscv-register-grouped-quotients/verdict.json
+++ b/autoresearch/submissions/2026-07-22-riscv-register-grouped-quotients/verdict.json
@@ -1,0 +1,990 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "69eda368bf49",
+  "repo_commit": "19ca3b8863ee",
+  "predecessor_commit": "e20d72ac90af",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "riscv",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 4.89
+    }
+  },
+  "search_health": {
+    "schema_version": 1,
+    "decision": {
+      "schema_version": 1,
+      "board": "riscv",
+      "workload_class": "deep",
+      "trailing_window": 8,
+      "trailing_evidence_count": 1,
+      "trailing_median_gradient_snr": 137.86353599909668,
+      "gradient_snr_threshold": 2.0,
+      "configured_rounds": 5,
+      "auto_boost_rounds": 5,
+      "maximum_rounds": 25,
+      "target_rounds": 5,
+      "workload_count": 7,
+      "class_wall_deadline_seconds": 600.0,
+      "estimated_seconds_per_round": 9.78874591847821,
+      "deadline_round_limit": 8,
+      "auto_boost_applied": false,
+      "auto_boost_reason": "trailing_median_at_or_above_threshold",
+      "recorded_before_measurement": true
+    },
+    "decision_sha256": "sha256:850d7a3db67e07c6fdf86acdafbe80dc949474bfe334dc95b6cc0f703839cb88",
+    "actual_rounds": 33,
+    "actual_rounds_per_workload": {
+      "riscv_fib_iter": 3,
+      "riscv_gcd_euclid": 5,
+      "riscv_multi_shard_addi": 5,
+      "riscv_sha2_1024b": 5,
+      "riscv_sha2_2048b": 5,
+      "riscv_sha2_512b": 5,
+      "riscv_xorshift_prng": 5
+    },
+    "objective_wall_seconds": 278.20017366704997,
+    "measurement_wall_seconds": 279.42371916701086,
+    "measurement_wall_hours": 0.07761769976861413,
+    "gradient_snr": null,
+    "credited_ln_improvement": null,
+    "credited_ln_improvement_per_measurement_hour": null,
+    "credit_status": "pending_ledger_adjudication",
+    "decision_record": "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/search-health-decision.json"
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned correctness oracle verified 7/7 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "RISC-V mechanism telemetry present, canonical, and semantically stable for 7/7 workloads"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.6626 vs targeted budget x1.02; matrix row upper CIs 7/7 within budget x1.05; request ratios 7/7 present rows within budget x1.05; resource vectors 7/7 within named budgets"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "riscv_xorshift_prng": {
+        "r": 0.961191,
+        "ci": [
+          0.954873,
+          0.966907
+        ],
+        "rounds": 5,
+        "a_median_ms": 1468.060292,
+        "b_median_ms": 1408.838959,
+        "request_ratio": 0.96221,
+        "rss_ratio": 1.000235,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.816331,
+            "ci": [
+              0.81318,
+              0.820655
+            ],
+            "observations": 5,
+            "candidate": 52.466403852
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000235,
+            "ci": [
+              0.999753,
+              1.000797
+            ],
+            "observations": 5,
+            "candidate": 1265.095832824707
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 61123.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 61123,
+        "measurement_seconds": 31.204475,
+        "resources_complete": true
+      },
+      "riscv_fib_iter": {
+        "r": 0.960254,
+        "ci": [
+          0.958887,
+          0.964196
+        ],
+        "rounds": 3,
+        "a_median_ms": 1636.7225,
+        "b_median_ms": 1569.976208,
+        "request_ratio": 0.962307,
+        "rss_ratio": 1.000826,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.84917,
+            "ci": [
+              0.846928,
+              0.850818
+            ],
+            "observations": 3,
+            "candidate": 57.164397781
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000826,
+            "ci": [
+              1.000194,
+              1.002069
+            ],
+            "observations": 3,
+            "candidate": 1292.7362976074219
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 60003.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 60003,
+        "measurement_seconds": 20.573081,
+        "resources_complete": true
+      },
+      "riscv_gcd_euclid": {
+        "r": 0.959542,
+        "ci": [
+          0.953218,
+          0.96287
+        ],
+        "rounds": 5,
+        "a_median_ms": 1560.441541,
+        "b_median_ms": 1494.325542,
+        "request_ratio": 0.961622,
+        "rss_ratio": 1.000269,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.834968,
+            "ci": [
+              0.832364,
+              0.840549
+            ],
+            "observations": 5,
+            "candidate": 53.926218429
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000269,
+            "ci": [
+              0.99931,
+              1.000556
+            ],
+            "observations": 5,
+            "candidate": 1279.064468383789
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 62582.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 62582,
+        "measurement_seconds": 32.930972,
+        "resources_complete": true
+      },
+      "riscv_multi_shard_addi": {
+        "r": 0.96809,
+        "ci": [
+          0.959831,
+          0.976283
+        ],
+        "rounds": 5,
+        "a_median_ms": 1620.772333,
+        "b_median_ms": 1570.431125,
+        "request_ratio": 0.974301,
+        "rss_ratio": 0.999818,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.863913,
+            "ci": [
+              0.856957,
+              0.874086
+            ],
+            "observations": 5,
+            "candidate": 54.087753153
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999818,
+            "ci": [
+              0.999485,
+              1.000085
+            ],
+            "observations": 5,
+            "candidate": 1289.5488891601562
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 58117.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 58117,
+        "measurement_seconds": 34.175679,
+        "resources_complete": true
+      },
+      "riscv_sha2_512b": {
+        "r": 0.945873,
+        "ci": [
+          0.93395,
+          0.966858
+        ],
+        "rounds": 5,
+        "a_median_ms": 1843.937167,
+        "b_median_ms": 1756.293375,
+        "request_ratio": 0.962728,
+        "rss_ratio": 0.999637,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.816328,
+            "ci": [
+              0.810131,
+              0.824485
+            ],
+            "observations": 5,
+            "candidate": 69.461900399
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999637,
+            "ci": [
+              0.999046,
+              1.001008
+            ],
+            "observations": 5,
+            "candidate": 1374.986686706543
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 78496.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 78496,
+        "measurement_seconds": 46.747334,
+        "resources_complete": true
+      },
+      "riscv_sha2_1024b": {
+        "r": 0.954801,
+        "ci": [
+          0.939027,
+          0.963837
+        ],
+        "rounds": 5,
+        "a_median_ms": 2149.973333,
+        "b_median_ms": 2051.770042,
+        "request_ratio": 0.964895,
+        "rss_ratio": 1.000301,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.82985,
+            "ci": [
+              0.827355,
+              0.832832
+            ],
+            "observations": 5,
+            "candidate": 78.00488909
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000301,
+            "ci": [
+              0.999798,
+              1.002394
+            ],
+            "observations": 5,
+            "candidate": 1428.9242095947266
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 76677.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 76677,
+        "measurement_seconds": 52.473945,
+        "resources_complete": true
+      },
+      "riscv_sha2_2048b": {
+        "r": 0.959373,
+        "ci": [
+          0.952284,
+          0.96452
+        ],
+        "rounds": 5,
+        "a_median_ms": 2379.369834,
+        "b_median_ms": 2292.50425,
+        "request_ratio": 0.9626,
+        "rss_ratio": 0.997022,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.833697,
+            "ci": [
+              0.831345,
+              0.837277
+            ],
+            "observations": 5,
+            "candidate": 86.125247664
+          },
+          "peak_rss_mib": {
+            "ratio": 0.997022,
+            "ci": [
+              0.978492,
+              0.999493
+            ],
+            "observations": 5,
+            "candidate": 1496.0649948120117
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 81115.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 81115,
+        "measurement_seconds": 59.942965,
+        "resources_complete": true
+      }
+    },
+    "R_geomean": 0.958426,
+    "portfolio": {
+      "ci_method": "independent_workload_round_bootstrap_percentile_v1",
+      "ci_level": 0.95,
+      "bootstrap_iterations": 4000,
+      "seed": 4042241451,
+      "ci": [
+        0.954944,
+        0.962133
+      ],
+      "prove_ms_method": "geometric_mean_candidate_workload_medians_ms_v1",
+      "b_median_ms_geomean": 1710.721072,
+      "proof_bytes_method": "rounded_geometric_mean_candidate_proof_bytes_v1",
+      "proof_bytes": 67692,
+      "measurement_seconds": 278.048451,
+      "measurement_rounds": 33
+    },
+    "theta": 0.012888,
+    "aa_dispersion": 0.006444,
+    "significant": true,
+    "neutral": false,
+    "promotion_significance": {
+      "eligible": true,
+      "method": "independent_workload_round_bootstrap_percentile_v1",
+      "reason": "prove-time objective uses the deterministic workload portfolio CI"
+    },
+    "resource_portfolio": {
+      "peak_rss_mib": {
+        "ratio_geomean": 0.9997289210071576,
+        "upper_ci_geomean": 1.0009141953748806,
+        "candidate_geomean": 1344.188736445225
+      },
+      "energy_j": {
+        "ratio_geomean": 0.8347440531662762,
+        "upper_ci_geomean": 0.8399359510938903,
+        "candidate_geomean": 63.322467456535925
+      },
+      "proof_bytes": {
+        "ratio_geomean": 1.0,
+        "upper_ci_geomean": 1.0,
+        "candidate_geomean": 67691.6135391908
+      }
+    }
+  },
+  "tiebreakers": {
+    "rss_ratio": 0.999729,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": 63.322467456535925,
+    "proof_bytes": 67691.6135391908
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "riscv_xorshift_prng",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "047374afe80180634df27b69990f4b3681fd9c28b113c6902c4422a115a2e6ef",
+      "proof_sha256": "c32a74186749f640a1b5b2a558768e9f6e60bcd58bc30595411e1722d5ead0e9"
+    },
+    {
+      "workload": "riscv_fib_iter",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "bcfe481669cff81eab57f283cc7b813a0d70d97b863fb56cc206757103e5d261",
+      "proof_sha256": "100f0251e29fa5bbd58dfca387f52b776c0fa387ca0c2250a2f5534235bedc02"
+    },
+    {
+      "workload": "riscv_gcd_euclid",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "6790c47f946667933be05725c6a7bb1945fc8a3a5401e7a0c789e6d752abe95a",
+      "proof_sha256": "7cfa5df8529186cc005ad38e86f5aae1fc0cb150a2d4c899a42bebac5f46778b"
+    },
+    {
+      "workload": "riscv_multi_shard_addi",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "9a6436a80f56773ed752254b184c0a386ea1e714316beb7cf218a8ac60acacdb",
+      "proof_sha256": "4bf8ab22c5ebb506421203abfb2905b06d3f9cc39cd42fcd3899f288f98775a4"
+    },
+    {
+      "workload": "riscv_sha2_512b",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "01e338f47af1812caa1b889a64123ee3d60912211e2d6f5f33f5cc9baf1195cb",
+      "proof_sha256": "a5c7b4e54d0ba913b0ae1f58c77ea823826e0ba776a4a2673be2ab6dc3bcb74a"
+    },
+    {
+      "workload": "riscv_sha2_1024b",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "578d9c6ec0789ac3a2eebab4ac15f8f42dbc4d7e43f81128d326c77178e9086b",
+      "proof_sha256": "63bbad02c8806622b99eba191ca9d1333ba77abd2f1486e2838525542d36cc50"
+    },
+    {
+      "workload": "riscv_sha2_2048b",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "e91578fc77eb89b9eef39903babb03b94336fe30b2c8397447646ef9dc6c5c31",
+      "proof_sha256": "adaa94716e7010c04814b2b574b3b7cb788f76f31f8258ad2a737bae68f1b851"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "pr6_supremacy",
+      "reason": "PR6 Supremacy remains disabled until every exact workload port, log22 oracle vector, both timing boundaries, locked-M5 statistical gate, and authenticated judged verdict are complete."
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "riscv_xorshift_prng": {
+        "round_ratios": [
+          0.966007,
+          0.954574,
+          0.967808,
+          0.955173,
+          0.961977
+        ],
+        "proof_digest": "c32a74186749f640a1b5b2a558768e9f6e60bcd58bc30595411e1722d5ead0e9",
+        "request_ratio": 0.96221,
+        "rss_ratio": 1.000235,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.816331,
+            "ci": [
+              0.81318,
+              0.820655
+            ],
+            "observations": 5,
+            "candidate": 52.466403852
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000235,
+            "ci": [
+              0.999753,
+              1.000797
+            ],
+            "observations": 5,
+            "candidate": 1265.095832824707
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 61123.0
+          }
+        },
+        "report_sha256s": [
+          "e56c2fd635dc90ae1542dba33bb6ecf4be8728fd886d734c303006dbc0afa0d2",
+          "1ccef1f7c22e11a3bbba5682cdb1f24d61e4afe31c8b503397da926f9b2f26ce",
+          "0ec4fcff57ca13179ea48c05725df0d5d54f225e9a786c2f7fe478851e230a84",
+          "db35e28c203c24cf37b987d67500cb1eb18fd7b3d2e5dc1b9fc1a3b7630f1ea6",
+          "1aac71c1d9b1db67a4233e865bfc026b5e460572de47e9af78f5176db286bd38",
+          "d4336b18d037bd63a14c61e2f79f78e9639383a52a615cefdb775e0ecc72ee4d",
+          "95b4fcf4e804267a40b2d7c7e6545837c6341b69e09adb8ab6d7013779c241eb",
+          "6a70cbe22a6daa01709a6869037445f99563c6127fa1bd2f42374800d717d306",
+          "281906e0daafb5d95a7e708d87cbc64abc86d29956efc71c1afc4f3fa7807116",
+          "2eceda2e980244848e36f00c8d5ce940422868aea20f0a8887e417bf5d72864e"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_fib_iter": {
+        "round_ratios": [
+          0.958967,
+          0.958887,
+          0.964196
+        ],
+        "proof_digest": "100f0251e29fa5bbd58dfca387f52b776c0fa387ca0c2250a2f5534235bedc02",
+        "request_ratio": 0.962307,
+        "rss_ratio": 1.000826,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.84917,
+            "ci": [
+              0.846928,
+              0.850818
+            ],
+            "observations": 3,
+            "candidate": 57.164397781
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000826,
+            "ci": [
+              1.000194,
+              1.002069
+            ],
+            "observations": 3,
+            "candidate": 1292.7362976074219
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 60003.0
+          }
+        },
+        "report_sha256s": [
+          "4b10d6dedffb458898b0acc7f975c6be28d20a29c99bf7beb55cd67b8c7bcc2e",
+          "aaa05462f371fa4667be36d4319544840a513b08154bd6fc7eb71b6aed76ef3d",
+          "e8d5bda0cfc86f186020e2ef54683664977d66d8905c76c2d50b29dd905195ef",
+          "476a622100351ef40429f3bfb5ba57987c5a3f37347847c0bbe328a52b619411",
+          "6449402083427c7e337341dfe3a51e7cf711055b7b0f205d2121ade04077c95c",
+          "e55534fb14b131fcf1eefa736be2160312c01a7e097914a00d9e862ca67726de"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_gcd_euclid": {
+        "round_ratios": [
+          0.960603,
+          0.947955,
+          0.965136,
+          0.96002,
+          0.958481
+        ],
+        "proof_digest": "7cfa5df8529186cc005ad38e86f5aae1fc0cb150a2d4c899a42bebac5f46778b",
+        "request_ratio": 0.961622,
+        "rss_ratio": 1.000269,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.834968,
+            "ci": [
+              0.832364,
+              0.840549
+            ],
+            "observations": 5,
+            "candidate": 53.926218429
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000269,
+            "ci": [
+              0.99931,
+              1.000556
+            ],
+            "observations": 5,
+            "candidate": 1279.064468383789
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 62582.0
+          }
+        },
+        "report_sha256s": [
+          "f218bbf600f57242bdbf7aea58860f712432874393f5a3a80d4a6d59c1b3ce7b",
+          "9f1c137994445cba2598e6997d0f50e9fe83a1248f3531bf87e9677857b7d35f",
+          "a4f44bfa6f7accab8ed346c3c797520ffa927320d533f8d722d9027de4883834",
+          "aeea57185f5adfaff27b9128e3948cd12a22fd3d41f73e5381f51e9081e19fbf",
+          "f5ae5fe5f7341c00cd6783e8f289f148cf15326fcc1553bd578aaa31e9fe6367",
+          "eb24bf3b8f5f3ba88c457eb027df1911921ef4bfdbfc66b361154a614039aabe",
+          "d3eff375372a951e58bca70b2e3ccb8cc4f1eb651341a9e247ea70b9118cb86a",
+          "f01bf13ece4a4009eaed9e4c39c67b7df60444056579b39e8a9ced12f0393064",
+          "f7bb554f5849328f85d976221aecada0a70710cdad699a53f3597dbc987c1b14",
+          "ec3ed1a3742f133b1ba0984d8cca8ada603ce099e9e1eeb0c5a501c72a896f93"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_multi_shard_addi": {
+        "round_ratios": [
+          0.973627,
+          0.95909,
+          0.975607,
+          0.97696,
+          0.960573
+        ],
+        "proof_digest": "4bf8ab22c5ebb506421203abfb2905b06d3f9cc39cd42fcd3899f288f98775a4",
+        "request_ratio": 0.974301,
+        "rss_ratio": 0.999818,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.863913,
+            "ci": [
+              0.856957,
+              0.874086
+            ],
+            "observations": 5,
+            "candidate": 54.087753153
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999818,
+            "ci": [
+              0.999485,
+              1.000085
+            ],
+            "observations": 5,
+            "candidate": 1289.5488891601562
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 58117.0
+          }
+        },
+        "report_sha256s": [
+          "60a6deedc050b51be4f1f80454c45488d185143a05966d2087687e2475609746",
+          "0b602c46389da6c678dbc8591aa1142fe8f9c975a758b49b58fc5b9d3f16567b",
+          "08de621ca4a48909f2462a97ca8c2370f7fe144c1db79271053ade7e2727260c",
+          "7c37612be8c346ad10eb7b33058ff0f0647d939c79ccf0339a87af0008ee83d2",
+          "a41060035104b20e0cfa2da0a7917eeead71db60f7effb22b02e73626abc87da",
+          "61c44cee4311d17c53060e4a8ef417239e6cc36b844a3901b3c7f405b78052f8",
+          "ec940dfcdeda577abcc179b5e90730476ab6c8364e621fb81c73726c7e5d29b4",
+          "d5cb0d417326f4c5f2b2db32a70a8489e498da94b122cc9686c3b5ed277df29c",
+          "cfe5ebdacc9a6ef1b47eb32f3e02015273a4bc08b6e1c114d5ef8b5201ccbde1",
+          "e9e9e0325d472345f615372032feae59dc9d418e3c928b1de5a11f3ed4b4c560"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_sha2_512b": {
+        "round_ratios": [
+          0.932803,
+          0.95665,
+          0.94464,
+          0.935097,
+          0.977067
+        ],
+        "proof_digest": "a5c7b4e54d0ba913b0ae1f58c77ea823826e0ba776a4a2673be2ab6dc3bcb74a",
+        "request_ratio": 0.962728,
+        "rss_ratio": 0.999637,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.816328,
+            "ci": [
+              0.810131,
+              0.824485
+            ],
+            "observations": 5,
+            "candidate": 69.461900399
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999637,
+            "ci": [
+              0.999046,
+              1.001008
+            ],
+            "observations": 5,
+            "candidate": 1374.986686706543
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 78496.0
+          }
+        },
+        "report_sha256s": [
+          "c7dfe273c4e33ad35293deb1114037e1889630052848f988c1344e4d71ff2536",
+          "a4864f84daa6614917b8f0aa9728d34dc6c228ac1a54c7a79e291b9e9ba4b668",
+          "acd7ae97337265e6830d9c927c010fd165b1fe01f33804be8b74f442dd4cb2d4",
+          "b7fdee6b5cf4d805ab6d8427565f7adc84a162a307a8acacf6f0f559b74af992",
+          "d4a8c0728af519cf480c2797721ccc1dfb24dc304844743af659d7f5f80391e2",
+          "08c1f43b141d99bd37e56a063510cd62601582aebfe024e096aeaf45ccb0cbc0",
+          "ee5ebfe7f89a34ee67b697e59c9f795452748b149a328b43a985b1a876551bdb",
+          "17e3c414770f74dfabb70c8d6912ce3ee66045f80bc65c07a1bddd90009262fd",
+          "cc2b69dc020229acf289a12e30afc326f7daff9c67cef1d8c85b64cb2f9de1a9",
+          "bbde821ca24dfc34579da8961bacea2b6826f05ba962cf5e8ad4fbf19e008c73"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_sha2_1024b": {
+        "round_ratios": [
+          0.924451,
+          0.958411,
+          0.954801,
+          0.953603,
+          0.969263
+        ],
+        "proof_digest": "63bbad02c8806622b99eba191ca9d1333ba77abd2f1486e2838525542d36cc50",
+        "request_ratio": 0.964895,
+        "rss_ratio": 1.000301,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.82985,
+            "ci": [
+              0.827355,
+              0.832832
+            ],
+            "observations": 5,
+            "candidate": 78.00488909
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000301,
+            "ci": [
+              0.999798,
+              1.002394
+            ],
+            "observations": 5,
+            "candidate": 1428.9242095947266
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 76677.0
+          }
+        },
+        "report_sha256s": [
+          "271f090673c94fff0637099dc87d829cbcf480764aa5d61ebde71480ff30eeee",
+          "97598a0266396200d7fb3a30f54573df7320c7e409c30f73d7ea33267a17f75e",
+          "a60cfa3108ba2df229ed5bc5cfca1e6c03599311c614b504e01f8fa09352a858",
+          "d2014f9e85ede9b99ab440f6eb23368371051864db82feed7283d97a65748da2",
+          "2659c92bc7fd43b9e10459eed2dae3de91eade8d1eeb96a618189601b8e45664",
+          "85c651a2431223313f3fe7daef2941502056c8a275901b1b3e79ef5dad58b013",
+          "3edd686728e102a74a537708dd7b1e35c88e3a1ebeabed91e57e119696d730f2",
+          "40287ec1a9802b8baa6a06fa0f7c9b17e111156886e28d9cf9214a1cf10d8a4c",
+          "2b2210f00d5aa83479dd32ce190d5841732607ee66d3860bc6720356158e87e3",
+          "72f6efc28504e19c7b1635e83954588d9441f85632ab5a6b54c3cd5e2113fed9"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_sha2_2048b": {
+        "round_ratios": [
+          0.958211,
+          0.965445,
+          0.946356,
+          0.963596,
+          0.959373
+        ],
+        "proof_digest": "adaa94716e7010c04814b2b574b3b7cb788f76f31f8258ad2a737bae68f1b851",
+        "request_ratio": 0.9626,
+        "rss_ratio": 0.997022,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.833697,
+            "ci": [
+              0.831345,
+              0.837277
+            ],
+            "observations": 5,
+            "candidate": 86.125247664
+          },
+          "peak_rss_mib": {
+            "ratio": 0.997022,
+            "ci": [
+              0.978492,
+              0.999493
+            ],
+            "observations": 5,
+            "candidate": 1496.0649948120117
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 81115.0
+          }
+        },
+        "report_sha256s": [
+          "a40f662616b6d61c4e64ea0b02eff8cf119cfd84fe953f5221375f2a1dbddaec",
+          "dc6cb23ec481ccb8efad43db2f47a60c79237d47b62c7fc595591fb6278518d1",
+          "38f71e045c04c23e0410fbcfa07c0e54b21cd4784f9694bcf8fea646bfb27d80",
+          "c9e9502fb29bdad6311dbd0335c75f5e67b715e7f4cb4294b5389bb38c01d840",
+          "85f991b657907ac670bc310927319deb9d08380045df948c7bc5374092c32f17",
+          "6eaf9b68801c5041ff55412f5610bf99d4cab3af64c2d356188fd00136c6e816",
+          "3cbbea31d899f389fd1861924ee2f64b8702281349b1eca756207a1f18ba6c54",
+          "8a4a1ab36c255327787c9ea595f946a4b9ea6091b8df5f906ef02a176b06bc28",
+          "e1261a7f64fc3161e63f3f81bc59ac0fb6d51e26ed9ef7b20a5382091041062b",
+          "c02dd0c2f1e8659217133d39af7d2f265c6c2688be9f7a26bbea68dabd58668a"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_xorshift_prng.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_xorshift_prng.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_xorshift_prng.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_xorshift_prng.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_xorshift_prng.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_xorshift_prng.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_xorshift_prng.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_xorshift_prng.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_xorshift_prng.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_xorshift_prng.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_fib_iter.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_fib_iter.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_fib_iter.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_fib_iter.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_fib_iter.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_fib_iter.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_gcd_euclid.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_gcd_euclid.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_gcd_euclid.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_gcd_euclid.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_gcd_euclid.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_gcd_euclid.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_gcd_euclid.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_gcd_euclid.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_gcd_euclid.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_gcd_euclid.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_multi_shard_addi.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_multi_shard_addi.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_multi_shard_addi.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_multi_shard_addi.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_multi_shard_addi.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_multi_shard_addi.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_multi_shard_addi.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_multi_shard_addi.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_multi_shard_addi.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_multi_shard_addi.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_512b.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_512b.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_512b.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_512b.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_512b.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_512b.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_512b.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_512b.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_512b.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_512b.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_1024b.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_1024b.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_1024b.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_1024b.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_1024b.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_1024b.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_1024b.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_1024b.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_1024b.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_1024b.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_2048b.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_2048b.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_2048b.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_2048b.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_2048b.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_2048b.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_2048b.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_2048b.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_2048b.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch2/autoresearch/.runs/latest/riscv_sha2_2048b.b5.json"
+    ]
+  }
+}

--- a/src/prover/pcs/quotient_compact_groups.zig
+++ b/src/prover/pcs/quotient_compact_groups.zig
@@ -1,0 +1,160 @@
+//! Register-resident reduction of compact quotient contribution groups.
+
+const std = @import("std");
+const m31 = @import("stwo_core").fields.m31;
+const qm31 = @import("stwo_core").fields.qm31;
+const planning = @import("quotients/planning.zig");
+
+const M31 = m31.M31;
+const QM31 = qm31.QM31;
+
+pub const Group = planning.CompactContributionGroup;
+pub const Member = planning.CompactContributionMember;
+
+fn numerator(
+    numerators: []M31,
+    row_capacity: usize,
+    batch_count: usize,
+    batch: usize,
+    coordinate: usize,
+    row: usize,
+) *M31 {
+    std.debug.assert(batch < batch_count);
+    std.debug.assert(coordinate < qm31.SECURE_EXTENSION_DEGREE);
+    std.debug.assert(row < row_capacity);
+    const plane = batch * qm31.SECURE_EXTENSION_DEGREE + coordinate;
+    return &numerators[plane * row_capacity + row];
+}
+
+/// Reduces all members sharing one `(sample batch, source geometry)` into an
+/// even/odd compact pair, then broadcasts one exact packed group value across
+/// the lifted run. Multiplications remain distributed across quotient workers;
+/// output additions scale with groups instead of contributions.
+pub fn accumulate(
+    numerators: []M31,
+    row_capacity: usize,
+    batch_count: usize,
+    group: Group,
+    start: usize,
+    row_count: usize,
+) void {
+    std.debug.assert(group.shift_amt >= 2);
+    const end = start + row_count;
+    var position = start;
+    while (position < end) {
+        const source_block = position >> group.shift_amt;
+        const block_end = @min(end, (source_block + 1) << group.shift_amt);
+        const source_index = source_block << 1;
+
+        var sums: [qm31.SECURE_EXTENSION_DEGREE][2]M31 =
+            @splat(@splat(M31.zero()));
+        for (group.members) |member| {
+            std.debug.assert(source_index + 1 < member.values.len);
+            inline for (0..qm31.SECURE_EXTENSION_DEGREE) |coordinate| {
+                sums[coordinate][0] = sums[coordinate][0].add(
+                    member.values[source_index].mul(member.coefficients[coordinate]),
+                );
+                sums[coordinate][1] = sums[coordinate][1].add(
+                    member.values[source_index + 1].mul(member.coefficients[coordinate]),
+                );
+            }
+        }
+
+        var even_first: [qm31.SECURE_EXTENSION_DEGREE]m31.PackedM31 = undefined;
+        var odd_first: [qm31.SECURE_EXTENSION_DEGREE]m31.PackedM31 = undefined;
+        inline for (0..qm31.SECURE_EXTENSION_DEGREE) |coordinate| {
+            var even_lanes: [m31.PACK_WIDTH]u32 = undefined;
+            var odd_lanes: [m31.PACK_WIDTH]u32 = undefined;
+            inline for (0..m31.PACK_WIDTH) |lane| {
+                even_lanes[lane] = sums[coordinate][lane & 1].v;
+                odd_lanes[lane] = sums[coordinate][1 - (lane & 1)].v;
+            }
+            even_first[coordinate] = @bitCast(even_lanes);
+            odd_first[coordinate] = @bitCast(odd_lanes);
+        }
+
+        while (block_end - position >= m31.PACK_WIDTH) : (position += m31.PACK_WIDTH) {
+            const local_row = position - start;
+            inline for (0..qm31.SECURE_EXTENSION_DEGREE) |coordinate| {
+                const plane = group.batch_index * qm31.SECURE_EXTENSION_DEGREE + coordinate;
+                const values = numerators.ptr + plane * row_capacity + local_row;
+                const addend = if ((position & 1) == 0)
+                    even_first[coordinate]
+                else
+                    odd_first[coordinate];
+                m31.storePacked(values, m31.addPacked(m31.loadPacked(values), addend));
+            }
+        }
+        while (position < block_end) : (position += 1) {
+            const parity = position & 1;
+            inline for (0..qm31.SECURE_EXTENSION_DEGREE) |coordinate| {
+                const value = numerator(
+                    numerators,
+                    row_capacity,
+                    batch_count,
+                    group.batch_index,
+                    coordinate,
+                    position - start,
+                );
+                value.* = value.add(sums[coordinate][parity]);
+            }
+        }
+    }
+}
+
+pub fn scalarValueAt(group: Group, position: usize) QM31 {
+    const source_index = ((position >> group.shift_amt) << 1) + (position & 1);
+    var combined = QM31.zero();
+    for (group.members) |member| {
+        combined = combined.add(QM31.fromM31(
+            member.values[source_index].mul(member.coefficients[0]),
+            member.values[source_index].mul(member.coefficients[1]),
+            member.values[source_index].mul(member.coefficients[2]),
+            member.values[source_index].mul(member.coefficients[3]),
+        ));
+    }
+    return combined;
+}
+
+test "compact grouped lifting matches scalar member reduction" {
+    const row_capacity: usize = 37;
+    var numerators = [_]M31{M31.zero()} ** (2 * qm31.SECURE_EXTENSION_DEGREE * row_capacity);
+    var values_a: [64]M31 = undefined;
+    var values_b: [64]M31 = undefined;
+    for (&values_a, 0..) |*value, index| value.* = M31.fromCanonical(@intCast(19 + index * 97));
+    for (&values_b, 0..) |*value, index| value.* = M31.fromCanonical(@intCast(23 + index * 131));
+    const members = [_]Member{
+        .{ .values = &values_a, .coefficients = .{
+            M31.fromCanonical(3), M31.fromCanonical(5),
+            M31.fromCanonical(7), M31.fromCanonical(11),
+        } },
+        .{ .values = &values_b, .coefficients = .{
+            M31.fromCanonical(13), M31.fromCanonical(17),
+            M31.fromCanonical(19), M31.fromCanonical(23),
+        } },
+    };
+    const Case = struct { shift: u6, start: usize, len: usize };
+    for ([_]Case{
+        .{ .shift = 2, .start = 0, .len = 37 },
+        .{ .shift = 3, .start = 3, .len = 31 },
+        .{ .shift = 8, .start = 5, .len = 29 },
+    }) |case| {
+        @memset(&numerators, M31.zero());
+        accumulate(&numerators, row_capacity, 2, .{
+            .members = &members,
+            .batch_index = 1,
+            .shift_amt = case.shift,
+        }, case.start, case.len);
+        for (0..case.len) |row| {
+            const position = case.start + row;
+            const source_index = ((position >> case.shift) << 1) + (position & 1);
+            inline for (0..qm31.SECURE_EXTENSION_DEGREE) |coordinate| {
+                const expected = values_a[source_index].mul(members[0].coefficients[coordinate]).add(
+                    values_b[source_index].mul(members[1].coefficients[coordinate]),
+                );
+                const plane = qm31.SECURE_EXTENSION_DEGREE + coordinate;
+                try std.testing.expectEqual(expected.v, numerators[plane * row_capacity + row].v);
+            }
+        }
+    }
+}

--- a/src/prover/pcs/quotient_direct_plan.zig
+++ b/src/prover/pcs/quotient_direct_plan.zig
@@ -1,0 +1,72 @@
+//! Borrowed direct-column plan for bounded quotient tiles.
+
+const std = @import("std");
+const row_executor = @import("quotient_row_executor.zig");
+
+pub const Plan = struct {
+    views: []row_executor.LiftingColumnView,
+    ranges: []row_executor.ColumnContributionRange,
+
+    pub fn deinit(self: *Plan, allocator: std.mem.Allocator) void {
+        allocator.free(self.views);
+        allocator.free(self.ranges);
+        self.* = undefined;
+    }
+};
+
+pub fn build(
+    allocator: std.mem.Allocator,
+    flat_columns: anytype,
+    active_column_indices: []const usize,
+    contribution_ranges: []const row_executor.ColumnContributionRange,
+    nonzero_columns: []const bool,
+    lifting_log_size: u32,
+    exclude_shift_at_least: ?std.math.Log2Int(usize),
+) !Plan {
+    if (active_column_indices.len != contribution_ranges.len or
+        flat_columns.len != nonzero_columns.len)
+    {
+        return error.ShapeMismatch;
+    }
+
+    var included_count: usize = 0;
+    for (active_column_indices) |column_index| {
+        if (column_index >= flat_columns.len or column_index >= nonzero_columns.len) {
+            return error.ShapeMismatch;
+        }
+        if (!nonzero_columns[column_index]) continue;
+        const column = flat_columns[column_index];
+        if (column.log_size > lifting_log_size) return error.InvalidColumnLogSize;
+        const log_shift = lifting_log_size - column.log_size;
+        if (log_shift >= @bitSizeOf(usize)) return error.InvalidColumnLogSize;
+        const shift_amt: std.math.Log2Int(usize) = @intCast(log_shift + 1);
+        if (exclude_shift_at_least) |minimum| {
+            if (shift_amt >= minimum) continue;
+        }
+        included_count += 1;
+    }
+    const views = try allocator.alloc(row_executor.LiftingColumnView, included_count);
+    errdefer allocator.free(views);
+    const ranges = try allocator.alloc(row_executor.ColumnContributionRange, included_count);
+    errdefer allocator.free(ranges);
+
+    var write_index: usize = 0;
+    for (active_column_indices, contribution_ranges) |column_index, contribution_range| {
+        if (!nonzero_columns[column_index]) continue;
+        const column = flat_columns[column_index];
+        const log_shift = lifting_log_size - column.log_size;
+        const shift_amt: std.math.Log2Int(usize) = @intCast(log_shift + 1);
+        if (exclude_shift_at_least) |minimum| {
+            if (shift_amt >= minimum) continue;
+        }
+        views[write_index] = .{
+            .values = column.values,
+            .shift_amt = shift_amt,
+            .is_direct = column.log_size == lifting_log_size,
+        };
+        ranges[write_index] = contribution_range;
+        write_index += 1;
+    }
+    std.debug.assert(write_index == included_count);
+    return .{ .views = views, .ranges = ranges };
+}

--- a/src/prover/pcs/quotient_tile_executor.zig
+++ b/src/prover/pcs/quotient_tile_executor.zig
@@ -8,6 +8,8 @@ const qm31 = @import("stwo_core").fields.qm31;
 const quotients = @import("stwo_core").pcs.quotients;
 const row_executor = @import("quotient_row_executor.zig");
 const tile_sink = @import("quotient_tile_sink.zig");
+const compact_groups = @import("quotient_compact_groups.zig");
+const direct_plan = @import("quotient_direct_plan.zig");
 const constraints = @import("stwo_core").constraints;
 const domain_walk = @import("quotient_domain_walk.zig");
 const work_pool_mod = @import("../work_pool.zig");
@@ -25,59 +27,8 @@ pub inline fn shouldUseBoundedInput(lifting_log_size: u32) bool {
     return lifting_log_size >= 13;
 }
 
-pub const DirectContributionPlan = struct {
-    views: []row_executor.LiftingColumnView,
-    ranges: []row_executor.ColumnContributionRange,
-
-    pub fn deinit(self: *DirectContributionPlan, allocator: std.mem.Allocator) void {
-        allocator.free(self.views);
-        allocator.free(self.ranges);
-        self.* = undefined;
-    }
-};
-
-pub fn buildDirectContributionPlan(
-    allocator: std.mem.Allocator,
-    flat_columns: anytype,
-    active_column_indices: []const usize,
-    contribution_ranges: []const row_executor.ColumnContributionRange,
-    nonzero_columns: []const bool,
-    lifting_log_size: u32,
-) !DirectContributionPlan {
-    if (active_column_indices.len != contribution_ranges.len or
-        flat_columns.len != nonzero_columns.len)
-    {
-        return error.ShapeMismatch;
-    }
-
-    var nonzero_count: usize = 0;
-    for (active_column_indices) |column_index| {
-        if (column_index >= flat_columns.len) return error.ShapeMismatch;
-        if (nonzero_columns[column_index]) nonzero_count += 1;
-    }
-    const views = try allocator.alloc(row_executor.LiftingColumnView, nonzero_count);
-    errdefer allocator.free(views);
-    const ranges = try allocator.alloc(row_executor.ColumnContributionRange, nonzero_count);
-    errdefer allocator.free(ranges);
-
-    var write_index: usize = 0;
-    for (active_column_indices, contribution_ranges) |column_index, contribution_range| {
-        if (!nonzero_columns[column_index]) continue;
-        const column = flat_columns[column_index];
-        if (column.log_size > lifting_log_size) return error.InvalidColumnLogSize;
-        const log_shift = lifting_log_size - column.log_size;
-        if (log_shift >= @bitSizeOf(usize)) return error.InvalidColumnLogSize;
-        views[write_index] = .{
-            .values = column.values,
-            .shift_amt = @intCast(log_shift + 1),
-            .is_direct = column.log_size == lifting_log_size,
-        };
-        ranges[write_index] = contribution_range;
-        write_index += 1;
-    }
-    std.debug.assert(write_index == nonzero_count);
-    return .{ .views = views, .ranges = ranges };
-}
+pub const DirectContributionPlan = direct_plan.Plan;
+pub const buildDirectContributionPlan = direct_plan.build;
 
 pub const Scratch = struct {
     row_scratch: row_executor.Scratch,
@@ -202,6 +153,7 @@ pub const Work = struct {
     workspace: *quotients.RowQuotientWorkspace,
     scratch: ?*Scratch,
     domain: CircleDomain,
+    compact_groups: []const compact_groups.Group = &.{},
     column_views: []const row_executor.LiftingColumnView,
     contribution_ranges: []const row_executor.ColumnContributionRange,
     contributions: []const row_executor.ColumnContribution,
@@ -289,6 +241,16 @@ fn executeBatched(work: *Work, scratch: *Scratch) !void {
 }
 
 fn accumulateTile(work: *const Work, scratch: *Scratch, start: usize, row_count: usize) void {
+    for (work.compact_groups) |group| {
+        compact_groups.accumulate(
+            scratch.numerators,
+            scratch.row_capacity,
+            scratch.batch_count,
+            group,
+            start,
+            row_count,
+        );
+    }
     for (work.column_views, work.contribution_ranges) |view, contribution_range| {
         const column_contributions = work.contributions[contribution_range.start..][0..contribution_range.len];
         for (column_contributions) |contribution| {
@@ -454,6 +416,12 @@ fn executeScalar(work: *Work) !void {
                         );
                 }
             }
+            for (work.compact_groups) |group| {
+                work.workspace.batch_numerators[group.batch_index] =
+                    work.workspace.batch_numerators[group.batch_index].add(
+                        compact_groups.scalarValueAt(group, position),
+                    );
+            }
             try writeRow(work, position, domain_point.y, work.workspace.denominator_inverses);
         }
         try emitTile(work, tile_start, tile_end);
@@ -566,12 +534,14 @@ pub const ParallelRequest = struct {
     use_batched_inversion: bool,
     allow_parallel_scalar: bool,
     domain: CircleDomain,
+    compact_groups: []const compact_groups.Group = &.{},
     column_views: []const row_executor.LiftingColumnView,
     contribution_ranges: []const row_executor.ColumnContributionRange,
     contributions: []const row_executor.ColumnContribution,
     quotient_constants: *const quotients.QuotientConstants,
     lifting_log_size: u32,
     factory: ?tile_sink.Factory,
+    combined_intermediate_bytes: usize = 0,
 };
 
 pub fn executeParallel(
@@ -639,6 +609,7 @@ pub fn executeParallel(
             .workspace = &workspaces[worker_index],
             .scratch = if (scratches) |values| &values[worker_index] else null,
             .domain = request.domain,
+            .compact_groups = request.compact_groups,
             .column_views = request.column_views,
             .contribution_ranges = request.contribution_ranges,
             .contributions = request.contributions,
@@ -681,7 +652,7 @@ pub fn executeParallel(
         .peak_scratch_bytes_per_worker = peak_scratch_bytes,
         .total_scratch_bytes = total_scratch_bytes,
         .bounded_numerator_tile_bytes_per_worker = peak_numerator_bytes,
-        .complete_column_combined_intermediate_bytes = 0,
+        .complete_column_combined_intermediate_bytes = request.combined_intermediate_bytes,
         .post_compute_leaf_pass_count = if (request.factory == null) 1 else 0,
     };
 }

--- a/src/prover/pcs/quotients/lazy_provider.zig
+++ b/src/prover/pcs/quotients/lazy_provider.zig
@@ -30,6 +30,8 @@ const CombinedContributionView = row_executor.CombinedContributionView;
 const QuotientOpsError = column_geometry.QuotientOpsError;
 const SecureColumnByCoords = secure_column.SecureColumnByCoords;
 const MIN_POSITIONS_PER_WORKER = execution.min_positions_per_worker;
+const COMPACT_GROUP_MIN_SHIFT: std.math.Log2Int(usize) = 2;
+const MAX_COMPACT_GROUP_BYTES: usize = 1024 * 1024;
 
 /// Number of rows processed per chunk in lazy quotient evaluation.
 /// Chosen to amortize function-call overhead while keeping chunk memory bounded.
@@ -56,6 +58,7 @@ pub const LazyQuotientProvider = struct {
     prepared: planning.PreparedContext,
     input_mode: InputMode,
     combined_views: []CombinedContributionView,
+    compact_plan: planning.CompactContributionPlan,
     direct_plan: tile_executor.DirectContributionPlan,
     raw_columns: []ColumnEvaluation,
     workspace: quotients.RowQuotientWorkspace,
@@ -186,7 +189,14 @@ pub const LazyQuotientProvider = struct {
         const backend_raw = comptime B != void and @hasDecl(B, "rawQuotientInputs") and B.rawQuotientInputs;
         if ((input_mode == .raw_backend) != backend_raw) return error.InvalidQuotientInputMode;
         var combined_views: []CombinedContributionView = &.{};
+        var compact_plan = planning.CompactContributionPlan{ .groups = &.{}, .members = &.{} };
         var direct_plan = tile_executor.DirectContributionPlan{ .views = &.{}, .ranges = &.{} };
+        errdefer {
+            var combined_plan = planning.CombinedContributionPlan{ .views = combined_views };
+            combined_plan.deinit(allocator);
+            compact_plan.deinit(allocator);
+            direct_plan.deinit(allocator);
+        }
         switch (input_mode) {
             .combined_compatibility => {
                 const combined_plan = try planning.buildCombinedContributionPlan(
@@ -200,20 +210,31 @@ pub const LazyQuotientProvider = struct {
                 );
                 combined_views = combined_plan.views;
             },
-            .bounded_cpu => direct_plan = try tile_executor.buildDirectContributionPlan(
-                allocator,
-                flat_columns,
-                prepared.contribution_plan.active_column_indices,
-                prepared.contribution_plan.ranges,
-                nonzero_columns,
-                lifting_log_size,
-            ),
+            .bounded_cpu => {
+                const optional_compact_plan = try planning.buildCompactContributionPlan(
+                    allocator,
+                    flat_columns,
+                    prepared.contribution_plan.active_column_indices,
+                    prepared.contribution_plan.ranges,
+                    prepared.contribution_plan.contributions,
+                    nonzero_columns,
+                    lifting_log_size,
+                    COMPACT_GROUP_MIN_SHIFT,
+                    MAX_COMPACT_GROUP_BYTES,
+                );
+                const compact_admitted = optional_compact_plan != null;
+                if (optional_compact_plan) |plan| compact_plan = plan;
+                direct_plan = try tile_executor.buildDirectContributionPlan(
+                    allocator,
+                    flat_columns,
+                    prepared.contribution_plan.active_column_indices,
+                    prepared.contribution_plan.ranges,
+                    nonzero_columns,
+                    lifting_log_size,
+                    if (compact_admitted) COMPACT_GROUP_MIN_SHIFT else null,
+                );
+            },
             .raw_backend => {},
-        }
-        errdefer {
-            var combined_plan = planning.CombinedContributionPlan{ .views = combined_views };
-            combined_plan.deinit(allocator);
-            direct_plan.deinit(allocator);
         }
 
         var workspace = try quotients.RowQuotientWorkspace.init(allocator, prepared.sample_batches);
@@ -245,6 +266,7 @@ pub const LazyQuotientProvider = struct {
             .prepared = prepared,
             .input_mode = input_mode,
             .combined_views = combined_views,
+            .compact_plan = compact_plan,
             .direct_plan = direct_plan,
             .raw_columns = if (input_mode == .raw_backend) flat_columns else blk: {
                 allocator.free(flat_columns);
@@ -266,6 +288,7 @@ pub const LazyQuotientProvider = struct {
         self.workspace.deinit(allocator);
         var combined_plan = planning.CombinedContributionPlan{ .views = self.combined_views };
         combined_plan.deinit(allocator);
+        self.compact_plan.deinit(allocator);
         self.direct_plan.deinit(allocator);
         if (self.raw_columns.len != 0) allocator.free(self.raw_columns);
         self.prepared.deinit(allocator);
@@ -299,6 +322,7 @@ pub const LazyQuotientProvider = struct {
                     .workspace = &self.workspace,
                     .scratch = if (self.direct_chunk_scratch) |*scratch| scratch else null,
                     .domain = self.domain,
+                    .compact_groups = self.compact_plan.groups,
                     .column_views = self.direct_plan.views,
                     .contribution_ranges = self.direct_plan.ranges,
                     .contributions = self.prepared.contribution_plan.contributions,
@@ -376,6 +400,7 @@ pub const LazyQuotientProvider = struct {
                     .workspace = &self.workspace,
                     .scratch = if (self.direct_chunk_scratch) |*scratch| scratch else null,
                     .domain = self.domain,
+                    .compact_groups = self.compact_plan.groups,
                     .column_views = self.direct_plan.views,
                     .contribution_ranges = self.direct_plan.ranges,
                     .contributions = self.prepared.contribution_plan.contributions,
@@ -427,7 +452,7 @@ pub const LazyQuotientProvider = struct {
     }
 
     pub fn combinedIntermediateBytes(self: *const LazyQuotientProvider) !usize {
-        var bytes: usize = 0;
+        var bytes = self.compact_plan.retainedBytes();
         for (self.combined_views) |view| {
             for (view.coordinates) |coordinate| {
                 const coordinate_bytes = std.math.mul(usize, coordinate.len, @sizeOf(M31)) catch
@@ -564,12 +589,14 @@ pub const LazyQuotientProvider = struct {
             .use_batched_inversion = self.direct_chunk_scratch != null,
             .allow_parallel_scalar = self.allow_parallel_scalar,
             .domain = self.domain,
+            .compact_groups = self.compact_plan.groups,
             .column_views = self.direct_plan.views,
             .contribution_ranges = self.direct_plan.ranges,
             .contributions = self.prepared.contribution_plan.contributions,
             .quotient_constants = &self.prepared.quotient_constants,
             .lifting_log_size = self.lifting_log_size,
             .factory = factory,
+            .combined_intermediate_bytes = try self.combinedIntermediateBytes(),
         });
     }
 };

--- a/src/prover/pcs/quotients/planning.zig
+++ b/src/prover/pcs/quotients/planning.zig
@@ -39,6 +39,33 @@ pub const CombinedContributionPlan = struct {
     }
 };
 
+pub const CompactContributionMember = struct {
+    values: []const M31,
+    coefficients: [qm31.SECURE_EXTENSION_DEGREE]M31,
+};
+
+pub const CompactContributionGroup = struct {
+    members: []const CompactContributionMember,
+    batch_index: usize,
+    shift_amt: std.math.Log2Int(usize),
+};
+
+pub const CompactContributionPlan = struct {
+    groups: []CompactContributionGroup,
+    members: []CompactContributionMember,
+
+    pub fn deinit(self: *CompactContributionPlan, allocator: std.mem.Allocator) void {
+        allocator.free(self.groups);
+        allocator.free(self.members);
+        self.* = undefined;
+    }
+
+    pub fn retainedBytes(self: CompactContributionPlan) usize {
+        return self.groups.len * @sizeOf(CompactContributionGroup) +
+            self.members.len * @sizeOf(CompactContributionMember);
+    }
+};
+
 pub const ColumnContributionPlan = struct {
     active_column_indices: []usize,
     ranges: []ColumnContributionRange,
@@ -307,6 +334,7 @@ pub fn buildCombinedContributionPlan(
         if (column.log_size > lifting_log_size) return QuotientOpsError.InvalidColumnLogSize;
         const log_shift = lifting_log_size - column.log_size;
         if (log_shift >= @bitSizeOf(usize)) return QuotientOpsError.InvalidColumnLogSize;
+        const shift_amt: std.math.Log2Int(usize) = @intCast(log_shift + 1);
 
         const column_contributions = contributions[contribution_range.start .. contribution_range.start + contribution_range.len];
         for (column_contributions) |contribution| {
@@ -332,7 +360,7 @@ pub fn buildCombinedContributionPlan(
                 try views.append(allocator, .{
                     .coordinates = coordinates,
                     .batch_index = contribution.batch_index,
-                    .shift_amt = @intCast(log_shift + 1),
+                    .shift_amt = shift_amt,
                     .is_direct = column.log_size == lifting_log_size,
                 });
                 view_index = views.items.len - 1;
@@ -351,6 +379,183 @@ pub fn buildCombinedContributionPlan(
     }
 
     return .{ .views = try views.toOwnedSlice(allocator) };
+}
+
+/// Builds a lightweight grouping plan without materializing coefficient-weighted
+/// columns. Workers reduce each group's borrowed compact members in parallel.
+/// Optional-plan allocation or byte-budget failure selects the direct fallback;
+/// malformed quotient geometry still fails closed.
+pub fn buildCompactContributionPlan(
+    allocator: std.mem.Allocator,
+    flat_columns: []const ColumnEvaluation,
+    active_column_indices: []const usize,
+    contribution_ranges: []const ColumnContributionRange,
+    contributions: []const ColumnContribution,
+    nonzero_columns: []const bool,
+    lifting_log_size: u32,
+    min_shift_amt: std.math.Log2Int(usize),
+    max_bytes: usize,
+) !?CompactContributionPlan {
+    return buildCompactContributionPlanInner(
+        allocator,
+        flat_columns,
+        active_column_indices,
+        contribution_ranges,
+        contributions,
+        nonzero_columns,
+        lifting_log_size,
+        min_shift_amt,
+        max_bytes,
+    ) catch |err| switch (err) {
+        error.CompactContributionBudgetExceeded, error.OutOfMemory => null,
+        else => return err,
+    };
+}
+
+const CompactGroupSpec = struct {
+    batch_index: usize,
+    value_count: usize,
+    shift_amt: std.math.Log2Int(usize),
+    member_count: usize,
+};
+
+fn compactGroupIndex(
+    specs: []const CompactGroupSpec,
+    batch_index: usize,
+    value_count: usize,
+    shift_amt: std.math.Log2Int(usize),
+) ?usize {
+    for (specs, 0..) |spec, index| {
+        if (spec.batch_index == batch_index and
+            spec.value_count == value_count and
+            spec.shift_amt == shift_amt)
+        {
+            return index;
+        }
+    }
+    return null;
+}
+
+fn buildCompactContributionPlanInner(
+    allocator: std.mem.Allocator,
+    flat_columns: []const ColumnEvaluation,
+    active_column_indices: []const usize,
+    contribution_ranges: []const ColumnContributionRange,
+    contributions: []const ColumnContribution,
+    nonzero_columns: []const bool,
+    lifting_log_size: u32,
+    min_shift_amt: std.math.Log2Int(usize),
+    max_bytes: usize,
+) !CompactContributionPlan {
+    if (active_column_indices.len != contribution_ranges.len or
+        flat_columns.len != nonzero_columns.len)
+    {
+        return QuotientOpsError.ShapeMismatch;
+    }
+
+    var specs = std.ArrayList(CompactGroupSpec).empty;
+    defer specs.deinit(allocator);
+    var total_members: usize = 0;
+    for (active_column_indices, contribution_ranges) |column_idx, contribution_range| {
+        if (column_idx >= flat_columns.len or column_idx >= nonzero_columns.len) {
+            return QuotientOpsError.ShapeMismatch;
+        }
+        if (!nonzero_columns[column_idx]) continue;
+        const column = flat_columns[column_idx];
+        if (column.log_size > lifting_log_size) return QuotientOpsError.InvalidColumnLogSize;
+        const log_shift = lifting_log_size - column.log_size;
+        if (log_shift >= @bitSizeOf(usize)) return QuotientOpsError.InvalidColumnLogSize;
+        const shift_amt: std.math.Log2Int(usize) = @intCast(log_shift + 1);
+        if (shift_amt < min_shift_amt) continue;
+        const contribution_end = std.math.add(
+            usize,
+            contribution_range.start,
+            contribution_range.len,
+        ) catch return QuotientOpsError.ShapeMismatch;
+        if (contribution_end > contributions.len) return QuotientOpsError.ShapeMismatch;
+        for (contributions[contribution_range.start..contribution_end]) |contribution| {
+            if (compactGroupIndex(
+                specs.items,
+                contribution.batch_index,
+                column.values.len,
+                shift_amt,
+            )) |index| {
+                specs.items[index].member_count = std.math.add(
+                    usize,
+                    specs.items[index].member_count,
+                    1,
+                ) catch return error.CompactContributionBudgetExceeded;
+            } else {
+                try specs.append(allocator, .{
+                    .batch_index = contribution.batch_index,
+                    .value_count = column.values.len,
+                    .shift_amt = shift_amt,
+                    .member_count = 1,
+                });
+            }
+            total_members = std.math.add(usize, total_members, 1) catch
+                return error.CompactContributionBudgetExceeded;
+        }
+    }
+
+    const group_bytes = std.math.mul(
+        usize,
+        specs.items.len,
+        @sizeOf(CompactContributionGroup),
+    ) catch return error.CompactContributionBudgetExceeded;
+    const member_bytes = std.math.mul(
+        usize,
+        total_members,
+        @sizeOf(CompactContributionMember),
+    ) catch return error.CompactContributionBudgetExceeded;
+    const retained_bytes = std.math.add(usize, group_bytes, member_bytes) catch
+        return error.CompactContributionBudgetExceeded;
+    if (retained_bytes > max_bytes) return error.CompactContributionBudgetExceeded;
+
+    const groups = try allocator.alloc(CompactContributionGroup, specs.items.len);
+    errdefer allocator.free(groups);
+    const members = try allocator.alloc(CompactContributionMember, total_members);
+    errdefer allocator.free(members);
+    const next_offsets = try allocator.alloc(usize, specs.items.len);
+    defer allocator.free(next_offsets);
+
+    var member_offset: usize = 0;
+    for (specs.items, 0..) |spec, index| {
+        const member_end = member_offset + spec.member_count;
+        groups[index] = .{
+            .members = members[member_offset..member_end],
+            .batch_index = spec.batch_index,
+            .shift_amt = spec.shift_amt,
+        };
+        next_offsets[index] = member_offset;
+        member_offset = member_end;
+    }
+    std.debug.assert(member_offset == total_members);
+
+    for (active_column_indices, contribution_ranges) |column_idx, contribution_range| {
+        if (!nonzero_columns[column_idx]) continue;
+        const column = flat_columns[column_idx];
+        const log_shift = lifting_log_size - column.log_size;
+        const shift_amt: std.math.Log2Int(usize) = @intCast(log_shift + 1);
+        if (shift_amt < min_shift_amt) continue;
+        const contribution_end = contribution_range.start + contribution_range.len;
+        for (contributions[contribution_range.start..contribution_end]) |contribution| {
+            const group_index = compactGroupIndex(
+                specs.items,
+                contribution.batch_index,
+                column.values.len,
+                shift_amt,
+            ) orelse unreachable;
+            const write_index = next_offsets[group_index];
+            members[write_index] = .{
+                .values = column.values,
+                .coefficients = contribution.value_coeff.toM31Array(),
+            };
+            next_offsets[group_index] = write_index + 1;
+        }
+    }
+
+    return .{ .groups = groups, .members = members };
 }
 
 pub fn materializeActiveLiftedColumns(
@@ -404,4 +609,63 @@ fn validateSampleBatchColumnIndices(
             if (sample_data.column_index >= queried_values_cols) return error.ColumnIndexOutOfBounds;
         }
     }
+}
+
+test "compact contribution plan groups lifted geometry and fails back on budget" {
+    const values_a = [_]M31{
+        M31.fromCanonical(1), M31.fromCanonical(2),
+        M31.fromCanonical(3), M31.fromCanonical(4),
+    };
+    const values_b = [_]M31{
+        M31.fromCanonical(5), M31.fromCanonical(6),
+        M31.fromCanonical(7), M31.fromCanonical(8),
+    };
+    const direct_values = [_]M31{M31.one()} ** 16;
+    const columns = [_]ColumnEvaluation{
+        .{ .log_size = 2, .values = &values_a },
+        .{ .log_size = 2, .values = &values_b },
+        .{ .log_size = 4, .values = &direct_values },
+    };
+    const active_indices = [_]usize{ 0, 1, 2 };
+    const ranges = [_]ColumnContributionRange{
+        .{ .start = 0, .len = 1 },
+        .{ .start = 1, .len = 1 },
+        .{ .start = 2, .len = 1 },
+    };
+    const contributions = [_]ColumnContribution{
+        .{ .batch_index = 0, .value_coeff = QM31.fromU32Unchecked(1, 2, 3, 4) },
+        .{ .batch_index = 0, .value_coeff = QM31.fromU32Unchecked(5, 6, 7, 8) },
+        .{ .batch_index = 1, .value_coeff = QM31.one() },
+    };
+    const nonzero = [_]bool{ true, true, true };
+
+    var admitted = (try buildCompactContributionPlan(
+        std.testing.allocator,
+        &columns,
+        &active_indices,
+        &ranges,
+        &contributions,
+        &nonzero,
+        4,
+        2,
+        1024,
+    )).?;
+    defer admitted.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), admitted.groups.len);
+    try std.testing.expectEqual(@as(usize, 2), admitted.groups[0].members.len);
+    try std.testing.expectEqual(@as(usize, 0), admitted.groups[0].batch_index);
+    try std.testing.expectEqual(@as(std.math.Log2Int(usize), 3), admitted.groups[0].shift_amt);
+    try std.testing.expect(admitted.retainedBytes() <= 1024);
+
+    try std.testing.expect((try buildCompactContributionPlan(
+        std.testing.allocator,
+        &columns,
+        &active_indices,
+        &ranges,
+        &contributions,
+        &nonzero,
+        4,
+        2,
+        0,
+    )) == null);
 }


### PR DESCRIPTION
This groups structurally lifted quotient contributions by sample batch and source geometry, reduces each even/odd source pair in worker-local registers, and performs one packed broadcast per group. Direct columns remain on the packed path; checked descriptor admission falls back to the existing executor.

Clean claimed RISC-V deep S3 result: R 0.958426, 95% CI [0.954944, 0.962133]. All seven workloads win; verified-request geomean is 0.964371, energy 0.834744x, RSS 0.999729x, and proof bytes are unchanged. Every sample verified and the pinned Stark-V oracle accepted 7/7.

Local validation: aggregate ReleaseFast tests, source conformance, RISC-V CPU product closure, Native CPU product markers, Native Metal closure, and device-only Metal prove plus independent verify.

The submission includes the complete transcript, including the rejected serial-materialization architecture and the clean-provenance rerun.

PR6 Supremacy: not achieved.