### PR TITLE
perf: vectorize lifted Merkle leaf streams

### DIFF
--- a/autoresearch/submissions/2026-07-22-riscv-direct-column-streaming-simd/delta.json
+++ b/autoresearch/submissions/2026-07-22-riscv-direct-column-streaming-simd/delta.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "e6e86b072604",
+  "declared_objective": {
+    "board": "riscv",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/core/crypto/blake2s_backend.zig": "sha256:47d9e3fe20c9c79a23c5b3f4461d5186aa7c4b939d58e8557a71adae9e2816c0",
+    "src/core/crypto/blake2s_stream4.zig": "sha256:f0c6fa96fcf7a7452d12f7f800d423079648c3c7bee5ac3bbf14e4ee2652323d",
+    "src/core/crypto/mod.zig": "sha256:e240d651ed1217318e9e39d2a284c907b7a273fc11a0138ffadfe7ef9fa51e61",
+    "src/core/crypto/tests/blake2s_backend.zig": "sha256:fee3783ba7e01c5bf255881306d7c5c7388030c650b35a5ee72f6d99c13c939b",
+    "src/prover/pcs/scheme.zig": "sha256:ff3cf627637a307553500c6391d61ac3178dba3c4c19da55df8fdaf96e2d1b83",
+    "src/prover/pcs/tree_builders.zig": "sha256:7597cbe31a3c9db3a933b74f11fc8dda0267f794f8ff3aa8ecf6858c5b1c63d3",
+    "src/prover/vcs_lifted/blake2_stream4.zig": "sha256:e7b4e2a9b3ae06ac3effff896ec303e0c60716f6ab51abbc4d084e1272aa4d46",
+    "src/prover/vcs_lifted/leaves.zig": "sha256:50914d6eed8f05be5ae364519327e44264eabfa1c535a9356c760e4291240864",
+    "src/prover/vcs_lifted/prover.zig": "sha256:1c407528b762f506f31b8afeab8c33b8a0c11fc6a6871ce3569253ee91ef8e19",
+    "src/prover/vcs_lifted/tests/commit_paths.zig": "sha256:75db5e531fc92e8ff651a1d2a5b1df080dee7cbbbc5456ac48499febb775683a"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "9dd1b4eb46632b579a8dca6f0f6394a35efde44ab8bf86abb9c729d6d686621f",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-22-riscv-direct-column-streaming-simd/note.md
+++ b/autoresearch/submissions/2026-07-22-riscv-direct-column-streaming-simd/note.md
@@ -1,0 +1,92 @@
+# Vectorize lifted Merkle leaf streams directly from columns
+
+## Model and harness
+
+GPT-5 Codex developed and measured this change with refreshed `stwo-perf`
+harness `083877c03a81` on the Apple M5 Max host. The clean immutable candidate
+is `f6ef4dd0bcd5165d767b9e81d754347b7f40ffdf` over current-main predecessor
+`e6e86b072604f63c78c995f1edd2dbc9152f2de7`. The submitted S3 result covers
+the complete seven-program RISC-V deep portfolio in ReleaseFast mode with
+paired counterbalanced processes, independent proof verification, resource
+telemetry, and the repository-pinned Stark-V oracle.
+
+## Hypothesis
+
+The fresh SHA2-2048 sample put packed incremental BLAKE2s leaf ingestion at the
+frontier: it repeatedly staged column-major M31 values into row-major byte
+tiles and maintained one large scalar state per leaf. Four adjacent rows are
+already the four independent SIMD lanes consumed by the backend's parallel
+BLAKE2s compressor. Continuing those four states directly from canonical
+columns should remove message repacking, state-array expansion, barriers, and
+scratch traffic without changing a single hashed byte.
+
+## Changes
+
+The lifted PCS now admits a structural sparse-tail commit when the remaining
+high-domain columns fit the canonical terminal block. A new four-message
+BLAKE2s continuation primitive loads complete 16-word blocks directly from
+four adjacent column rows and completes the four final states together. The
+streaming builder still prepares columns in bounded batches and retains the
+same extended columns and PCS order; scalar and big-endian paths retain exact
+fallbacks.
+
+The optimization is selected by concrete hasher type, domain shape, column
+height, and terminal-block capacity—not workload name, input, or benchmark
+size. Differential tests cover distinct prefixes and long updates, distinct
+tails, direct column continuation against scalar streams, and the forced
+sparse commitment root against the fully materialized generic path.
+
+```text
+old: batches -> row staging -> per-leaf states -> finish
+new: columns -> four adjacent rows -> SIMD continuation -> sparse finish
+```
+
+Two broader alternatives were measured and rejected. Deferring all columns to
+the generic mixed-height commit regressed SHA2-2048 request time to 1.220x and
+instructions to 1.720x because it rebuilt every mixed-height leaf message.
+Grouping existing incremental batches by height was neutral at 1.004x request
+and 1.002x instructions. Both experiments were completely reverted. A first
+winning candidate passed performance and oracle gates but touched locked
+generic wrappers; the specialization was moved into the editable lifted-prover
+adapter before the final clean run.
+
+## Results
+
+Every deep workload improves against current main:
+
+| workload | proving ratio | 95% CI | verified-request ratio | energy ratio |
+| --- | ---: | ---: | ---: | ---: |
+| xorshift | 0.9091 | [0.9048, 0.9127] | 0.9160 | 0.9078 |
+| Fibonacci | 0.9392 | [0.9348, 0.9445] | 0.9429 | 0.9083 |
+| GCD | 0.9336 | [0.9296, 0.9367] | 0.9379 | 0.9019 |
+| multi-shard | 0.9107 | [0.9078, 0.9190] | 0.9140 | 0.9091 |
+| SHA2-512 | 0.9302 | [0.9173, 0.9484] | 0.9484 | 0.9025 |
+| SHA2-1024 | 0.9426 | [0.9360, 0.9503] | 0.9492 | 0.9072 |
+| SHA2-2048 | 0.9469 | [0.9415, 0.9506] | 0.9579 | 0.9190 |
+
+The portfolio proving ratio is **0.930236**, with 95% CI
+**[0.927643, 0.933370]**: 7.0% less latency. Geometric-mean energy falls 9.2%
+to ratio 0.907941, peak RSS is flat at 1.000545, and proof bytes remain exactly
+1.0. The new profile shows packed leaf ingestion collapsing from a leading 774
+samples to 49; canonical four-way compression, memory movement, LogUp,
+quotient execution, and FFT are the new frontier.
+
+## Correctness and validation
+
+Every timed proof verified independently, candidate and predecessor proof
+digests were byte-identical in every paired round, and the pinned Stark-V oracle
+accepted all 7/7 programs. Mechanism telemetry was canonical and stable. The
+full 374-source ReleaseFast test closure, formatting, source conformance,
+RISC-V CPU product, Native CPU product, and device-only Native Metal lifecycle
+all pass. Metal completed independent verification with zero CPU fallback.
+
+## Caveats
+
+This is a local claimed verdict; only the authenticated locked judge rerun can
+promote it. The harness's automatic Native guard mapping is malformed for this
+RISC-V objective, so the paired run used `--guards none` and all three affected
+product boundaries were run explicitly and sequentially. The exact PR6
+all-cell matrix, log22 oracle vectors, both required timing boundaries, and
+judged M5 verdict remain incomplete.
+
+**PR6 Supremacy: not achieved.**

--- a/autoresearch/submissions/2026-07-22-riscv-direct-column-streaming-simd/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-22-riscv-direct-column-streaming-simd/transcripts/session-01.md
@@ -1,0 +1,283 @@
+# Autoresearch session 01 — RISC-V deep epoch 4
+
+## Objective and frontier
+
+This session continues the long-running optimization loop after PR #83 merged
+the explicit Metal resident proof pipeline into `main` at `e6e86b072604`.
+The user extended the run for nine additional hours and explicitly requested
+large architectural improvements, with special priority on the largest RISC-V
+benchmarks. The acceptance unit is therefore the complete seven-program
+`riscv/deep` portfolio, followed by Native CPU and Metal product guards; an
+isolated kernel win is only diagnostic.
+
+The repository-resident CLI was refreshed before work. A clean detached
+workspace was cloned from current main and `stwo-perf setup` built the Native,
+RISC-V, and Metal bench products. No source edit has been made yet.
+
+## Method and prior evidence
+
+All five repository skills were reread from current main. Their binding method
+is: profile before editing; write a problem-match brief before a material
+algorithm change; use instruction/cycle/sample evidence for CPU attribution;
+preserve the compute-only Metal residency, synchronization, AOT, and proof-byte
+contracts; and capture rejected approaches and surprises rather than erasing
+them. The Metal common-patterns reference was read completely; render-specific
+guidance is inapplicable.
+
+The two immediately preceding RISC-V promotions were reviewed in full. Run-wise
+lifted quotient strength reduction cut deep proving to ratio 0.724575, then
+worker-local grouping of equal quotient geometries cut the new frontier to
+0.958426. That second session rejected serial compact-column materialization:
+although instructions fell to 0.749x, main-thread plan construction lengthened
+the critical path and did not improve verified proving time. The next profile
+must therefore start from current main and must not simply repeat quotient
+materialization.
+
+A later unsubmitted experiment proposed deferring streaming Merkle leaf hashing
+until all already-retained columns were available, exposing four-message SIMD
+hashing and removing per-leaf incremental state. Its source remains isolated in
+an older dirty worktree and is treated as a hypothesis/dead end, not inherited
+code. This session will first reproduce the current-main large-row profile and
+measure whether Merkle ingestion, memory movement, quotient execution, or a new
+stage now dominates after PR #83's additional CPU batching and SIMD work.
+
+## Fresh current-main baseline and profile
+
+All seven `riscv/deep` programs were run from the clean ReleaseFast main binary
+with one verified warmup and one timed sample. Request / proving seconds were:
+xorshift 1.445/1.353, Fibonacci 1.586/1.487, GCD 1.504/1.395,
+multi-shard 1.564/1.464, SHA2-512 2.138/1.636, SHA2-1024 2.412/1.928,
+and SHA2-2048 2.792/2.140. Every artifact verified and its digest was retained
+in the external session evidence directory.
+
+A fresh three-second macOS sample of SHA2-2048 changed the priority relative to
+the previous epoch. Useful top frames were four-message BLAKE2s compression
+845 samples, packed incremental leaf ingestion 774, `memmove` 738, quotient
+tile execution 600, scalar/SIMD BLAKE2s 381, batch inversion 251, and direct
+batched leaves 126. Merkle leaf work is now the largest cluster by a wide
+margin; quotient work remains material but no longer deserves the first edit.
+
+The prior deferred-commit candidate is being reconsidered only because its
+premise changed after PR #83. The merged branch added direct equal-height
+column-layout hashing, which eliminates the row-message repacking cost that
+made the earlier plain deferred builder unattractive. The updated problem-match
+and Metal compute design briefs were written before editing. The predicted
+signature is simultaneous removal of the large per-leaf incremental-state
+array, collapse of packed-update/scalar-finalize frames, preservation of the
+required four-message compression work, and at least an 8% SHA2-2048 proving
+win. A sub-3% result or any correctness/resource regression rejects it.
+
+## Deferred-all-columns experiment rejected
+
+The minimal candidate removed the `StreamingTreeBuilder`'s duplicate leaf-state
+array, retained batch-wise column preparation, restored original PCS order, and
+invoked the backend's normal commitment once. The complete ReleaseFast test
+root passed its 372-source closure before measurement.
+
+The first verified SHA2-2048 screen decisively falsified the performance model.
+Request time regressed from 2.791643 s to 3.407045 s and proving from
+2.140442 s to 2.714156 s. Across one warmup and one sample, retired
+instructions rose from 258.44 billion to 444.51 billion and cycles from
+83.00 billion to 175.21 billion. Peak physical footprint was essentially
+unchanged (1.570 GB to 1.576 GB), so the predicted state-memory benefit did
+not materialize at the process peak. Statement and transcript digests remained
+exact, but the benchmark artifact identity changed and would require separate
+proof-byte investigation if the candidate had survived performance screening.
+
+The inferred equal-height premise was wrong for the complete commitment. The
+RISC-V trees mix column heights, causing the backend to use its mixed-height
+message-packing path; reconstructing every complete 895/444-column leaf message
+costs far more than preserving incremental state across the 64-column batches.
+This explains why PR #83's direct equal-height path did not rescue the old
+architecture. The source change was reverted with `apply_patch`, formatted,
+and checked byte-for-byte against current main. The test and measurement remain
+in the transcript as a rejected architecture.
+
+## Height-grouped incremental fusion candidate
+
+A temporary read-only shape diagnostic on the restored streaming path showed
+why a narrower loop interchange remains promising. The SHA2-2048 commitment
+has groups from log 5 through log 21, hundreds of columns around log 16, but
+only one log-19, one log-20, and two log-21 columns. Preparation emits many
+64-column batches at the same log size. The current builder therefore schedules
+and scans the same leaf-state array repeatedly even though it retains every
+extended column until decommitment. The diagnostic log was removed before the
+candidate edit.
+
+The revised candidate does **not** call the generic mixed-height Merkle builder.
+It keeps the existing lifted incremental state expansion and exact byte stream,
+but delays `StreamingCommitter.addColumns` until `commit`, sorts all retained
+column references once, and feeds the committer once. Columns of equal height
+are consequently processed as a single group instead of one group per
+preparation batch. Interpolation and extension stay bounded at 64 columns;
+ownership, original PCS ordering, transcript mix order, final leaf semantics,
+and the standalone streaming-committer API are unchanged.
+
+This is batch fusion/loop interchange rather than a cryptographic change. Its
+predicted signature is fewer worker-pool barriers and scratch allocations,
+especially at log 16, with the same number of BLAKE2s payload bytes and the
+same canonical proof. A meaningful large-row win without a small-row or memory
+regression promotes it; a sub-1% result or digest/parity failure rejects it.
+
+The complete ReleaseFast closure passed, but the first large-row measurement
+made the decision unambiguous. SHA2-2048 request ratio was 1.004166, proving
+ratio 0.999535, retired-instruction ratio 1.001727, cycle ratio 1.013827, and
+peak-footprint ratio 1.000063 versus the fresh current-main sample. Statement
+and transcript digests matched exactly. The artifact envelope digest was the
+same candidate-build identity observed in the earlier rejected experiment, so
+it is not being treated as a canonical-proof mismatch.
+
+The predicted scheduling gain does not exist at end-to-end scale: merging the
+same-height batches does not reduce the dominant BLAKE2s payload or persistent
+state traffic enough to measure. This candidate was rejected under its stated
+sub-1% falsifier and reverted with `apply_patch`. The next architecture must
+remove the million-entry sparse-tail state expansion or vectorize continuation
+of independent leaf hashers, not merely reschedule it.
+
+## Sparse tail and four-message incremental architecture
+
+The sparse-terminal-block path passed the full 372-source ReleaseFast closure.
+Its first scalar-tail screen was nearly neutral, showing that expansion removal
+alone was insufficient. Adding four-message SIMD finalization made the same
+SHA2-2048 request 0.979452x and proving 0.986919x current main, with instruction
+ratio 0.987590, cycle ratio 0.984358, and energy ratio 0.976789. This retained
+exact statement and transcript digests and established the terminal-block
+equivalence, but still left the profiled dense incremental ingestion untouched.
+
+The next stacked change generalized four-message SIMD from one-shot leaves to
+four independent in-progress BLAKE2s states. A differential unit fixture now
+covers distinct prefixes, distinct 257-byte updates, partial buffers, distinct
+20-byte final tails, and scalar-equivalent digests. The first row-packed
+version improved SHA2-2048 proving to 0.955130x and request to 0.967578x, with
+cycles at 0.909943x and energy at 0.931985x.
+
+Finally, the update path was fused directly with equal-height column-major M31
+storage. Four adjacent rows are already the vector lanes required by the
+four-message compressor, so complete 16-word blocks no longer pass through the
+256 KiB-per-worker row-major staging tile. Partial buffered words retain the
+same little-endian encoding and terminal-full-block rule. This is structurally
+admitted by hasher capability and adjacent equal-height columns; scalar and
+big-endian implementations retain exact fallbacks.
+
+The first complete SHA2-2048 screen is large: verified request fell from
+2.791643 s to 2.434196 s, ratio 0.871958 (1.147x throughput); instructions to
+0.951499, cycles to 0.842603, and energy to 0.899145. Peak footprint was flat at
+0.999697x. The reported witness substage fell from 0.544390 s to 0.193482 s,
+while `prove_ms` returned to 0.999527x, because deferring the complete-shape
+leaf pass moves Merkle work across the recorder's preparation/commit labels.
+The verified request boundary, retired work, and energy all demonstrate a real
+end-to-end gain; `prove_ms` is diagnostic and is not used as the verdict.
+Statement and transcript digests remain exact. The artifact-envelope digest is
+stable across all dirty candidate builds and differs from main's clean-build
+envelope, so canonical proof bytes will be compared from frozen proof outputs
+rather than inferred from that build-labelled envelope hash.
+
+## Complete portfolio screen and bottleneck transfer
+
+The direct-column continuation was then screened once against current main on
+all seven deep programs. Every row won verified request time, proving time,
+retired instructions, cycles, and energy while remaining within 0.1% of the
+baseline peak footprint. The request ratios were 0.9214 xorshift, 0.9314
+Fibonacci, 0.9229 GCD, 0.9114 multi-shard, 0.9530 SHA2-512, 0.9591 SHA2-1024,
+and 0.9503 SHA2-2048. The corresponding cycle ratios were 0.8768, 0.8629,
+0.8579, 0.8617, 0.8628, 0.8690, and 0.8696. This broad signature rejected the
+possibility that the first large-row win was a target-specific accident.
+
+A new eight-second sample of the candidate confirmed the intended transfer:
+
+```text
+before                         after
+packed leaf ingestion  774 ->   49 samples
+four-way compression   845 -> 3359 samples
+memmove                 738 -> 2180 samples
+quotient executor       600 -> 1076 samples
+direct batched leaves   126 ->  480 samples
+```
+
+Absolute counts are not directly comparable because sample duration and proof
+progress differ, but stack ordering is. Packed incremental ingestion collapsed
+from the leading cluster to background noise. Canonical four-message BLAKE2s
+compression is now the largest remaining stage, followed by memory movement,
+RISC-V LogUp evaluation, quotient execution, and circle FFT work. The profile
+is retained at `evidence/direct-column-profile/process.sample.txt`, with its
+machine-readable report beside it. A future epoch should attack compression
+round scheduling or eliminate another copy; it should not add another builder
+reschedule or restore row-major message packing.
+
+The material dataflow change is:
+
+```text
+old: batches -> row-major staging -> per-leaf incremental states -> scalar/SIMD finish
+new: retained columns -> four adjacent rows -> direct SIMD continuation -> sparse finish
+```
+
+The final implementation includes three differential fixtures: independent
+four-stream prefixes plus 257-byte updates, distinct 20-byte terminal tails,
+and direct column-major continuation versus four scalar streams. A focused PCS
+test forces the sparse terminal path and compares its root with the fully
+materialized generic path. Scalar and big-endian fallbacks remain unchanged.
+
+## Source-policy correction before the frozen run
+
+The first immutable candidate, `8404000`, passed the seven-row paired benchmark
+with a 0.9367 portfolio ratio and all proof/oracle gates, but failed G2 because
+its specialization had been placed in two locked generic VCS wrapper files.
+That run is retained under `evidence/official-first-8404000-run`; it is not the
+submission verdict. The failure exposed a packaging error, not a benchmark or
+correctness failure.
+
+The specialization was moved into the editable lifted-prover adapter
+`src/prover/vcs_lifted/blake2_stream4.zig`. The locked wrapper files were
+restored byte-for-byte from `main`, and the candidate was amended to the clean
+commit `f6ef4dd0bcd5165d767b9e81d754347b7f40ffdf`. Only MANIFEST-approved core
+crypto, PCS, and lifted-prover paths differ from its predecessor. The complete
+ReleaseFast closure then passed with 374 transitive Zig sources and no new
+source-conformance findings.
+
+## Frozen paired verdict
+
+The final local S3 run paired clean candidate `f6ef4dd0bcd5` against clean
+current-main predecessor `e6e86b072604`, using the refreshed harness
+`083877c03a81`. It ran the full seven-program RISC-V deep portfolio, continued
+the two noisier SHA2 rows to five rounds, and accepted every gate:
+
+| workload | proving ratio | 95% CI | verified-request ratio | rounds |
+| --- | ---: | ---: | ---: | ---: |
+| xorshift | 0.9091 | [0.9048, 0.9127] | 0.9160 | 3 |
+| Fibonacci | 0.9392 | [0.9348, 0.9445] | 0.9429 | 3 |
+| GCD | 0.9336 | [0.9296, 0.9367] | 0.9379 | 3 |
+| multi-shard | 0.9107 | [0.9078, 0.9190] | 0.9140 | 3 |
+| SHA2-512 | 0.9302 | [0.9173, 0.9484] | 0.9484 | 5 |
+| SHA2-1024 | 0.9426 | [0.9360, 0.9503] | 0.9492 | 5 |
+| SHA2-2048 | 0.9469 | [0.9415, 0.9506] | 0.9579 | 3 |
+
+The geometric-mean proving ratio is 0.930236 with portfolio 95% CI
+[0.927643, 0.933370], a statistically significant 7.0% latency reduction.
+Geometric-mean energy ratio is 0.907941 (9.2% lower), peak-RSS ratio is
+1.000545, and proof-byte ratio is exactly 1.0. Every timed sample verified,
+candidate and predecessor proof digests were byte-identical per round, the
+pinned Stark-V correctness oracle accepted all 7 workloads, and mechanism
+telemetry remained canonical. This is a local claimed verdict; only the
+authenticated judge rerun can promote it.
+
+The shared change also passed `test-riscv-cpu-product`,
+`test-native-cpu-product`, device-only `test-native-metal`, `fmt`,
+`source-conformance`, and the full ReleaseFast test root. Native Metal reported
+no CPU fallback and completed independent verification. The local harness's
+automatic Native guard mapping is currently malformed for this RISC-V board,
+so the objective was run with `--guards none` and the three product boundaries
+were executed explicitly and sequentially instead of being silently omitted.
+
+## Decision and remaining work
+
+Promote. The implementation generalizes over BLAKE2s message structure and
+equal-height column layout, not workload names, sizes, or input digests. It
+removes a profiled architectural bottleneck across the complete deep portfolio,
+passes exact proof/oracle checks, saves energy, and does not materially increase
+memory. The remote locked judge remains authoritative for the final verdict.
+
+This submission improves the repository's RISC-V product but does not complete
+the separate all-cell PR6 objective: its exact workload ports, log22 vectors,
+two timing boundaries, and locked-M5 judged matrix remain incomplete.
+
+**PR6 Supremacy: not achieved.**

--- a/autoresearch/submissions/2026-07-22-riscv-direct-column-streaming-simd/verdict.json
+++ b/autoresearch/submissions/2026-07-22-riscv-direct-column-streaming-simd/verdict.json
@@ -1,0 +1,950 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "083877c03a81",
+  "repo_commit": "f6ef4dd0bcd5",
+  "predecessor_commit": "e6e86b072604",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "riscv",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 2.84
+    }
+  },
+  "search_health": {
+    "schema_version": 1,
+    "decision": {
+      "schema_version": 1,
+      "board": "riscv",
+      "workload_class": "deep",
+      "trailing_window": 8,
+      "trailing_evidence_count": 2,
+      "trailing_median_gradient_snr": 73.93166336679784,
+      "gradient_snr_threshold": 2.0,
+      "configured_rounds": 5,
+      "auto_boost_rounds": 5,
+      "maximum_rounds": 25,
+      "target_rounds": 5,
+      "workload_count": 7,
+      "class_wall_deadline_seconds": 600.0,
+      "estimated_seconds_per_round": 9.128065673890784,
+      "deadline_round_limit": 9,
+      "auto_boost_applied": false,
+      "auto_boost_reason": "trailing_median_at_or_above_threshold",
+      "recorded_before_measurement": true
+    },
+    "decision_sha256": "sha256:34b7da3f9e48a684a53f7f432ef7458aaabcc2d870c4dfab5c13912c6015bca9",
+    "actual_rounds": 25,
+    "actual_rounds_per_workload": {
+      "riscv_fib_iter": 3,
+      "riscv_gcd_euclid": 3,
+      "riscv_multi_shard_addi": 3,
+      "riscv_sha2_1024b": 5,
+      "riscv_sha2_2048b": 3,
+      "riscv_sha2_512b": 5,
+      "riscv_xorshift_prng": 3
+    },
+    "objective_wall_seconds": 202.00673279096372,
+    "measurement_wall_seconds": 203.21466258296277,
+    "measurement_wall_hours": 0.05644851738415633,
+    "gradient_snr": null,
+    "credited_ln_improvement": null,
+    "credited_ln_improvement_per_measurement_hour": null,
+    "credit_status": "pending_ledger_adjudication",
+    "decision_record": "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/search-health-decision.json"
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned correctness oracle verified 7/7 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "RISC-V mechanism telemetry present, canonical, and semantically stable for 7/7 workloads"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.6041 vs targeted budget x1.02; matrix row upper CIs 7/7 within budget x1.05; request ratios 7/7 present rows within budget x1.05; resource vectors 7/7 within named budgets"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "riscv_xorshift_prng": {
+        "r": 0.909101,
+        "ci": [
+          0.904795,
+          0.912676
+        ],
+        "rounds": 3,
+        "a_median_ms": 1386.254792,
+        "b_median_ms": 1256.890916,
+        "request_ratio": 0.916029,
+        "rss_ratio": 1.00008,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.907759,
+            "ci": [
+              0.904661,
+              0.911628
+            ],
+            "observations": 3,
+            "candidate": 46.498610594
+          },
+          "peak_rss_mib": {
+            "ratio": 1.00008,
+            "ci": [
+              0.999716,
+              1.000506
+            ],
+            "observations": 3,
+            "candidate": 1265.439308166504
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 61123.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 61123,
+        "measurement_seconds": 17.489703,
+        "resources_complete": true
+      },
+      "riscv_fib_iter": {
+        "r": 0.939161,
+        "ci": [
+          0.934793,
+          0.944487
+        ],
+        "rounds": 3,
+        "a_median_ms": 1534.74375,
+        "b_median_ms": 1434.6675,
+        "request_ratio": 0.942919,
+        "rss_ratio": 1.000287,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.908251,
+            "ci": [
+              0.907255,
+              0.909481
+            ],
+            "observations": 3,
+            "candidate": 50.704191008
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000287,
+            "ci": [
+              0.999685,
+              1.000544
+            ],
+            "observations": 3,
+            "candidate": 1292.548728942871
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 60003.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 60003,
+        "measurement_seconds": 19.168139,
+        "resources_complete": true
+      },
+      "riscv_gcd_euclid": {
+        "r": 0.933631,
+        "ci": [
+          0.92957,
+          0.9367
+        ],
+        "rounds": 3,
+        "a_median_ms": 1455.7915,
+        "b_median_ms": 1361.377791,
+        "request_ratio": 0.937881,
+        "rss_ratio": 1.000049,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.901889,
+            "ci": [
+              0.900999,
+              0.904337
+            ],
+            "observations": 3,
+            "candidate": 47.513920138
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000049,
+            "ci": [
+              0.999512,
+              1.000391
+            ],
+            "observations": 3,
+            "candidate": 1278.9862976074219
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 62582.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 62582,
+        "measurement_seconds": 18.286835,
+        "resources_complete": true
+      },
+      "riscv_multi_shard_addi": {
+        "r": 0.910748,
+        "ci": [
+          0.907787,
+          0.918994
+        ],
+        "rounds": 3,
+        "a_median_ms": 1534.161958,
+        "b_median_ms": 1401.408792,
+        "request_ratio": 0.914048,
+        "rss_ratio": 0.999873,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.909102,
+            "ci": [
+              0.90805,
+              0.9117
+            ],
+            "observations": 3,
+            "candidate": 49.344157868
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999873,
+            "ci": [
+              0.999479,
+              1.000545
+            ],
+            "observations": 3,
+            "candidate": 1290.2675247192383
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 58117.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 58117,
+        "measurement_seconds": 18.899316,
+        "resources_complete": true
+      },
+      "riscv_sha2_512b": {
+        "r": 0.930222,
+        "ci": [
+          0.917307,
+          0.948411
+        ],
+        "rounds": 5,
+        "a_median_ms": 1730.3935,
+        "b_median_ms": 1608.891666,
+        "request_ratio": 0.948368,
+        "rss_ratio": 1.000495,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.90254,
+            "ci": [
+              0.900775,
+              0.90427
+            ],
+            "observations": 5,
+            "candidate": 62.40659334
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000495,
+            "ci": [
+              0.999841,
+              1.001455
+            ],
+            "observations": 5,
+            "candidate": 1375.689582824707
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 78496.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 78496,
+        "measurement_seconds": 43.836317,
+        "resources_complete": true
+      },
+      "riscv_sha2_1024b": {
+        "r": 0.942577,
+        "ci": [
+          0.935995,
+          0.950294
+        ],
+        "rounds": 5,
+        "a_median_ms": 2016.381542,
+        "b_median_ms": 1901.458333,
+        "request_ratio": 0.949186,
+        "rss_ratio": 1.000679,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.907174,
+            "ci": [
+              0.904223,
+              0.91044
+            ],
+            "observations": 5,
+            "candidate": 69.888108492
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000679,
+            "ci": [
+              1.000388,
+              1.001002
+            ],
+            "observations": 5,
+            "candidate": 1428.6117095947266
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 76677.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 76677,
+        "measurement_seconds": 49.897459,
+        "resources_complete": true
+      },
+      "riscv_sha2_2048b": {
+        "r": 0.946939,
+        "ci": [
+          0.941542,
+          0.950579
+        ],
+        "rounds": 3,
+        "a_median_ms": 2263.631041,
+        "b_median_ms": 2133.9615,
+        "request_ratio": 0.957948,
+        "rss_ratio": 1.002354,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.918976,
+            "ci": [
+              0.916459,
+              0.920288
+            ],
+            "observations": 3,
+            "candidate": 78.44976665
+          },
+          "peak_rss_mib": {
+            "ratio": 1.002354,
+            "ci": [
+              0.999657,
+              1.003734
+            ],
+            "observations": 3,
+            "candidate": 1502.9711532592773
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 81115.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 81115,
+        "measurement_seconds": 34.317924,
+        "resources_complete": true
+      }
+    },
+    "R_geomean": 0.930236,
+    "portfolio": {
+      "ci_method": "independent_workload_round_bootstrap_percentile_v1",
+      "ci_level": 0.95,
+      "bootstrap_iterations": 4000,
+      "seed": 4042241451,
+      "ci": [
+        0.927643,
+        0.93337
+      ],
+      "prove_ms_method": "geometric_mean_candidate_workload_medians_ms_v1",
+      "b_median_ms_geomean": 1559.75389,
+      "proof_bytes_method": "rounded_geometric_mean_candidate_proof_bytes_v1",
+      "proof_bytes": 67692,
+      "measurement_seconds": 201.895694,
+      "measurement_rounds": 25
+    },
+    "theta": 0.012888,
+    "aa_dispersion": 0.006444,
+    "significant": true,
+    "neutral": false,
+    "promotion_significance": {
+      "eligible": true,
+      "method": "independent_workload_round_bootstrap_percentile_v1",
+      "reason": "prove-time objective uses the deterministic workload portfolio CI"
+    },
+    "resource_portfolio": {
+      "peak_rss_mib": {
+        "ratio_geomean": 1.0005449962643198,
+        "upper_ci_geomean": 1.0011674984145884,
+        "candidate_geomean": 1345.2492026834143
+      },
+      "energy_j": {
+        "ratio_geomean": 0.9079410070109568,
+        "upper_ci_geomean": 0.9102924822619012,
+        "candidate_geomean": 56.731425189512024
+      },
+      "proof_bytes": {
+        "ratio_geomean": 1.0,
+        "upper_ci_geomean": 1.0,
+        "candidate_geomean": 67691.6135391908
+      }
+    }
+  },
+  "tiebreakers": {
+    "rss_ratio": 1.000545,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": 56.731425189512024,
+    "proof_bytes": 67691.6135391908
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "riscv_xorshift_prng",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "63f804963cf4f6e1a2cffa52e12eb91ef73ad1fb8f00cfac082ebb9f1dfef243",
+      "proof_sha256": "c32a74186749f640a1b5b2a558768e9f6e60bcd58bc30595411e1722d5ead0e9"
+    },
+    {
+      "workload": "riscv_fib_iter",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "3dcedef929fcb6a8d8cd91c912fe7e54bdfe80259048f7d53793eb3dd46dd38b",
+      "proof_sha256": "100f0251e29fa5bbd58dfca387f52b776c0fa387ca0c2250a2f5534235bedc02"
+    },
+    {
+      "workload": "riscv_gcd_euclid",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "89ccfda37a5a24d595f266b1f04efbc7dc1b6806de5729c6a77837c883b18f81",
+      "proof_sha256": "7cfa5df8529186cc005ad38e86f5aae1fc0cb150a2d4c899a42bebac5f46778b"
+    },
+    {
+      "workload": "riscv_multi_shard_addi",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "6b9fbbd7f0a1a439cfb5bc1f473228c84e89f7c4223fc8d0c2e0c50189305ef6",
+      "proof_sha256": "4bf8ab22c5ebb506421203abfb2905b06d3f9cc39cd42fcd3899f288f98775a4"
+    },
+    {
+      "workload": "riscv_sha2_512b",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "3b2841f530673e265f66efc024cd71b242f5e29dda4a9dbb95c0bc34fe91e602",
+      "proof_sha256": "a5c7b4e54d0ba913b0ae1f58c77ea823826e0ba776a4a2673be2ab6dc3bcb74a"
+    },
+    {
+      "workload": "riscv_sha2_1024b",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "c0e9ec4d4964afae789fe11ed792e2437c5cd75d4e4fdbb99dbb2a977810a728",
+      "proof_sha256": "63bbad02c8806622b99eba191ca9d1333ba77abd2f1486e2838525542d36cc50"
+    },
+    {
+      "workload": "riscv_sha2_2048b",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "f5e549005e120224352761aba8b6cb5f19b6e74be0d754d637ffc1580db5c606",
+      "proof_sha256": "adaa94716e7010c04814b2b574b3b7cb788f76f31f8258ad2a737bae68f1b851"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "pr6_supremacy",
+      "reason": "PR6 Supremacy remains disabled until every exact workload port, log22 oracle vector, both timing boundaries, locked-M5 statistical gate, and authenticated judged verdict are complete."
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "riscv_xorshift_prng": {
+        "round_ratios": [
+          0.909467,
+          0.904795,
+          0.912676
+        ],
+        "proof_digest": "c32a74186749f640a1b5b2a558768e9f6e60bcd58bc30595411e1722d5ead0e9",
+        "request_ratio": 0.916029,
+        "rss_ratio": 1.00008,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.907759,
+            "ci": [
+              0.904661,
+              0.911628
+            ],
+            "observations": 3,
+            "candidate": 46.498610594
+          },
+          "peak_rss_mib": {
+            "ratio": 1.00008,
+            "ci": [
+              0.999716,
+              1.000506
+            ],
+            "observations": 3,
+            "candidate": 1265.439308166504
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 61123.0
+          }
+        },
+        "report_sha256s": [
+          "d22bd659a31799e22321e3f592b347b6c3a019c02dd076f52bb3abb1a5087818",
+          "4e7168b7d83874365b3fd8f6b226cb54f4d23e60a9e94f2afb51c9d8b15404f4",
+          "76ea0110add1dba48592bec7eeada9b4f93aa3f5a03cee4471b957d6289be4ae",
+          "0703ed5f6ef308bd937bf80346be7aba3947eafc3486048ed91ebf610ba5779b",
+          "b4d50db9ac4be57359ea307e550c40190ca7414302a0d44f7138082dc45792aa",
+          "aaf67cf9972b5eeb20f5dc71da0ae3db96bcf4c1befcf86a49609d6c99167f2e"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_fib_iter": {
+        "round_ratios": [
+          0.934793,
+          0.938681,
+          0.944487
+        ],
+        "proof_digest": "100f0251e29fa5bbd58dfca387f52b776c0fa387ca0c2250a2f5534235bedc02",
+        "request_ratio": 0.942919,
+        "rss_ratio": 1.000287,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.908251,
+            "ci": [
+              0.907255,
+              0.909481
+            ],
+            "observations": 3,
+            "candidate": 50.704191008
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000287,
+            "ci": [
+              0.999685,
+              1.000544
+            ],
+            "observations": 3,
+            "candidate": 1292.548728942871
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 60003.0
+          }
+        },
+        "report_sha256s": [
+          "055572fe7815498ac049c377527866cc20cc7f1f1f2b0a442f661a44f894d194",
+          "77a7fcec26240c9bf80f066ec4e79b8e9191298a73d9288ecf3bcede176144aa",
+          "48850b91d13be6f081f0547c7a3b5c823e016c3c3ce2c937f30039ebafb3b7ab",
+          "d7efb55b6925c6dcd19e88acf60396ddb16897e85d6e4218fb5313a5e2c6a21b",
+          "252cb7b30c758c1b0a6bd215ba93099649200918b01b49fb9d6d4658eb193108",
+          "3966bb4311b1ab98c19c94e2afa4eaedc466d0bf0adad6fb22b1c0123a8a9b4d"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_gcd_euclid": {
+        "round_ratios": [
+          0.92957,
+          0.9367,
+          0.934127
+        ],
+        "proof_digest": "7cfa5df8529186cc005ad38e86f5aae1fc0cb150a2d4c899a42bebac5f46778b",
+        "request_ratio": 0.937881,
+        "rss_ratio": 1.000049,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.901889,
+            "ci": [
+              0.900999,
+              0.904337
+            ],
+            "observations": 3,
+            "candidate": 47.513920138
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000049,
+            "ci": [
+              0.999512,
+              1.000391
+            ],
+            "observations": 3,
+            "candidate": 1278.9862976074219
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 62582.0
+          }
+        },
+        "report_sha256s": [
+          "3b6e5879f188f49280e134f1df07aaad9e4519375519013144b3659d701a1465",
+          "fd49518aa02a5675a5b6595828b60c9bb42fcf7a1ff0fc2412c2f242e6c92807",
+          "29c0909b2f6feff2c40b6375d60982d6771c5bb87d991344ba6ccbc70c7e8c04",
+          "da8ca69aadb9c2eafdcb92f00a6220521a4f581f3c69a11a93d017acf2ca1dfa",
+          "edd8cc0e554aff9e6c85839826df298b227ceabd66b72c4d29504d786d535831",
+          "ecf4ef32d91c0aabb37e6183e76ccd41ea5e9f5371a0bc967c187cd77b545fc6"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_multi_shard_addi": {
+        "round_ratios": [
+          0.908106,
+          0.907787,
+          0.918994
+        ],
+        "proof_digest": "4bf8ab22c5ebb506421203abfb2905b06d3f9cc39cd42fcd3899f288f98775a4",
+        "request_ratio": 0.914048,
+        "rss_ratio": 0.999873,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.909102,
+            "ci": [
+              0.90805,
+              0.9117
+            ],
+            "observations": 3,
+            "candidate": 49.344157868
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999873,
+            "ci": [
+              0.999479,
+              1.000545
+            ],
+            "observations": 3,
+            "candidate": 1290.2675247192383
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 58117.0
+          }
+        },
+        "report_sha256s": [
+          "0fadbf5a9f99addcab1f3ff45ed1eaf0b0844a5ab9be13f5909e55d190d00809",
+          "0a0ddac0c537e685665fca0a820d64f3e6477c4c52c41f6bed3f07a382a34efc",
+          "546e45f54ffd6206543e9abb8d73b997105515d4fb0af34604d6232cb426dfaf",
+          "bd569a5faadfbd2e1e3d7ea2e583a76a576141483e4a6ca84e79ef283943988c",
+          "e282f24ad66f033ab3a050eb6755e312ef2a8287c129f3d0cf0e2efc77ed8ec0",
+          "33c4678c0ad30361f38161f1147f5d052259263273f26960a7c8789debe8575d"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_sha2_512b": {
+        "round_ratios": [
+          0.94109,
+          0.91526,
+          0.919354,
+          0.955732,
+          0.925453
+        ],
+        "proof_digest": "a5c7b4e54d0ba913b0ae1f58c77ea823826e0ba776a4a2673be2ab6dc3bcb74a",
+        "request_ratio": 0.948368,
+        "rss_ratio": 1.000495,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.90254,
+            "ci": [
+              0.900775,
+              0.90427
+            ],
+            "observations": 5,
+            "candidate": 62.40659334
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000495,
+            "ci": [
+              0.999841,
+              1.001455
+            ],
+            "observations": 5,
+            "candidate": 1375.689582824707
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 78496.0
+          }
+        },
+        "report_sha256s": [
+          "73631ffac4a768b06bdc15dfb0ee4c2ce56538b3303561952cb50b9312630f79",
+          "d27ed15fc7b5483bee38aa3bfe4d1c0a662e0d2ae034e54fa37df63499c1f6b4",
+          "c7587509f4dd0f8ffff260a6146a3a9fafe1a00544177ef3bff7233a4cb37621",
+          "52c97491ce7c8755bd8165459e7d95a2b872225e8246a4875a310f790b0c3b1c",
+          "ede330e49151d1744e1823285fed423dbec998cc2331e361d980da462289a870",
+          "c384610e78e71815cadd9792bea20c89235f6e63b2a7b673ef7232f32b6a6683",
+          "4f4f8baee8308db98fec957056aca2ac1595d811a98a48527d8ddda61686d0d0",
+          "21fbba96e20878f87fa5dfe6912388bf9bf9fa4e2f5f4cd348479c52438f8a62",
+          "104a182886bd97304100e04d3176973c9345c7cbf58598a5b86c46b9bcf1d059",
+          "7adf9eca1b515bebcd5512b92c8808f8c7198ca7af5e44290cb8393328417f02"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_sha2_1024b": {
+        "round_ratios": [
+          0.941298,
+          0.94857,
+          0.933135,
+          0.952019,
+          0.938856
+        ],
+        "proof_digest": "63bbad02c8806622b99eba191ca9d1333ba77abd2f1486e2838525542d36cc50",
+        "request_ratio": 0.949186,
+        "rss_ratio": 1.000679,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.907174,
+            "ci": [
+              0.904223,
+              0.91044
+            ],
+            "observations": 5,
+            "candidate": 69.888108492
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000679,
+            "ci": [
+              1.000388,
+              1.001002
+            ],
+            "observations": 5,
+            "candidate": 1428.6117095947266
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 76677.0
+          }
+        },
+        "report_sha256s": [
+          "381e2e9b17094b72b2faeffe687d258ae2dbced4fd04b84ca6fc606b181667a1",
+          "daa2525dca982ae8e45319bd86c19280dc46e5bc4091ff98e5c4df055c9275f4",
+          "5744b46de389c88ff82fea0325ad40c7124987363cfc454b189bcab124a9f44e",
+          "6b5e5b190b9c9a2282372e38e6240894bd54fc0cd4189b851793414ad8b48e7d",
+          "1255470c57eb267dc9419f6cf1fc7fce1f1f1fd36fe63303a691f0ecb1e3c0b5",
+          "acce72c9a27c0b4a3247538e3a5ab9f866229dde88592620edc1b13e8ba2c6e0",
+          "315d63a7c4a3edb86405a09ba0e1030e372d94dcbd650c522bd16bd123fca54a",
+          "48a5073dd64d42b398caa28235885f38916795a0415357beba1b6d9eb16b6a9e",
+          "05b674ba632e8bae1d26267da1526a40cefd52f3a6f89204905e448c08bb14fa",
+          "392de553691b7428ce6456951d086f0d6641fde28453d540b08c7a6f7d11afc1"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_sha2_2048b": {
+        "round_ratios": [
+          0.947817,
+          0.950579,
+          0.941542
+        ],
+        "proof_digest": "adaa94716e7010c04814b2b574b3b7cb788f76f31f8258ad2a737bae68f1b851",
+        "request_ratio": 0.957948,
+        "rss_ratio": 1.002354,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.918976,
+            "ci": [
+              0.916459,
+              0.920288
+            ],
+            "observations": 3,
+            "candidate": 78.44976665
+          },
+          "peak_rss_mib": {
+            "ratio": 1.002354,
+            "ci": [
+              0.999657,
+              1.003734
+            ],
+            "observations": 3,
+            "candidate": 1502.9711532592773
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 81115.0
+          }
+        },
+        "report_sha256s": [
+          "42182b10eb144b661c4e4d2af77321c03afa064deb2977949dc4dbc8697de5fa",
+          "57df3ed1d976ed7c08658165bd1f2accf7ac3a0b44bad114ae9b43da99ed7e94",
+          "8bb10ffb3472741669fcf3890e11ee1b4c6dff105f43dfc7dd431b09a8aca457",
+          "7767347c7972d1b34db886f977e7242bb0486fc606ce2d41f31c83081e5ac182",
+          "ac741d6a0b4f3c75a798749f86c882b92116f4e1bf322e241b97b34bfbba09c0",
+          "5e5429cc70d8688521b55ab7074e64f403d18b2955034fd5513aede230b9e10e"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_xorshift_prng.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_xorshift_prng.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_xorshift_prng.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_xorshift_prng.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_xorshift_prng.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_xorshift_prng.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_fib_iter.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_fib_iter.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_fib_iter.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_fib_iter.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_fib_iter.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_fib_iter.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_gcd_euclid.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_gcd_euclid.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_gcd_euclid.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_gcd_euclid.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_gcd_euclid.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_gcd_euclid.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_multi_shard_addi.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_multi_shard_addi.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_multi_shard_addi.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_multi_shard_addi.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_multi_shard_addi.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_multi_shard_addi.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_512b.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_512b.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_512b.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_512b.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_512b.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_512b.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_512b.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_512b.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_512b.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_512b.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_1024b.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_1024b.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_1024b.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_1024b.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_1024b.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_1024b.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_1024b.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_1024b.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_1024b.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_1024b.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_2048b.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_2048b.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_2048b.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_2048b.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_2048b.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch4/autoresearch/.runs/latest/riscv_sha2_2048b.b3.json"
+    ]
+  }
+}

--- a/src/core/crypto/blake2s_backend.zig
+++ b/src/core/crypto/blake2s_backend.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const stream4 = @import("blake2s_stream4.zig");
 
 pub const Blake2sHash = [32]u8;
 
@@ -363,6 +364,52 @@ pub const Blake2sHasher = struct {
         compressParallel4(&states, &final_messages, counter, 0, 0xFFFF_FFFF);
 
         return parallelStatesToDigests(&states);
+    }
+
+    pub fn finalizeEqualTail4(
+        hashers: *const [4]Self,
+        tails: *const [4][]const u8,
+    ) [4]Blake2sHash {
+        return stream4.finalizeEqualTail4(
+            Self,
+            V4,
+            Blake2sHash,
+            hashers,
+            tails,
+            loadParallelBlock4,
+            compressParallel4,
+            parallelStatesToDigests,
+        );
+    }
+
+    pub fn updateEqual4(
+        hashers: *[4]Self,
+        data: *const [4][]const u8,
+    ) void {
+        stream4.updateEqual4(
+            Self,
+            V4,
+            hashers,
+            data,
+            loadParallelBlock4,
+            compressParallel4,
+        );
+    }
+
+    pub fn updateM31Columns4(
+        hashers: *[4]Self,
+        columns: anytype,
+        position: usize,
+    ) void {
+        stream4.updateM31Columns4(
+            Self,
+            V4,
+            hashers,
+            columns,
+            position,
+            loadParallelBlock4,
+            compressParallel4,
+        );
     }
 
     /// Hashes four equal-length M31 leaf messages directly from column-major

--- a/src/core/crypto/blake2s_stream4.zig
+++ b/src/core/crypto/blake2s_stream4.zig
@@ -1,0 +1,231 @@
+//! Four-message continuation helpers for independent BLAKE2s streams.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+fn gatherStates(comptime State: type, comptime V4: type, hashers: *const [4]State) [8]V4 {
+    var states: [8]V4 = undefined;
+    for (0..8) |word_index| {
+        states[word_index] = .{
+            hashers[0].h[word_index],
+            hashers[1].h[word_index],
+            hashers[2].h[word_index],
+            hashers[3].h[word_index],
+        };
+    }
+    return states;
+}
+
+fn scatterStates(
+    comptime State: type,
+    comptime V4: type,
+    hashers: *[4]State,
+    states: *const [8]V4,
+    t0: u32,
+    t1: u32,
+    buf_len: usize,
+) void {
+    for (0..4) |lane| {
+        for (0..8) |word_index| hashers[lane].h[word_index] = states[word_index][lane];
+        hashers[lane].t0 = t0;
+        hashers[lane].t1 = t1;
+        hashers[lane].buf_len = buf_len;
+    }
+}
+
+fn addBlockCounter(t0: *u32, t1: *u32) void {
+    const sum = @as(u64, t0.*) + 64;
+    t0.* = @truncate(sum);
+    t1.* +%= @intCast(sum >> 32);
+}
+
+fn assertCompatible(comptime State: type, hashers: *const [4]State) void {
+    for (0..4) |lane| {
+        std.debug.assert(!hashers[lane].finalized);
+        std.debug.assert(hashers[lane].buf_len == hashers[0].buf_len);
+        std.debug.assert(hashers[lane].t0 == hashers[0].t0);
+        std.debug.assert(hashers[lane].t1 == hashers[0].t1);
+        std.debug.assert(hashers[lane].selection.effective == hashers[0].selection.effective);
+    }
+}
+
+pub fn finalizeEqualTail4(
+    comptime State: type,
+    comptime V4: type,
+    comptime Hash: type,
+    hashers: *const [4]State,
+    tails: *const [4][]const u8,
+    comptime loadParallelBlock4: fn (*const [4][64]u8, *[16]V4) void,
+    comptime compressParallel4: fn (*[8]V4, *const [16]V4, u32, u32, u32) void,
+    comptime statesToDigests: fn (*const [8]V4) [4]Hash,
+) [4]Hash {
+    assertCompatible(State, hashers);
+    const tail_len = tails[0].len;
+    for (0..4) |lane| {
+        std.debug.assert(tails[lane].len == tail_len);
+        std.debug.assert(tail_len <= 64 - hashers[lane].buf_len);
+    }
+    if (hashers[0].selection.effective == .scalar) {
+        var out: [4]Hash = undefined;
+        for (&out, 0..) |*digest, lane| {
+            var hasher = hashers[lane];
+            hasher.update(tails[lane]);
+            digest.* = hasher.finalize();
+        }
+        return out;
+    }
+
+    var blocks = [_][64]u8{[_]u8{0} ** 64} ** 4;
+    for (0..4) |lane| {
+        const buffered = hashers[lane].buf_len;
+        @memcpy(blocks[lane][0..buffered], hashers[lane].buf[0..buffered]);
+        @memcpy(blocks[lane][buffered .. buffered + tail_len], tails[lane]);
+    }
+    var messages: [16]V4 = undefined;
+    loadParallelBlock4(&blocks, &messages);
+    var states = gatherStates(State, V4, hashers);
+    const increment = hashers[0].buf_len + tail_len;
+    const counter_sum = @as(u64, hashers[0].t0) + @as(u64, @intCast(increment));
+    const t0: u32 = @truncate(counter_sum);
+    const t1 = hashers[0].t1 +% @as(u32, @intCast(counter_sum >> 32));
+    compressParallel4(&states, &messages, t0, t1, 0xFFFF_FFFF);
+    return statesToDigests(&states);
+}
+
+pub fn updateEqual4(
+    comptime State: type,
+    comptime V4: type,
+    hashers: *[4]State,
+    data: *const [4][]const u8,
+    comptime loadParallelBlock4: fn (*const [4][64]u8, *[16]V4) void,
+    comptime compressParallel4: fn (*[8]V4, *const [16]V4, u32, u32, u32) void,
+) void {
+    assertCompatible(State, hashers);
+    const data_len = data[0].len;
+    for (data) |message| std.debug.assert(message.len == data_len);
+    if (data_len == 0) return;
+    if (hashers[0].selection.effective == .scalar) {
+        for (0..4) |lane| hashers[lane].update(data[lane]);
+        return;
+    }
+
+    var states = gatherStates(State, V4, hashers);
+    var t0 = hashers[0].t0;
+    var t1 = hashers[0].t1;
+    var buf_len = hashers[0].buf_len;
+    var at: usize = 0;
+    if (buf_len > 0 or data_len <= 64) {
+        const copy_len = @min(64 - buf_len, data_len);
+        for (0..4) |lane| {
+            @memcpy(hashers[lane].buf[buf_len .. buf_len + copy_len], data[lane][0..copy_len]);
+        }
+        buf_len += copy_len;
+        at += copy_len;
+        if (buf_len < 64 or at == data_len) {
+            for (0..4) |lane| hashers[lane].buf_len = buf_len;
+            return;
+        }
+        addBlockCounter(&t0, &t1);
+        var blocks: [4][64]u8 = undefined;
+        for (0..4) |lane| blocks[lane] = hashers[lane].buf;
+        var messages: [16]V4 = undefined;
+        loadParallelBlock4(&blocks, &messages);
+        compressParallel4(&states, &messages, t0, t1, 0);
+        buf_len = 0;
+    }
+    while (at + 64 < data_len) : (at += 64) {
+        var blocks: [4][64]u8 = undefined;
+        for (0..4) |lane| @memcpy(blocks[lane][0..], data[lane][at .. at + 64]);
+        var messages: [16]V4 = undefined;
+        loadParallelBlock4(&blocks, &messages);
+        addBlockCounter(&t0, &t1);
+        compressParallel4(&states, &messages, t0, t1, 0);
+    }
+    const remaining = data_len - at;
+    for (0..4) |lane| @memcpy(hashers[lane].buf[0..remaining], data[lane][at..]);
+    scatterStates(State, V4, hashers, &states, t0, t1, remaining);
+}
+
+pub fn updateM31Columns4(
+    comptime State: type,
+    comptime V4: type,
+    hashers: *[4]State,
+    columns: anytype,
+    position: usize,
+    comptime loadParallelBlock4: fn (*const [4][64]u8, *[16]V4) void,
+    comptime compressParallel4: fn (*[8]V4, *const [16]V4, u32, u32, u32) void,
+) void {
+    assertCompatible(State, hashers);
+    for (columns) |column| std.debug.assert(position + 4 <= column.values.len);
+    if (columns.len == 0) return;
+    if (hashers[0].selection.effective == .scalar or
+        comptime builtin.cpu.arch.endian() != .little)
+    {
+        for (0..4) |lane| {
+            for (columns) |column| {
+                var encoded: [4]u8 = undefined;
+                std.mem.writeInt(u32, &encoded, column.values[position + lane].v, .little);
+                hashers[lane].update(&encoded);
+            }
+        }
+        return;
+    }
+
+    std.debug.assert((hashers[0].buf_len & 3) == 0);
+    var states = gatherStates(State, V4, hashers);
+    var t0 = hashers[0].t0;
+    var t1 = hashers[0].t1;
+    var buffered_words = hashers[0].buf_len / @sizeOf(u32);
+    var word_at: usize = 0;
+    if (buffered_words > 0 or columns.len <= 16) {
+        const copy_words = @min(16 - buffered_words, columns.len);
+        for (0..copy_words) |word| {
+            for (0..4) |lane| {
+                var encoded: [4]u8 = undefined;
+                std.mem.writeInt(u32, &encoded, columns[word].values[position + lane].v, .little);
+                const byte_start = (buffered_words + word) * @sizeOf(u32);
+                @memcpy(hashers[lane].buf[byte_start .. byte_start + 4], encoded[0..]);
+            }
+        }
+        buffered_words += copy_words;
+        word_at += copy_words;
+        if (buffered_words < 16 or word_at == columns.len) {
+            for (0..4) |lane| hashers[lane].buf_len = buffered_words * @sizeOf(u32);
+            return;
+        }
+        addBlockCounter(&t0, &t1);
+        var blocks: [4][64]u8 = undefined;
+        for (0..4) |lane| blocks[lane] = hashers[lane].buf;
+        var messages: [16]V4 = undefined;
+        loadParallelBlock4(&blocks, &messages);
+        compressParallel4(&states, &messages, t0, t1, 0);
+        buffered_words = 0;
+    }
+    while (word_at + 16 < columns.len) : (word_at += 16) {
+        var messages: [16]V4 = undefined;
+        inline for (0..16) |word| {
+            const values: *const [4]u32 = @ptrCast(columns[word_at + word].values.ptr + position);
+            messages[word] = values.*;
+        }
+        addBlockCounter(&t0, &t1);
+        compressParallel4(&states, &messages, t0, t1, 0);
+    }
+    const remaining_words = columns.len - word_at;
+    for (0..remaining_words) |word| {
+        for (0..4) |lane| {
+            var encoded: [4]u8 = undefined;
+            std.mem.writeInt(u32, &encoded, columns[word_at + word].values[position + lane].v, .little);
+            const byte_start = word * @sizeOf(u32);
+            @memcpy(hashers[lane].buf[byte_start .. byte_start + 4], encoded[0..]);
+        }
+    }
+    scatterStates(
+        State,
+        V4,
+        hashers,
+        &states,
+        t0,
+        t1,
+        remaining_words * @sizeOf(u32),
+    );
+}

--- a/src/core/crypto/mod.zig
+++ b/src/core/crypto/mod.zig
@@ -1,1 +1,2 @@
 pub const hash256 = @import("hash256.zig");
+pub const blake2s_backend = @import("blake2s_backend.zig");

--- a/src/core/crypto/tests/blake2s_backend.zig
+++ b/src/core/crypto/tests/blake2s_backend.zig
@@ -119,3 +119,54 @@ test "blake2s backend: fixed-seed scalar and simd modes cover boundaries and una
         }
     }
 }
+
+test "blake2s backend: four-way incremental updates preserve independent streams" {
+    var prng = std.Random.DefaultPrng.init(0x7570_6461_7465_345f);
+    var prefixes: [4][93]u8 = undefined;
+    var updates: [4][257]u8 = undefined;
+    var update_views: [4][]const u8 = undefined;
+    var batched: [4]Blake2sHasher = undefined;
+    var expected: [4]Blake2sHasher = undefined;
+    for (0..4) |lane| {
+        prng.random().bytes(prefixes[lane][0..]);
+        prng.random().bytes(updates[lane][0..]);
+        batched[lane] = Blake2sHasher.initWithMode(.simd);
+        batched[lane].update(prefixes[lane][0..]);
+        expected[lane] = batched[lane];
+        update_views[lane] = updates[lane][0..];
+    }
+
+    Blake2sHasher.updateEqual4(&batched, &update_views);
+    for (0..4) |lane| {
+        expected[lane].update(update_views[lane]);
+        try std.testing.expectEqualSlices(
+            u8,
+            expected[lane].finalize()[0..],
+            batched[lane].finalize()[0..],
+        );
+    }
+}
+
+test "blake2s backend: four-way final tails preserve independent states" {
+    var prng = std.Random.DefaultPrng.init(0x7461_696c_7334_5f78);
+    var prefixes: [4][100]u8 = undefined;
+    var tails: [4][20]u8 = undefined;
+    var tail_views: [4][]const u8 = undefined;
+    var states: [4]Blake2sHasher = undefined;
+    var expected: [4]backend.Blake2sHash = undefined;
+    for (0..4) |lane| {
+        prng.random().bytes(prefixes[lane][0..]);
+        prng.random().bytes(tails[lane][0..]);
+        states[lane] = Blake2sHasher.initWithMode(.simd);
+        states[lane].update(prefixes[lane][0..]);
+        var sequential = states[lane];
+        sequential.update(tails[lane][0..]);
+        expected[lane] = sequential.finalize();
+        tail_views[lane] = tails[lane][0..];
+    }
+
+    const actual = Blake2sHasher.finalizeEqualTail4(&states, &tail_views);
+    for (0..4) |lane| {
+        try std.testing.expectEqualSlices(u8, expected[lane][0..], actual[lane][0..]);
+    }
+}

--- a/src/prover/pcs/scheme.zig
+++ b/src/prover/pcs/scheme.zig
@@ -353,10 +353,9 @@ pub fn CommitmentSchemeProver(comptime B: type, comptime H: type, comptime MC: t
         ///   1. Call `streamingTreeBuilder()` to obtain a builder.
         ///   2. Call `builder.addColumns(batch)` for each batch of
         ///      `ColumnEvaluation` (owned values).  The batch data is prepared
-        ///      (interpolated + extended), hashed into the Merkle leaf layer,
-        ///      and the extended column data is freed immediately.
-        ///   3. Call `builder.commit(channel)` to finalise the Merkle tree and
-        ///      append it to the commitment scheme.
+        ///      (interpolated + extended) and retained for decommitment.
+        ///   3. Call `builder.commit(channel)` to hash the complete sorted shape,
+        ///      finalise the Merkle tree, and append it to the scheme.
         ///
         /// The final Merkle root is bit-identical to `commitOwned()`.
         pub fn streamingTreeBuilder(
@@ -372,12 +371,11 @@ pub fn CommitmentSchemeProver(comptime B: type, comptime H: type, comptime MC: t
         }
 
         /// Commits owned evaluation columns in streaming batches to reduce peak
-        /// memory.  Semantically identical to `commitOwned()` but processes
-        /// columns in groups of `batch_size`, freeing each batch's extended
-        /// evaluation data before the next batch is prepared.
+        /// memory. Semantically identical to `commitOwned()` but prepares
+        /// columns in groups of `batch_size` before one shape-aware leaf pass.
         ///
-        /// `batch_size` controls the number of columns prepared and hashed in
-        /// each round.  A value of 0 uses the default (64).
+        /// `batch_size` controls the number of columns prepared in each round.
+        /// A value of 0 uses the default (64).
         pub fn commitOwnedStreaming(
             self: *Self,
             allocator: std.mem.Allocator,

--- a/src/prover/pcs/tree_builders.zig
+++ b/src/prover/pcs/tree_builders.zig
@@ -117,9 +117,9 @@ fn adoptStreamingCommitment(
     @compileError("Backend-specific Merkle trees require `adoptHostMerkle` for streaming PCS commits.");
 }
 
-/// A streaming tree builder that commits columns in configurable batches,
-/// building the Merkle leaf layer incrementally and freeing each batch's
-/// extended column data before the next batch is prepared.
+/// A streaming tree builder that prepares columns in configurable batches,
+/// then incrementally hashes the complete height-sorted column set. Retaining
+/// the complete shape enables sparse high-domain tail finalization.
 ///
 /// The resulting Merkle root is bit-identical to building the tree from all
 /// columns at once.
@@ -130,7 +130,7 @@ pub fn StreamingTreeBuilder(comptime B: type, comptime H: type, comptime MC: typ
         commitment_scheme: *Scheme,
         batch_size: usize,
 
-        /// Streaming Merkle committer that accumulates leaf hashes incrementally.
+        /// Streaming Merkle committer used for the height-grouped leaf pass.
         streaming_committer: MerkleProver.StreamingCommitter,
 
         /// Columns retained for later decommitment and sampled-value evaluation.
@@ -183,8 +183,8 @@ pub fn StreamingTreeBuilder(comptime B: type, comptime H: type, comptime MC: typ
         }
 
         /// Add a batch of owned columns.  The column values are consumed:
-        /// they are interpolated, extended to the commitment domain, hashed into
-        /// the streaming Merkle leaf layer, and the *original* values freed.
+        /// they are interpolated, extended to the commitment domain, retained for
+        /// the Merkle leaf pass, and the *original* values freed.
         /// The *extended* values are retained (needed for decommitment).
         ///
         /// Columns MUST be supplied so that within each call (and across calls)
@@ -238,24 +238,12 @@ pub fn StreamingTreeBuilder(comptime B: type, comptime H: type, comptime MC: typ
             };
             errdefer prepared.deinit(self.allocator);
 
-            // Build sorted ColumnRef array for the streaming Merkle committer.
-            const col_refs = try self.allocator.alloc([]const M31, prepared.columns.len);
-            defer self.allocator.free(col_refs);
-            for (prepared.columns, 0..) |col, i| {
-                col_refs[i] = col.values;
-            }
-            const sorted = try MerkleProver.sortColumnsByLogSizeAsc(self.allocator, col_refs);
-            defer self.allocator.free(sorted);
-
             // Pre-allocate space in retained lists before any ownership transfer.
             try self.retained_columns.ensureUnusedCapacity(self.allocator, prepared.columns.len);
             try self.retained_column_indices.ensureUnusedCapacity(self.allocator, prepared.columns.len);
             if (prepared.coefficients) |coeffs| {
                 try self.retained_coefficients.ensureUnusedCapacity(self.allocator, coeffs.len);
             }
-
-            // Feed into streaming Merkle leaf layer.
-            try self.streaming_committer.addColumns(sorted);
 
             // From here, all operations are guaranteed not to fail (no try).
             // Retain extended columns (needed for decommitment and quotient evaluation).
@@ -282,8 +270,17 @@ pub fn StreamingTreeBuilder(comptime B: type, comptime H: type, comptime MC: typ
         /// the root into the channel, and append the tree to the commitment
         /// scheme.
         pub fn commit(self: *Self, channel: anytype) !void {
-            // Finalize the Merkle tree.
-            var merkle = try self.streaming_committer.finalize();
+            const col_refs = try self.allocator.alloc([]const M31, self.retained_columns.items.len);
+            defer self.allocator.free(col_refs);
+            for (self.retained_columns.items, col_refs) |column, *reference| {
+                reference.* = column.values;
+            }
+            const sorted = try MerkleProver.sortColumnsByLogSizeAsc(self.allocator, col_refs);
+            defer self.allocator.free(sorted);
+
+            // Preserve incremental lifted hashing for the dense prefix, while
+            // allowing the committer to bypass sparse high-domain expansions.
+            var merkle = try self.streaming_committer.commitColumnsWithSparseTail(sorted);
             // streaming_committer is now consumed; reinitialize to safe state for deinit.
             self.streaming_committer = MerkleProver.StreamingCommitter.init(self.allocator);
             errdefer merkle.deinit(self.allocator);

--- a/src/prover/vcs_lifted/blake2_stream4.zig
+++ b/src/prover/vcs_lifted/blake2_stream4.zig
@@ -1,0 +1,103 @@
+//! Prover-side adapter for four-message BLAKE2s leaf continuation.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const stwo_core = @import("stwo_core");
+
+const M31 = stwo_core.fields.m31.M31;
+const BackendHasher = stwo_core.crypto.blake2s_backend.Blake2sHasher;
+const CoreHasher = stwo_core.vcs_lifted.blake2_merkle.Blake2sMerkleHasher;
+
+pub fn supports(comptime H: type) bool {
+    return H == CoreHasher;
+}
+
+fn loadStates(hashers: *const [4]CoreHasher) [4]BackendHasher {
+    var states: [4]BackendHasher = undefined;
+    for (0..4) |lane| states[lane] = hashers[lane].inner.ctx;
+    return states;
+}
+
+fn storeStates(hashers: *[4]CoreHasher, states: *const [4]BackendHasher) void {
+    for (0..4) |lane| hashers[lane].inner.ctx = states[lane];
+}
+
+pub fn updatePacked4(
+    hashers: *[4]CoreHasher,
+    packed_bytes: *const [4][]const u8,
+) void {
+    var states = loadStates(hashers);
+    BackendHasher.updateEqual4(&states, packed_bytes);
+    storeStates(hashers, &states);
+}
+
+pub fn updateM31Columns4(
+    hashers: *[4]CoreHasher,
+    columns: anytype,
+    position: usize,
+) void {
+    var states = loadStates(hashers);
+    BackendHasher.updateM31Columns4(&states, columns, position);
+    storeStates(hashers, &states);
+}
+
+pub fn finalize4(hashers: *const [4]CoreHasher) [4]CoreHasher.Hash {
+    const states = loadStates(hashers);
+    const empty = [_]u8{};
+    const tails = [_][]const u8{empty[0..]} ** 4;
+    return BackendHasher.finalizeEqualTail4(&states, &tails);
+}
+
+pub fn finalizeTail4(
+    hashers: *const [4]CoreHasher,
+    tail_values: *const [4][]const M31,
+) [4]CoreHasher.Hash {
+    if (comptime builtin.cpu.arch.endian() != .little) {
+        var out: [4]CoreHasher.Hash = undefined;
+        for (&out, 0..) |*digest, lane| {
+            var hasher = hashers[lane];
+            hasher.updateLeaf(tail_values[lane]);
+            digest.* = hasher.finalize();
+        }
+        return out;
+    }
+
+    const states = loadStates(hashers);
+    var byte_views: [4][]const u8 = undefined;
+    for (0..4) |lane| byte_views[lane] = std.mem.sliceAsBytes(tail_values[lane]);
+    return BackendHasher.finalizeEqualTail4(&states, &byte_views);
+}
+
+test "prover lifted BLAKE2s: direct continuation matches scalar streams" {
+    const Column = struct { values: []const M31 };
+    var prefixes: [4][17]M31 = undefined;
+    var storage: [33][4]M31 = undefined;
+    var columns: [storage.len]Column = undefined;
+    var expected: [4]CoreHasher = undefined;
+    var actual: [4]CoreHasher = undefined;
+
+    for (0..4) |lane| {
+        for (&prefixes[lane], 0..) |*value, index| {
+            value.* = M31.fromCanonical(@intCast(3 + lane * 701 + index * 29));
+        }
+        expected[lane] = CoreHasher.defaultWithInitialState();
+        expected[lane].updateLeaf(prefixes[lane][0..]);
+        actual[lane] = expected[lane];
+    }
+    for (&storage, &columns, 0..) |*values, *column, column_index| {
+        for (values, 0..) |*value, lane| {
+            value.* = M31.fromCanonical(@intCast(7 + column_index * 43 + lane * 101));
+        }
+        column.* = .{ .values = values };
+    }
+
+    updateM31Columns4(&actual, &columns, 0);
+    for (0..4) |lane| {
+        var row: [storage.len]M31 = undefined;
+        for (storage, 0..) |values, column_index| row[column_index] = values[lane];
+        expected[lane].updateLeaf(row[0..]);
+        const expected_hash = expected[lane].finalize();
+        const actual_hash = actual[lane].finalize();
+        try std.testing.expectEqualSlices(u8, expected_hash[0..], actual_hash[0..]);
+    }
+}

--- a/src/prover/vcs_lifted/leaves.zig
+++ b/src/prover/vcs_lifted/leaves.zig
@@ -7,6 +7,7 @@ const work_pool_mod = @import("../work_pool.zig");
 const columns_mod = @import("columns.zig");
 const layers_mod = @import("layers.zig");
 const parameters = @import("parameters.zig");
+const blake2_stream4 = @import("blake2_stream4.zig");
 
 pub fn Operations(comptime H: type) type {
     return struct {
@@ -375,6 +376,124 @@ pub fn Operations(comptime H: type) type {
             return out;
         }
 
+        pub const max_lifted_tail_columns: usize = 15;
+
+        const LiftedTailRangeCtx = struct {
+            base_hashers: []const H,
+            base_log_size: u32,
+            tail_columns: []const ColumnRef,
+            final_log_size: u32,
+            out: []H.Hash,
+            start: usize,
+            end: usize,
+        };
+
+        fn liftedTailBaseIndex(ctx: *const LiftedTailRangeCtx, position: usize) usize {
+            const base_shift: std.math.Log2Int(usize) = @intCast(
+                ctx.final_log_size - ctx.base_log_size + 1,
+            );
+            return ((position >> base_shift) << 1) + (position & 1);
+        }
+
+        fn fillLiftedTailValues(
+            ctx: *const LiftedTailRangeCtx,
+            position: usize,
+            values: *[max_lifted_tail_columns]M31,
+        ) void {
+            for (ctx.tail_columns, 0..) |column, column_index| {
+                const column_shift: std.math.Log2Int(usize) = @intCast(
+                    ctx.final_log_size - column.log_size + 1,
+                );
+                const source_index = ((position >> column_shift) << 1) + (position & 1);
+                values[column_index] = column.values[source_index];
+            }
+        }
+
+        fn finalizeLiftedTailOne(ctx: *const LiftedTailRangeCtx, position: usize) void {
+            var tail_values: [max_lifted_tail_columns]M31 = undefined;
+            fillLiftedTailValues(ctx, position, &tail_values);
+            var hasher = ctx.base_hashers[liftedTailBaseIndex(ctx, position)];
+            hasher.updateLeaf(tail_values[0..ctx.tail_columns.len]);
+            ctx.out[position] = hasher.finalize();
+        }
+
+        fn finalizeLiftedTailRange(ctx: *const LiftedTailRangeCtx) void {
+            var position = ctx.start;
+
+            if (comptime blake2_stream4.supports(H)) {
+                while (position < ctx.end and (position & 3) != 0) : (position += 1) {
+                    finalizeLiftedTailOne(ctx, position);
+                }
+                while (position + 4 <= ctx.end) : (position += 4) {
+                    var hashers: [4]H = undefined;
+                    var tail_storage: [4][max_lifted_tail_columns]M31 = undefined;
+                    var tail_views: [4][]const M31 = undefined;
+                    inline for (0..4) |lane| {
+                        const lane_position = position + lane;
+                        hashers[lane] = ctx.base_hashers[liftedTailBaseIndex(ctx, lane_position)];
+                        fillLiftedTailValues(ctx, lane_position, &tail_storage[lane]);
+                        tail_views[lane] = tail_storage[lane][0..ctx.tail_columns.len];
+                    }
+                    const hashes = blake2_stream4.finalizeTail4(&hashers, &tail_views);
+                    inline for (0..4) |lane| ctx.out[position + lane] = hashes[lane];
+                }
+            }
+
+            while (position < ctx.end) : (position += 1) {
+                finalizeLiftedTailOne(ctx, position);
+            }
+        }
+
+        /// Finalizes a lifted leaf layer without materializing intermediate
+        /// hasher arrays when the remaining M31 values fit in the current
+        /// terminal hash block. The caller proves that no compression occurs
+        /// between `base_hashers` and finalization.
+        pub fn finalizeLiftedTail(
+            base_hashers: []const H,
+            base_log_size: u32,
+            tail_columns: []const ColumnRef,
+            final_log_size: u32,
+            out: []H.Hash,
+        ) void {
+            std.debug.assert(tail_columns.len > 0);
+            std.debug.assert(tail_columns.len <= max_lifted_tail_columns);
+            std.debug.assert(out.len == @as(usize, 1) << @intCast(final_log_size));
+
+            const pool = work_pool_mod.getGlobalPool();
+            const worker_capacity = out.len / parallel_min_nodes_per_worker;
+            const worker_count = if (pool) |active_pool|
+                @max(@as(usize, 1), @min(active_pool.workerCount(), worker_capacity))
+            else
+                1;
+            var contexts: [max_parallel_workers]LiftedTailRangeCtx = undefined;
+            for (0..worker_count) |worker| {
+                const start = out.len * worker / worker_count;
+                const end = out.len * (worker + 1) / worker_count;
+                contexts[worker] = .{
+                    .base_hashers = base_hashers,
+                    .base_log_size = base_log_size,
+                    .tail_columns = tail_columns,
+                    .final_log_size = final_log_size,
+                    .out = out,
+                    .start = start,
+                    .end = end,
+                };
+            }
+
+            if (worker_count > 1) {
+                var wait_group: WaitGroup = .{};
+                for (contexts[1..worker_count]) |*ctx| {
+                    pool.?.spawnWg(&wait_group, finalizeLiftedTailRange, .{
+                        @as(*const LiftedTailRangeCtx, ctx),
+                    });
+                }
+                finalizeLiftedTailRange(&contexts[0]);
+                wait_group.wait();
+            } else {
+                finalizeLiftedTailRange(&contexts[0]);
+            }
+        }
+
         const FinalizeRangeCtx = struct {
             hashers: []H,
             out: []H.Hash,
@@ -384,6 +503,13 @@ pub fn Operations(comptime H: type) type {
 
         fn finalizeRange(ctx: *const FinalizeRangeCtx) void {
             var i = ctx.start;
+            if (comptime blake2_stream4.supports(H)) {
+                while (i + 4 <= ctx.end) : (i += 4) {
+                    const hashers: *const [4]H = @ptrCast(ctx.hashers.ptr + i);
+                    const hashes = blake2_stream4.finalize4(hashers);
+                    inline for (0..4) |lane| ctx.out[i + lane] = hashes[lane];
+                }
+            }
             while (i < ctx.end) : (i += 1) {
                 ctx.out[i] = ctx.hashers[i].finalize();
             }
@@ -477,6 +603,31 @@ pub fn Operations(comptime H: type) type {
                 while (column_start < ctx.group_columns.len) {
                     const column_end = @min(ctx.group_columns.len, column_start + max_chunk_columns);
                     const column_chunk = ctx.group_columns[column_start..column_end];
+
+                    if (comptime blake2_stream4.supports(H)) {
+                        var local_leaf: usize = 0;
+                        while (local_leaf + 4 <= tile_size) : (local_leaf += 4) {
+                            const hashers: *[4]H = @ptrCast(
+                                ctx.leaf_hashers.ptr + tile_start + local_leaf,
+                            );
+                            blake2_stream4.updateM31Columns4(
+                                hashers,
+                                column_chunk,
+                                tile_start + local_leaf,
+                            );
+                        }
+                        while (local_leaf < tile_size) : (local_leaf += 1) {
+                            const leaf_index = tile_start + local_leaf;
+                            for (column_chunk) |column| {
+                                ctx.leaf_hashers[leaf_index].updateLeaf(
+                                    column.values[leaf_index .. leaf_index + 1],
+                                );
+                            }
+                        }
+                        column_start = column_end;
+                        continue;
+                    }
+
                     const bytes_per_leaf = column_chunk.len * @sizeOf(M31);
                     const scratch_len = tile_size * bytes_per_leaf;
                     packLeafTileBytes(
@@ -486,7 +637,8 @@ pub fn Operations(comptime H: type) type {
                         tile_size,
                     );
 
-                    for (0..tile_size) |local_leaf| {
+                    var local_leaf: usize = 0;
+                    while (local_leaf < tile_size) : (local_leaf += 1) {
                         const byte_start = local_leaf * bytes_per_leaf;
                         ctx.leaf_hashers[tile_start + local_leaf].updateLeafPackedBytes(
                             ctx.scratch[byte_start .. byte_start + bytes_per_leaf],

--- a/src/prover/vcs_lifted/prover.zig
+++ b/src/prover/vcs_lifted/prover.zig
@@ -535,43 +535,95 @@ pub fn MerkleProverLifted(comptime H: type) type {
                 }
             }
 
-            /// Finalize the streaming commitment: produce leaf hashes from the
-            /// accumulated hasher state, build internal Merkle layers, and return
-            /// the completed tree.  The `StreamingCommitter` is consumed (its
-            /// hasher memory is freed).
-            pub fn finalize(self: *StreamingCommitter) !Self {
-                const allocator = self.allocator;
-                const layer_alloc = layerAllocator(allocator);
-                if (!self.initialized) {
-                    // No columns were added — replicate the empty-column path
-                    // from buildLeaves.
-                    const seed_hasher = H.defaultWithInitialState();
-                    var h = seed_hasher;
-                    const leaves = try layer_alloc.alloc(H.Hash, 1);
-                    leaves[0] = h.finalize();
-
-                    var layers_bottom_up = std.ArrayList([]H.Hash).empty;
-                    defer layers_bottom_up.deinit(allocator);
-                    errdefer {
-                        for (layers_bottom_up.items) |layer| layer_alloc.free(layer);
+            /// Commits a complete sorted column set while retaining lifted
+            /// hasher-state reuse. When the final higher-domain columns fit in
+            /// the already-open terminal BLAKE2s block, their intermediate
+            /// expanded state arrays are bypassed and finalized directly.
+            pub fn commitColumnsWithSparseTail(
+                self: *StreamingCommitter,
+                columns: []const ColumnRef,
+            ) !Self {
+                for (columns, 0..) |column, index| {
+                    if (!std.math.isPowerOfTwo(column.values.len) or column.values.len < 2) {
+                        return error.InvalidColumnSize;
                     }
-                    try layers_bottom_up.append(allocator, leaves);
-
-                    const out_layers = try allocator.alloc([]H.Hash, 1);
-                    out_layers[0] = leaves;
-                    self.* = undefined;
-                    return .{ .layers = out_layers, .layer_allocator = layer_alloc };
+                    if (index > 0 and column.log_size < columns[index - 1].log_size) {
+                        return error.InvalidColumnOrder;
+                    }
                 }
 
-                // Finalize leaf hashers into leaf hashes.
-                const leaf_count = self.leaf_hashers.len;
+                const tail_start = liftedTailStart(columns) orelse {
+                    try self.addColumns(columns);
+                    return self.finalize();
+                };
+                try self.addColumns(columns[0..tail_start]);
+                return self.finalizeLiftedTail(columns[tail_start..]);
+            }
+
+            fn liftedTailStart(columns: []const ColumnRef) ?usize {
+                if (comptime !@hasDecl(H, "domainPrefixBytes")) return null;
+                if (H.domainPrefixBytes() != 64 or columns.len < 2) return null;
+
+                const final_log_size = columns[columns.len - 1].log_size;
+                var group_start: usize = 0;
+                while (group_start < columns.len) {
+                    const log_size = columns[group_start].log_size;
+                    var group_end = group_start + 1;
+                    while (group_end < columns.len and
+                        columns[group_end].log_size == log_size)
+                    {
+                        group_end += 1;
+                    }
+                    if (group_end == columns.len) return null;
+
+                    const buffered_words = if ((group_end & 15) == 0)
+                        @as(usize, 16)
+                    else
+                        group_end & 15;
+                    const tail_columns = columns.len - group_end;
+                    if (final_log_size >= log_size + 2 and
+                        tail_columns <= 16 - buffered_words and
+                        tail_columns <= LeafOps.max_lifted_tail_columns)
+                    {
+                        return group_end;
+                    }
+                    group_start = group_end;
+                }
+                return null;
+            }
+
+            fn finalizeLiftedTail(
+                self: *StreamingCommitter,
+                tail_columns: []const ColumnRef,
+            ) !Self {
+                std.debug.assert(self.initialized);
+                std.debug.assert(tail_columns.len > 0);
+                const allocator = self.allocator;
+                const layer_alloc = layerAllocator(allocator);
+                const final_log_size = tail_columns[tail_columns.len - 1].log_size;
+                std.debug.assert(final_log_size > self.leaf_log_size);
+                const leaf_count = @as(usize, 1) << @intCast(final_log_size);
                 const leaves = try layer_alloc.alloc(H.Hash, leaf_count);
-                LeafOps.finalizeHashers(self.leaf_hashers, leaves);
-                // Free hasher state — column data is no longer needed.
+                LeafOps.finalizeLiftedTail(
+                    self.leaf_hashers,
+                    self.leaf_log_size,
+                    tail_columns,
+                    final_log_size,
+                    leaves,
+                );
                 allocator.free(self.leaf_hashers);
                 self.leaf_hashers = &[_]H{};
 
-                // Build internal tree layers — identical to commitWithOptions.
+                const tree = try finishLeaves(allocator, layer_alloc, leaves);
+                self.* = undefined;
+                return tree;
+            }
+
+            fn finishLeaves(
+                allocator: std.mem.Allocator,
+                layer_alloc: std.mem.Allocator,
+                leaves: []H.Hash,
+            ) !Self {
                 const worker_override = merkleWorkerOverride(allocator);
                 const reuse_pool = merklePoolReuseEnabled(allocator);
 
@@ -607,8 +659,38 @@ pub fn MerkleProverLifted(comptime H: type) type {
                 while (i < out_layers.len) : (i += 1) {
                     out_layers[i] = layers_bottom_up.items[out_layers.len - 1 - i];
                 }
-                self.* = undefined;
                 return .{ .layers = out_layers, .layer_allocator = layer_alloc };
+            }
+
+            /// Finalize the streaming commitment: produce leaf hashes from the
+            /// accumulated hasher state, build internal Merkle layers, and return
+            /// the completed tree.  The `StreamingCommitter` is consumed (its
+            /// hasher memory is freed).
+            pub fn finalize(self: *StreamingCommitter) !Self {
+                const allocator = self.allocator;
+                const layer_alloc = layerAllocator(allocator);
+                if (!self.initialized) {
+                    // No columns were added — replicate the empty-column path
+                    // from buildLeaves.
+                    const seed_hasher = H.defaultWithInitialState();
+                    var h = seed_hasher;
+                    const leaves = try layer_alloc.alloc(H.Hash, 1);
+                    leaves[0] = h.finalize();
+                    const tree = try finishLeaves(allocator, layer_alloc, leaves);
+                    self.* = undefined;
+                    return tree;
+                }
+
+                // Finalize leaf hashers into leaf hashes.
+                const leaf_count = self.leaf_hashers.len;
+                const leaves = try layer_alloc.alloc(H.Hash, leaf_count);
+                LeafOps.finalizeHashers(self.leaf_hashers, leaves);
+                // Free hasher state — column data is no longer needed.
+                allocator.free(self.leaf_hashers);
+                self.leaf_hashers = &[_]H{};
+                const tree = try finishLeaves(allocator, layer_alloc, leaves);
+                self.* = undefined;
+                return tree;
             }
         };
 

--- a/src/prover/vcs_lifted/tests/commit_paths.zig
+++ b/src/prover/vcs_lifted/tests/commit_paths.zig
@@ -250,6 +250,42 @@ test "prover vcs_lifted: streaming committer produces identical root — many co
     try std.testing.expectEqualSlices(u8, expected_root[0..], streaming_prover.root()[0..]);
 }
 
+test "prover vcs_lifted: sparse terminal-block tail matches materialized commitment" {
+    const Hasher = @import("stwo_core").vcs_lifted.blake2_merkle.Blake2sMerkleHasher;
+    const Prover = MerkleProverLifted(Hasher);
+    const alloc = std.testing.allocator;
+
+    var base_storage: [13][16]M31 = undefined;
+    var middle_storage: [32]M31 = undefined;
+    var final_storage: [64]M31 = undefined;
+    var columns: [15][]const M31 = undefined;
+    for (&base_storage, 0..) |*values, column_index| {
+        for (values, 0..) |*value, row| {
+            value.* = M31.fromCanonical(@intCast(1 + column_index * 97 + row * 11));
+        }
+        columns[column_index] = values;
+    }
+    for (&middle_storage, 0..) |*value, row| {
+        value.* = M31.fromCanonical(@intCast(1701 + row * 13));
+    }
+    for (&final_storage, 0..) |*value, row| {
+        value.* = M31.fromCanonical(@intCast(2903 + row * 17));
+    }
+    columns[13] = &middle_storage;
+    columns[14] = &final_storage;
+
+    var reference = try Prover.commit(alloc, &columns);
+    defer reference.deinit(alloc);
+    const sorted = try Prover.sortColumnsByLogSizeAsc(alloc, &columns);
+    defer alloc.free(sorted);
+    var sparse = Prover.StreamingCommitter.init(alloc);
+    errdefer sparse.deinit();
+    var candidate = try sparse.commitColumnsWithSparseTail(sorted);
+    defer candidate.deinit(alloc);
+
+    try std.testing.expectEqualSlices(u8, reference.root()[0..], candidate.root()[0..]);
+}
+
 test "prover vcs_lifted: streaming committer empty columns" {
     const Hasher = @import("stwo_core").vcs_lifted.blake2_merkle.Blake2sMerkleHasher;
     const Prover = MerkleProverLifted(Hasher);


### PR DESCRIPTION
Directly continues four independent BLAKE2s leaf streams from equal-height column-major M31 data, eliminating row-major staging and sparse per-leaf state expansion.\n\nFull RISC-V deep S3 result: portfolio ratio 0.930236, 95% CI [0.927643, 0.933370], with all seven workloads winning. Energy ratio 0.907941, peak RSS 1.000545, proof bytes identical, pinned oracle 7/7. Native CPU, RISC-V CPU, and device-only Metal product checks pass.\n\nThe complete submission note and transcript include rejected architectures, profiler evidence, and the earlier source-policy correction.\n\nPR6 Supremacy: not achieved.