### PR TITLE
Vectorize shared quotient denominators across CPU and Metal

### DIFF
--- a/autoresearch/notes/20260723-023155-shared-prover-vectorization-and-batch-major-quotient-denomin.md
+++ b/autoresearch/notes/20260723-023155-shared-prover-vectorization-and-batch-major-quotient-denomin.md
@@ -1,0 +1,60 @@
+---
+title: Shared prover vectorization and batch-major quotient denominators
+author: Teddy Pender
+created_utc: 2026-07-23T02:31:55Z
+---
+
+# Problem match — shared prover vectorization, epoch 6
+
+## Measured problem
+
+After the direct-column BLAKE2 promotion, the longest RISC-V proof is no longer
+dominated by message staging. The largest editable clusters are four-message
+BLAKE2 compression, quotient tiles, forward/inverse circle FFT passes, and
+batch inversion. The seven-workload portfolio must move together; frontend-only
+specialization is both locked by policy and too narrow.
+
+## Structural matches
+
+| observed shape | known optimization pattern | repository application |
+| --- | --- | --- |
+| independent inversion chains | dependency striping + SIMD batching | pack four CM31 values across AdvSIMD lanes |
+| four products before a field reduction | delayed modular reduction | exact `u64` M31 `dot4` |
+| four contiguous extension coordinates | transpose the SIMD dimension | multiply `[c0,c1,c2,c3]` by scalar splats |
+| final transform followed by uniform scale | fuse producer and affine consumer | absorb `n^-1` into final inverse radix-8 |
+| zero-padded 2x extension | exploit known-zero/duplicate boundary | synthesize upper half in first active radix pass |
+| four independent ARX chains | software pipelining / ILP exposure | advance BLAKE2 G dependency levels in lockstep |
+| constant extension sample point, varying base row | partial evaluation + structure-of-arrays transpose | precompute the CM31 determinant and evaluate four batch-major rows together |
+
+## Generalization and safety
+
+The matches depend on mathematical and layout properties, not benchmark IDs:
+nonzero CM31 batches, canonical M31 bounds, compact contribution geometry,
+four-coordinate QM31 representation, transform stage position, and 2x LDE
+semantics. The quotient denominator reduction follows the exact identity
+`(prx-x)*piy-(pry-y)*pix = det-x*piy+y*pix`; CPU and Metal share that algebra.
+Generic architectures retain scalar fallbacks. Focused differential tests
+cover odd lengths, high-value reductions, zero rejection, row- and batch-major
+layouts, changing retained-scratch strides, fused versus generic FFT stages,
+and synthesized versus materialized expansion.
+
+## Falsifiers used
+
+- Reject a layer if exact proof hex, statement, transcript, or oracle parity
+  changes.
+- Reject instruction-saving SIMD if cycles or end-to-end latency regress under
+  paired measurement.
+- Reject a plan/layout change below 0.1% process work reduction when it adds
+  persistent complexity.
+- Do not submit until the complete deep portfolio CI clears the repository's
+  noise-adjusted significance boundary.
+
+## Result
+
+The final stacked clean candidate reaches proving geomean ratio 0.982416 with
+95% CI [0.980101, 0.984837], 4.78% lower energy, flat RSS, identical proof
+bytes, and oracle acceptance for all seven workloads. The last denominator
+layer alone removes 1.21% of SHA2-2048 process instructions and 0.95% of
+cycles. Rejected worker sweeps, flattened direct plans, wide dependency
+stripes, extra accumulators, generic QM31 SIMD, and statistically inconclusive
+paired runs are retained in the session transcript.

--- a/autoresearch/submissions/2026-07-23-riscv-shared-prover-vectorization/delta.json
+++ b/autoresearch/submissions/2026-07-23-riscv-shared-prover-vectorization/delta.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "0a04f85af1e2",
+  "declared_objective": {
+    "board": "riscv",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/backends/metal/kernels.metal": "sha256:1ba4c6ad86d2177e7fb367e26883a895ddc8bbafc8af11eaf19ed722ef9a41c1",
+    "src/backends/metal/runtime/polynomial_operations.zig": "sha256:a1aafadf1f5fde500b89cf59e66572e76e4d59c5afaa8307f2aaeb0b7c490017",
+    "src/core/crypto/blake2s_backend.zig": "sha256:8d2f7d30d754c367e4a9c398d9e751487862e7dbda9c47c025aa3bde079460c4",
+    "src/core/crypto/blake2s_contract.zig": "sha256:20c994d8e1679faba17bc222ff1fdf48ef8ee0232761e12df8ecc004e9f8970b",
+    "src/core/crypto/blake2s_parallel4.zig": "sha256:9b14b3ff7bbb15d6ca4f02970c533cfc2f632d049716f5d7cc728ef068d81239",
+    "src/core/fields/m31.zig": "sha256:4fc330e004420a64dab38d35a04db0b3fc3ab0c4e53f8088ad5ff1fe13b42789",
+    "src/core/fields/mod.zig": "sha256:0c37640089d8bfd08ff8cc302693122f127263bf17c5d59e7515014bd26eacee",
+    "src/core/pcs/quotients/row_evaluation.zig": "sha256:30e9e8768b083ca3d218b9d4903d7e3805b4219971e7d92847303d9de5778442",
+    "src/prover/pcs/quotient_compact_groups.zig": "sha256:196539f89de7955bfdcc42836b5648986eb365e3b5f60a87769041b5abea337c",
+    "src/prover/pcs/quotient_row_executor.zig": "sha256:f9657adfa9eb246377d95e4587e5f308a0ebeafa1035d4c195ca706328e1c48e",
+    "src/prover/pcs/quotient_tile_executor.zig": "sha256:0741627220c562f1805b76e2baf067b1d9ea5e1a423b57961903dcf3ccc953c2",
+    "src/prover/poly/circle/fft_kernels.zig": "sha256:d40f705b3ec5c5f755f468cf3007e3ae8c7969278aff0d3ec1351938d1abb220",
+    "src/prover/poly/circle/fft_radix8.zig": "sha256:edcf256939c4e51353f990b592567ea4d335f7a88614c8e8677981928e8de319",
+    "src/prover/poly/circle/transforms.zig": "sha256:da6c104e5a600ce31b9d2a6b048ad084707f72ba453bd894f14a0c17f52ab928"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "644c9640faf081dc869e32266baf9b97a86924a50185cc3f0e8797d05987f130",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-23-riscv-shared-prover-vectorization/note.md
+++ b/autoresearch/submissions/2026-07-23-riscv-shared-prover-vectorization/note.md
@@ -1,0 +1,73 @@
+# Vectorize shared quotient denominators across CPU and Metal
+
+## Model and harness
+
+Model: GPT-5 Codex. Harness: repo-resident `stwo-perf` at `20e097517010`,
+candidate `8a3b16047112`, clean promoted predecessor `0a04f85af1e2`, Zig
+0.15.2, ReleaseFast on arm64 macOS. The claimed board is RISC-V `deep/time` at
+S3. Adaptive same-host paired measurements used the harness's ABBA policy.
+Every timed proof verified, cross-arm proof bytes matched per round, and the
+pinned Stark-V oracle accepted all seven workloads. A reasoning-first
+sanitized transcript is attached as `transcripts/session-01.md`.
+
+## Hypothesis
+
+Quotient denominators repeat two full CM31 products for every domain row and
+sample point even though the sample terms are proof-session constants. They
+are then stored row-major and gathered across four rows by SIMD finalization.
+Precomputing the constant determinant, evaluating adjacent rows in native M31
+vectors, and retaining inverses batch-major should remove arithmetic and
+strided loads without changing the quotient identity. The same algebra should
+also reduce Metal shader work rather than leaving divergent CPU/GPU formulas.
+
+## Changes
+
+The workspace now precomputes `det = prx*piy - pry*pix` and evaluates each
+denominator as `det - x*piy + y*pix`. The CPU tile path groups four adjacent
+rows per sample, deinterleaves domain x/y vectors, performs packed base-field
+products, stores batch-major CM31 values, batch-inverts them, and finalizes via
+contiguous vector loads. Layout state fails closed if a row-major accessor is
+used after batch-major preparation. Scalar tails and generic row-major callers
+remain supported.
+
+Metal's runtime uploads the same determinant in its existing eight-word ABI.
+Direct, raw, and split-finalize quotient shaders use two CM31-by-M31 products
+instead of two full CM31 products. The independent resident FRI point ABI is
+unchanged. The broader stack also includes packed CM31 inversion, exact dot4
+compact quotient reduction, coordinate SIMD, fused FFT normalization and 2x
+LDE expansion, and four-chain BLAKE2 scheduling. No workload name, input
+digest, benchmark size, statement, protocol, transcript, or proof format is
+special-cased.
+
+## Results
+
+The focused SHA2-2048 screen removed 2.82 billion instructions (1.21%) and 653
+million cycles (0.95%); proving moved from 2.029 to 1.983 seconds. Canonical
+proof bytes were identical.
+
+The final clean seven-workload verdict used 23 paired rounds. Portfolio proving
+ratio is **0.982416**, 95% CI **[0.980101, 0.984837]**, clearing theta
+0.012888. Every row won: xorshift 0.9830, Fibonacci 0.9814, GCD 0.9855,
+multi-shard 0.9920, SHA2-512 0.9734, SHA2-1024 0.9769, and SHA2-2048 0.9849.
+Verified-request ratios were also below 1.0 for all rows. Energy ratio is
+**0.952201**, peak-RSS ratio **0.998642** with upper-CI geomean 1.001208, and
+proof-byte ratio exactly **1.0**. G1-G5 pass.
+
+ReleaseFast closures passed for the 377-source aggregate, 352-source RISC-V
+CPU product, 210-source Native CPU product, and 256-source Native Metal
+product. Source conformance passed. Metal source-JIT, device-only lifecycle,
+independent verification, and zero-fallback policy passed.
+
+## Caveats
+
+This is a local claimed verdict; only the authenticated judge's rerun can
+promote it. A first run on the final identity was favorable but narrowly
+inconclusive at 0.984744 [0.981673, 0.987511]; it and the successful declared
+confirmation are both retained. The harness-wide guard route has a known
+manifest classification bug for `guard_blake_10x10`, so explicit Native CPU,
+RISC-V CPU, and Native Metal product gates were run and recorded. No separate
+Metal timing verdict is claimed from the cross-backend arithmetic change.
+
+The separate PR6 all-cell contract is incomplete: exact full workload parity,
+log22 oracle vectors, both timing boundaries, and a locked-M5 judged verdict
+remain outstanding. **PR6 Supremacy: not achieved.**

--- a/autoresearch/submissions/2026-07-23-riscv-shared-prover-vectorization/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-23-riscv-shared-prover-vectorization/transcripts/session-01.md
@@ -1,0 +1,417 @@
+# Autoresearch session 01 — RISC-V deep epoch 6
+
+## Objective, policy, and starting point
+
+This session continues the user-directed optimization loop after PR #86 merged
+direct column-to-four-message BLAKE2s streaming. The promoted predecessor is
+clean `main` commit `0a04f85af1e2`. The priority is the complete seven-program
+`riscv/deep` portfolio, especially SHA2-2048, while retaining Native CPU,
+Native Metal, proof-size, energy, RSS, and correctness guards. A single fast
+screen is diagnostic; the promotion unit is a clean paired portfolio verdict.
+
+The repository-resident CLI had already been refreshed and the five repository
+skills were exercised. Their binding method in this epoch was:
+
+1. match a measured hot path to a structural algorithm change before editing;
+2. use macOS sampling plus instruction/cycle/energy counters for attribution;
+3. preserve Metal residency and fallback contracts even though this objective
+   scores the shared CPU/RISC-V prover;
+4. distinguish exact canonical proof bytes from provenance-bearing artifact
+   envelopes; and
+5. preserve unsuccessful iterations in this transcript and external evidence.
+
+The editable-path audit was decisive. The attractive epoch-5 Horner LogUp
+prototype lives under locked `src/frontends/riscv/**`, so it was retained as
+architecture evidence but excluded from this scored candidate. Epoch 6 starts
+from shared MANIFEST-approved field, PCS, polynomial, and crypto code only.
+
+## Baseline profile and bottleneck map
+
+The current-main SHA2-2048 profile retained at
+`evidence/packed32-sha2-2048.sample.txt` sampled the live ReleaseFast prover.
+The useful collapsed top-of-stack counts were:
+
+```text
+four-message BLAKE2s compression                         3246
+memmove                                                  2004
+RISC-V LogUp pairConstraint                              1316
+quotient tile executor                                   1121
+forward circle FFT tail                                   994
+Poseidon full-round AIR                                   615
+lookup denominator                                        601
+batched Merkle leaves                                     437
+inverse circle FFT batch                                  242
+CM31 quotient batch inversion                              83
+```
+
+The main thread spent most samples in worker waits, so optimization decisions
+used worker stacks and process-wide counters rather than treating wait samples
+as work. Locked frontend frames were not edited. The shared quotient, FFT,
+field, and BLAKE2 frames became the search surface.
+
+## Layer 1: packed CM31 batch inversion
+
+The quotient row preparer performs many independent CM31 inversions. The
+existing prefix/suffix batch algorithm serialized every multiplication. The
+new AArch64 path packs four independent CM31 values across AdvSIMD lanes, then
+uses size-adaptive dependency stripes of 8, 16, or 32 elements. Generic hosts
+retain scalar stripes of width 8 or 4. Zero input remains fail-closed.
+
+An isolated 4,096-value profile measured:
+
+| implementation | ns/value | instructions/value | cycles/value |
+| --- | ---: | ---: | ---: |
+| serial prefix/suffix | 8.614 | 134.1 | 39.59 |
+| scalar striped-8 | 5.531 | 148.2 | 25.42 |
+| packed striped-8 | 2.954 | 42.8 | 13.58 |
+| packed striped-16 | 2.566 | 42.15 | 11.80 |
+| packed striped-32 | 2.538 | 43.5 | 11.67 |
+
+Width 64 was rejected: latency was flat at 2.539 ns/value while instructions
+rose. Differential coverage includes lengths 1, 2, 3, 7, 8, 16, 24, 31, 32,
+40, 63, and 64 plus zero rejection. Commit `90703d2` passed the complete test
+closure. Its clean paired portfolio was a real but sub-threshold improvement:
+ratio 0.991250, 95% CI [0.988412, 0.993043]. It was retained for stacking.
+
+## Layer 2: exact four-term compact quotient reduction
+
+SHA2-2048's quotient plan contains 33 compact groups, 2,122 compact members,
+2,291 total contributions, and 13 numerator batches. Each compact group was
+performing a modular reduction after every base-field product. Four canonical
+M31 products sum below `2^64`, so `M31.dot4` now accumulates four exact `u64`
+products and performs one final Mersenne reduction. Compact groups use that
+primitive for even and odd lifted values across all four extension coordinates
+and retain a scalar tail.
+
+The live reducer microprofile improved from 7.381 ns/member, 55.05
+instructions/member, and 33.94 cycles/member to 6.060 ns, 43.06 instructions,
+and 27.86 cycles. Two- and four-accumulator alternatives were measured and
+rejected because register spills raised instructions to about 65/member and
+latency to 6.86–7.30 ns/member.
+
+Commit `2ddb141` moved the clean portfolio to 0.989187 with 95% CI
+[0.986560, 0.991975], still below promotion significance. It remained in the
+stack because the instruction and cycle mechanism was direct and broad.
+
+## Layer 3: M31 reduction and inverse-FFT scaling
+
+The general `reduce64` helper was corrected and shortened to two complete
+Mersenne folds followed by unsigned minimum against wrapping subtraction. A
+full-range unit fixture prevents confusing the stricter product-only bound with
+arbitrary `u64` reduction.
+
+Inverse FFT normalization was then expressed as four interleaved packed M31
+products plus a scalar tail. The normalization microprofile improved from
+0.2942 ns/value, 3.816 instructions, and 1.009 cycles to 0.2454 ns,
+2.378 instructions, and 0.633 cycles. Commit `dc21153` produced clean portfolio
+ratio 0.988733 with 95% CI [0.985543, 0.992656]. The stack was now close but
+still honestly reported as not significant.
+
+The SHA2-2048 screen at this point measured 2.632837 s verified request,
+1.990471 s proving, 234.193 billion instructions, and 69.156 billion cycles.
+Statement digest `6bc61b...97e88` and transcript digest `4ca8cf...fac8` remained
+stable.
+
+## Rejected quotient and scheduling experiments
+
+Several plausible designs were falsified before the final architecture:
+
+- Factoring the quotient determinant added dependency depth and did not reduce
+  the complete row path. It was removed.
+- Worker counts 12, 14, 16, and 18 plus an oversubscribed configuration did not
+  improve the critical path. More workers increased contention or left the
+  same serial joins.
+- A flattened immutable direct-contribution plan converted 24 direct views
+  into the grouped reducer and passed exact proofs, but changed SHA2-2048
+  instructions by only -0.0086% while cycles rose 0.31%. It was removed in
+  full, including its temporary diagnostic exports.
+- Two and four independent compact accumulators increased spills and were
+  rejected by the microprofile above.
+- A generic three-batch SIMD QM31 multiplication saved instructions but lost
+  latency on dependent multiplication chains; independent-row packing remains
+  the correct SIMD dimension.
+- Runtime worker oversubscription was not used to manufacture a benchmark win.
+
+These outcomes matter because they rule out repeating plan materialization,
+generic aggregate SIMD, or worker-count tuning as the next epoch's first move.
+
+## Layer 4: fuse inverse normalization into radix-8
+
+For the final three inverse FFT stages, the normal flow computed
+
+```text
+lo = lhs + rhs
+hi = (lhs - rhs) * twiddle
+```
+
+and then traversed the whole coefficient buffer to multiply both outputs by
+`n^-1`. The normalized radix-8 kernel instead computes
+
+```text
+lo = (lhs + rhs) * n^-1
+hi = (lhs - rhs) * (twiddle * n^-1)
+```
+
+inside the final register-resident stage. Production transforms always reach
+that final radix group; small shapes retain the generic scale fallback. A
+focused differential test compares the normalized fused kernel with the old
+three stages followed by scaling.
+
+The first SHA2-2048 screen removed about 193 million instructions (0.082%) and
+was deterministic across repeated runs. Its canonical proof bytes were stable.
+An apparent artifact-hash change versus an older dirty build was traced to the
+provenance envelope; comparing `proof_bytes_hex` is the correctness-relevant
+test.
+
+## Layer 5: expose four independent BLAKE2 G chains
+
+Disassembly of `compressParallel4` showed a 5.8 KiB fully unrolled AArch64
+function. Rotate-16 and rotate-8 were already one-instruction `rev32`/`tbl`
+forms, while rotate-12 and rotate-7 were optimal two-instruction shift/insert
+forms. The remaining opportunity was instruction scheduling: source issued
+four complete independent G calls, so the generated code followed long local
+dependency chains.
+
+`g4Interleaved` advances four independent G functions one dependency level at
+a time. Generated stack accesses fell from 85 to 70 and static instructions
+from 1,448 to 1,440. The full SHA2 screen removed another 131 million
+instructions. Cycle movement was too small for an isolated claim, so this was
+kept only as part of the broad stack and later judged by the paired portfolio.
+
+## Layer 6: synthesize 2x LDE expansion in the first radix pass
+
+The two-times LDE extension previously copied each coefficient buffer's lower
+half into its upper half, then immediately reread both halves for the first
+active radix-8 group. The skipped degenerate stage has exact output `(a, a)`.
+The new expansion kernel processes the upper destination group first while the
+lower source is intact, then transforms the lower group in place. This removes
+one complete `memcpy` traversal. Small transforms that do not begin with a
+packed radix-8 pass retain the old materialization fallback.
+
+A focused fixture deliberately fills the unused upper half with unrelated
+values and proves that synthesized expansion exactly matches explicit
+duplication followed by the generic kernel. The SHA2-2048 screen reduced the
+proving substage from 2.034471 s to 2.006513 s (1.37%); process-wide
+instructions, cycles, and energy all fell. The verified-request sample itself
+was obscured by a 43 ms witness fluctuation, which is why this layer proceeded
+to ABBA rather than being claimed from one timing.
+
+Commit `2f15522` combined the normalized inverse boundary, BLAKE2 scheduling,
+and direct LDE expansion. Its clean paired seven-workload run reached ratio
+0.985260 with portfolio 95% CI [0.981583, 0.988590]. Six rows were clearly
+faster and SHA2-512 reached 0.9718, but the promotion boundary was approximately
+0.987112, so the candidate remained a near miss and was not submitted.
+
+## Layer 7: transpose compact quotients across extension coordinates
+
+The remaining 0.15-point confidence gap prompted a second look at compact
+groups. The scalar `dot4` reduction vectorized across members, but every member
+already stores four contiguous extension coefficients. On AArch64 the better
+dimension is therefore the four coordinates:
+
+```text
+member coefficients [c0 c1 c2 c3]
+                    × splat(even value)
+                    × splat(odd value)
+```
+
+Four members are issued together. Their eight independent `mulVec4` operations
+are pairwise tree-reduced into even and odd vector accumulators. Generic and
+stage2-C builds retain the exact scalar `dot4` implementation.
+
+The focused SHA2-2048 screen removed 1.109 billion instructions (0.475%) and
+522 million cycles (0.753%) from the complete warmup-plus-sample process. The
+canonical proof hex, statement, claim, and transcript were byte-identical to
+the predecessor. The whole JSON artifact digest changed only because its
+provenance moved from dirty `dc21153` to dirty `2f15522`.
+
+## First significant paired checkpoint
+
+The first clean significant checkpoint is `e7560c9ceae5`, paired on the same host against
+clean predecessor `0a04f85af1e2` under harness `20e097517010`. Adaptive paired
+sampling used 29 total rounds. Every timed proof verified, candidate and
+predecessor proof digests were byte-identical per round, and the pinned Stark-V
+oracle accepted 7/7 workloads.
+
+| workload | proving ratio | 95% CI | request ratio | rounds |
+| --- | ---: | ---: | ---: | ---: |
+| xorshift | 0.9866 | [0.9791, 0.9940] | 0.9909 | 5 |
+| Fibonacci | 0.9859 | [0.9808, 0.9905] | 0.9867 | 3 |
+| GCD | 0.9838 | [0.9780, 0.9888] | 0.9819 | 3 |
+| multi-shard | 0.9834 | [0.9739, 0.9910] | 0.9826 | 5 |
+| SHA2-512 | 0.9824 | [0.9626, 0.9989] | 0.9910 | 5 |
+| SHA2-1024 | 0.9855 | [0.9798, 0.9915] | 0.9838 | 5 |
+| SHA2-2048 | 0.9722 | [0.9662, 0.9759] | 0.9877 | 3 |
+
+The geometric-mean proving ratio is **0.982829** with portfolio 95% CI
+**[0.979287, 0.986004]**, clearing the noise-adjusted significance boundary.
+Geometric-mean energy ratio is **0.962484** (3.75% lower). Peak-RSS ratio is
+1.000374 with upper-CI geomean 1.003405, and proof-byte ratio is exactly 1.0.
+All seven mechanism rows and all repository gates G1–G5 passed. This remains a
+local claimed verdict until the authenticated judge reruns it.
+
+The architecture is structural rather than benchmark-specific:
+
+```text
+CM31 inversion: serial dependency chain -> independent SIMD stripes
+compact quotient: product-by-product reduction -> exact dot4 -> coordinate SIMD
+inverse FFT: radix pass -> full scale traversal -> normalized final radix pass
+2x LDE: memcpy duplicate -> reread both halves -> synthesize upper radix group
+BLAKE2s: four complete G chains -> four dependency levels in lockstep
+```
+
+No workload name, input digest, target size, or proof parameter controls these
+paths. Admission follows field type, AArch64 capability, compact-group geometry,
+and the mathematically structural 2x-extension boundary.
+
+## Remaining work and PR6 status
+
+The next shared-prover epoch should profile after promotion. Likely remaining
+editable targets are quotient finalization, forward FFT tail arithmetic, and
+BLAKE2 message scheduling; locked RISC-V LogUp and lookup construction require
+separate maintainer review. The 2x expansion kernel can also be extended to
+load the lower radix tuple once and emit both twiddle variants if a microprofile
+shows enough register headroom.
+
+This promotion advances the broad RISC-V prover but does not satisfy the
+separate all-cell PR6 contract. Exact PR6 workload ports, log22 oracle vectors,
+both verified-request and cold-process timing boundaries, the locked-M5 matrix,
+and an authenticated judged verdict remain incomplete.
+
+**PR6 Supremacy: not achieved.**
+
+## Submission-conformance extraction
+
+The first significant checkpoint could not yet be submitted because two
+optimized implementation files exceeded the repository's manual 850-line
+ceiling. This was a source-conformance issue, not a failed proof or benchmark.
+The four-message BLAKE scheduling kernel and its public dispatch contract were
+moved into focused crypto modules. The packed radix-8 implementation was moved
+into a focused FFT module and re-exported through the existing API. No
+arithmetic or call-site policy changed.
+
+The first extraction compile exposed a Zig name-shadowing error between the
+radix helper's `inverse` parameter and its public `inverse` wrapper. Renaming
+the parameter to `inverse_transform` resolved it. The complete ReleaseFast
+closure then passed across 377 transitive Zig sources, and source conformance
+reported only the five already-explained legacy findings. The clean extraction
+commit was `0e15f1af3bdb`.
+
+A fresh paired run on that immutable identity produced portfolio ratio
+0.988161, 95% CI [0.985446, 0.991572], and was correctly classified as not
+significant. Deterministic diagnosis ruled out a code-generation regression:
+SHA2-2048 retained approximately 232.58 billion instructions and 68.8 billion
+cycles, essentially identical to the prior significant checkpoint. The
+candidate/predecessor clock relationship had moved. This near-miss is retained
+at `evidence/run-clean-0e15f1a-nearmiss-raw`; it was not selected as promotion
+evidence.
+
+## Layer 8: algebraically reduced, batch-major quotient denominators
+
+The near-miss left a small confidence gap, so the next iteration targeted a
+real remaining quotient cost. Each denominator was formed for every row and
+sample batch as
+
+```text
+(prx - x) * piy - (pry - y) * pix
+```
+
+where `x` and `y` are base-field domain coordinates and every other term is
+constant for a proof session. Expanding once gives
+
+```text
+det = prx*piy - pry*pix
+denominator(row) = det - x(row)*piy + y(row)*pix
+```
+
+The session now precomputes `det`. The CPU tile path transposes denominator
+storage from row-major to sample-batch-major and evaluates four adjacent rows
+with native M31 vectors. Four domain points are deinterleaved into x/y vectors;
+four coordinate products cover all four rows. The resulting CM31 values are
+interleaved into contiguous storage, batch-inverted with the already optimized
+packed inversion, and loaded back by quotient finalization with two vector
+loads and two shuffles instead of eight strided scalar gathers.
+
+```text
+old: row -> [sample0 sample1 ...] -> scalar CM31 products -> strided gather
+new: sample -> [row0 row1 row2 row3] -> packed base products -> contiguous load
+```
+
+The retained scratch records whether inverses are row-major or batch-major so
+the old API fails closed if called under the wrong layout. Tests cover batch
+counts 1, 3, and 8; row counts 1, 2, 3, 4, 7, 8, and 17; repeated stride
+changes; zero denominators; scalar tails; and packed finalization against the
+canonical scalar quotient. The full SHA2-2048 proof supplied end-to-end parity.
+
+The profiled SHA2-2048 screen moved from 232.617 to 229.797 billion
+instructions (-1.21%), 68.800 to 68.147 billion cycles (-0.95%), and 2.029 to
+1.983 seconds proving (-2.28%). Statement and transcript digests were stable,
+and the canonical proof-byte SHA-256 was identical. Clean commit `cf9dee1bda01`
+then produced a significant seven-workload verdict: portfolio ratio 0.981894,
+95% CI [0.979489, 0.984016], 23 rounds, energy ratio 0.951516, RSS ratio
+0.999773, and proof-byte ratio 1.0.
+
+## Cross-backend breakage found and generalized Metal fix
+
+The explicit Native Metal product guard then found an important compile-time
+dependency: Metal's runtime uploader read the old `prx` and `pry` fields from
+the shared CPU workspace. Restoring redundant fields would have hidden the
+architectural mismatch. Instead, the Metal request path was changed to upload
+the same precomputed determinant, `pix`, and `piy` in its existing eight-word
+ABI envelope. The direct quotient, raw quotient, and split-finalize shaders now
+use the same reduced formula and replace two full CM31 multiplies with two
+CM31-by-M31 multiplies per sample and row. The independent resident FRI recipe
+keeps its separate original point ABI and was intentionally not conflated with
+this request layout.
+
+Source-JIT compiled the changed shader through the macOS Metal runtime. The
+Native Metal product closure passed across 256 transitive Zig sources, and the
+device-only lifecycle proof plus independent verification passed with no CPU
+fallback. This generalized fix became clean commit `8a3b16047112`.
+
+## Final immutable verdict and confidence resolution
+
+Because the Metal-only commit changed the candidate identity, the RISC-V board
+was measured again rather than attaching the prior commit's verdict. The first
+`8a3b160` run was faster on all seven rows, with portfolio ratio 0.984744 and
+95% CI [0.981673, 0.987511]. Its upper bound missed the promotion threshold by
+0.000316, so it was retained as a near-miss rather than called significant.
+No sample failed or was discarded.
+
+One declared confirmation run on the same immutable commit resolved that
+narrow confidence edge. It used 23 adaptive paired rounds, with every timed
+proof independently verified, cross-arm proof bytes identical per round, and
+the pinned Stark-V oracle accepting 7/7 workloads.
+
+| workload | proving ratio | 95% CI | request ratio | rounds |
+| --- | ---: | ---: | ---: | ---: |
+| xorshift | 0.9830 | [0.9782, 0.9850] | 0.9833 | 3 |
+| Fibonacci | 0.9814 | [0.9694, 0.9933] | 0.9815 | 5 |
+| GCD | 0.9855 | [0.9836, 0.9889] | 0.9894 | 3 |
+| multi-shard | 0.9920 | [0.9849, 0.9961] | 0.9951 | 3 |
+| SHA2-512 | 0.9734 | [0.9696, 0.9796] | 0.9793 | 3 |
+| SHA2-1024 | 0.9769 | [0.9729, 0.9845] | 0.9819 | 3 |
+| SHA2-2048 | 0.9849 | [0.9810, 0.9901] | 0.9792 | 3 |
+
+The final portfolio ratio is **0.982416**, 95% CI **[0.980101, 0.984837]**,
+which clears the predeclared theta 0.012888 significance rule. Energy ratio is
+**0.952201** (4.78% lower); peak-RSS ratio is **0.998642** with upper-CI
+geomean 1.001208; proof-byte ratio is exactly **1.0**. G1-G5 pass. The raw
+confirmation evidence is retained at `evidence/run-final-8a-significant-raw`;
+the non-significant confirmation predecessor and every earlier iteration are
+retained alongside it.
+
+Explicit guards on the final content passed the complete ReleaseFast test
+closure, source conformance, the 352-source RISC-V CPU product closure, the
+210-source Native CPU product closure, and the 256-source Native Metal product
+closure with device-only proof lifecycle. The aggregate `--guards all` route
+was also attempted earlier and exposed a harness manifest bug: a Native guard
+row named `guard_blake_10x10` was parsed as RISC-V and lacked the required
+`{admission}` placeholder. Explicit product gates were used rather than hiding
+that harness failure.
+
+The claimed verdict remains advisory until the authenticated judge repeats it.
+The separate PR6 all-cell task still lacks the exact complete workload matrix,
+log22 oracle vectors, both timing boundaries, and locked-M5 judged evidence.
+
+**PR6 Supremacy: not achieved.**

--- a/autoresearch/submissions/2026-07-23-riscv-shared-prover-vectorization/verdict.json
+++ b/autoresearch/submissions/2026-07-23-riscv-shared-prover-vectorization/verdict.json
@@ -1,0 +1,940 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "20e097517010",
+  "repo_commit": "8a3b16047112",
+  "predecessor_commit": "0a04f85af1e2",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "riscv",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 3.52
+    }
+  },
+  "search_health": {
+    "schema_version": 1,
+    "decision": {
+      "schema_version": 1,
+      "board": "riscv",
+      "workload_class": "deep",
+      "trailing_window": 8,
+      "trailing_evidence_count": 3,
+      "trailing_median_gradient_snr": 20.501307668744357,
+      "gradient_snr_threshold": 2.0,
+      "configured_rounds": 5,
+      "auto_boost_rounds": 5,
+      "maximum_rounds": 25,
+      "target_rounds": 5,
+      "workload_count": 7,
+      "class_wall_deadline_seconds": 600.0,
+      "estimated_seconds_per_round": 8.46738542930336,
+      "deadline_round_limit": 10,
+      "auto_boost_applied": false,
+      "auto_boost_reason": "trailing_median_at_or_above_threshold",
+      "recorded_before_measurement": true
+    },
+    "decision_sha256": "sha256:62fde1e487830e8a0c69601a702cc90fb73700245be35819debd06cf0cc53084",
+    "actual_rounds": 23,
+    "actual_rounds_per_workload": {
+      "riscv_fib_iter": 5,
+      "riscv_gcd_euclid": 3,
+      "riscv_multi_shard_addi": 3,
+      "riscv_sha2_1024b": 3,
+      "riscv_sha2_2048b": 3,
+      "riscv_sha2_512b": 3,
+      "riscv_xorshift_prng": 3
+    },
+    "objective_wall_seconds": 170.37439720809925,
+    "measurement_wall_seconds": 171.57515495806,
+    "measurement_wall_hours": 0.04765976526612778,
+    "gradient_snr": null,
+    "credited_ln_improvement": null,
+    "credited_ln_improvement_per_measurement_hour": null,
+    "credit_status": "pending_ledger_adjudication",
+    "decision_record": "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/search-health-decision.json"
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned correctness oracle verified 7/7 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "RISC-V mechanism telemetry present, canonical, and semantically stable for 7/7 workloads"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.5931 vs targeted budget x1.02; matrix row upper CIs 7/7 within budget x1.05; request ratios 7/7 present rows within budget x1.05; resource vectors 7/7 within named budgets"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "riscv_xorshift_prng": {
+        "r": 0.982982,
+        "ci": [
+          0.978183,
+          0.985022
+        ],
+        "rounds": 3,
+        "a_median_ms": 1274.757541,
+        "b_median_ms": 1250.71025,
+        "request_ratio": 0.983282,
+        "rss_ratio": 1.000006,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.952583,
+            "ci": [
+              0.951998,
+              0.953176
+            ],
+            "observations": 3,
+            "candidate": 44.35597928
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000006,
+            "ci": [
+              0.999432,
+              1.001112
+            ],
+            "observations": 3,
+            "candidate": 1265.6893997192383
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 61123.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 61123,
+        "measurement_seconds": 16.374258,
+        "resources_complete": true
+      },
+      "riscv_fib_iter": {
+        "r": 0.981406,
+        "ci": [
+          0.969368,
+          0.993262
+        ],
+        "rounds": 5,
+        "a_median_ms": 1461.237625,
+        "b_median_ms": 1434.068083,
+        "request_ratio": 0.981533,
+        "rss_ratio": 0.999722,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.958424,
+            "ci": [
+              0.954623,
+              0.960595
+            ],
+            "observations": 5,
+            "candidate": 48.448860116
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999722,
+            "ci": [
+              0.999534,
+              0.999939
+            ],
+            "observations": 5,
+            "candidate": 1291.8768768310547
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 60003.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 60003,
+        "measurement_seconds": 31.121011,
+        "resources_complete": true
+      },
+      "riscv_gcd_euclid": {
+        "r": 0.985501,
+        "ci": [
+          0.983609,
+          0.988914
+        ],
+        "rounds": 3,
+        "a_median_ms": 1356.439417,
+        "b_median_ms": 1335.831417,
+        "request_ratio": 0.98941,
+        "rss_ratio": 1.000352,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.958297,
+            "ci": [
+              0.957486,
+              0.958833
+            ],
+            "observations": 3,
+            "candidate": 45.546822514
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000352,
+            "ci": [
+              0.998926,
+              1.001602
+            ],
+            "observations": 3,
+            "candidate": 1279.4862518310547
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 62582.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 62582,
+        "measurement_seconds": 17.570213,
+        "resources_complete": true
+      },
+      "riscv_multi_shard_addi": {
+        "r": 0.992005,
+        "ci": [
+          0.984875,
+          0.996114
+        ],
+        "rounds": 3,
+        "a_median_ms": 1395.90025,
+        "b_median_ms": 1381.284042,
+        "request_ratio": 0.995132,
+        "rss_ratio": 0.999528,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.958763,
+            "ci": [
+              0.956088,
+              0.960592
+            ],
+            "observations": 3,
+            "candidate": 47.319429709
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999528,
+            "ci": [
+              0.998911,
+              1.000654
+            ],
+            "observations": 3,
+            "candidate": 1289.6894226074219
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 58117.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 58117,
+        "measurement_seconds": 17.966329,
+        "resources_complete": true
+      },
+      "riscv_sha2_512b": {
+        "r": 0.973404,
+        "ci": [
+          0.969623,
+          0.979567
+        ],
+        "rounds": 3,
+        "a_median_ms": 1594.6465,
+        "b_median_ms": 1551.9425,
+        "request_ratio": 0.979339,
+        "rss_ratio": 1.000122,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.943475,
+            "ci": [
+              0.938928,
+              0.947806
+            ],
+            "observations": 3,
+            "candidate": 58.58960113
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000122,
+            "ci": [
+              0.999875,
+              1.000273
+            ],
+            "observations": 3,
+            "candidate": 1375.1116409301758
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 78496.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 78496,
+        "measurement_seconds": 25.333423,
+        "resources_complete": true
+      },
+      "riscv_sha2_1024b": {
+        "r": 0.976866,
+        "ci": [
+          0.972876,
+          0.984463
+        ],
+        "rounds": 3,
+        "a_median_ms": 1884.82275,
+        "b_median_ms": 1849.218792,
+        "request_ratio": 0.98187,
+        "rss_ratio": 0.992117,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.943813,
+            "ci": [
+              0.94241,
+              0.946041
+            ],
+            "observations": 3,
+            "candidate": 66.137494135
+          },
+          "peak_rss_mib": {
+            "ratio": 0.992117,
+            "ci": [
+              0.967997,
+              1.000405
+            ],
+            "observations": 3,
+            "candidate": 1429.2992553710938
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 76677.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 76677,
+        "measurement_seconds": 28.677231,
+        "resources_complete": true
+      },
+      "riscv_sha2_2048b": {
+        "r": 0.984857,
+        "ci": [
+          0.981023,
+          0.990123
+        ],
+        "rounds": 3,
+        "a_median_ms": 2119.553834,
+        "b_median_ms": 2079.331042,
+        "request_ratio": 0.979232,
+        "rss_ratio": 0.99867,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.950196,
+            "ci": [
+              0.945784,
+              0.954617
+            ],
+            "observations": 3,
+            "candidate": 73.877817906
+          },
+          "peak_rss_mib": {
+            "ratio": 0.99867,
+            "ci": [
+              0.994072,
+              1.00448
+            ],
+            "observations": 3,
+            "candidate": 1498.549301147461
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 81115.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 81115,
+        "measurement_seconds": 33.231969,
+        "resources_complete": true
+      }
+    },
+    "R_geomean": 0.982416,
+    "portfolio": {
+      "ci_method": "independent_workload_round_bootstrap_percentile_v1",
+      "ci_level": 0.95,
+      "bootstrap_iterations": 4000,
+      "seed": 4042241451,
+      "ci": [
+        0.980101,
+        0.984837
+      ],
+      "prove_ms_method": "geometric_mean_candidate_workload_medians_ms_v1",
+      "b_median_ms_geomean": 1531.363827,
+      "proof_bytes_method": "rounded_geometric_mean_candidate_proof_bytes_v1",
+      "proof_bytes": 67692,
+      "measurement_seconds": 170.274433,
+      "measurement_rounds": 23
+    },
+    "theta": 0.012888,
+    "aa_dispersion": 0.006444,
+    "significant": true,
+    "neutral": false,
+    "promotion_significance": {
+      "eligible": true,
+      "method": "independent_workload_round_bootstrap_percentile_v1",
+      "reason": "prove-time objective uses the deterministic workload portfolio CI"
+    },
+    "resource_portfolio": {
+      "peak_rss_mib": {
+        "ratio_geomean": 0.9986416287328092,
+        "upper_ci_geomean": 1.0012082349373335,
+        "candidate_geomean": 1344.6218683104717
+      },
+      "energy_j": {
+        "ratio_geomean": 0.9522014821331106,
+        "upper_ci_geomean": 0.9545071813909249,
+        "candidate_geomean": 53.92472652315083
+      },
+      "proof_bytes": {
+        "ratio_geomean": 1.0,
+        "upper_ci_geomean": 1.0,
+        "candidate_geomean": 67691.6135391908
+      }
+    }
+  },
+  "tiebreakers": {
+    "rss_ratio": 0.998642,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": 53.92472652315083,
+    "proof_bytes": 67691.6135391908
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "riscv_xorshift_prng",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "38e4dc966a442d148546d9aac58c1c6398ad572018269d5552726f571f1767e4",
+      "proof_sha256": "c32a74186749f640a1b5b2a558768e9f6e60bcd58bc30595411e1722d5ead0e9"
+    },
+    {
+      "workload": "riscv_fib_iter",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "69fbb6d01abcabb766584a3b905087921c2fac4617eeb07fbc247800a7aa1092",
+      "proof_sha256": "100f0251e29fa5bbd58dfca387f52b776c0fa387ca0c2250a2f5534235bedc02"
+    },
+    {
+      "workload": "riscv_gcd_euclid",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "51e5190d6cbc99a1e4683d3341e148a2580f01edf7a1217f7b864093fe402268",
+      "proof_sha256": "7cfa5df8529186cc005ad38e86f5aae1fc0cb150a2d4c899a42bebac5f46778b"
+    },
+    {
+      "workload": "riscv_multi_shard_addi",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "f20a2e1cc1d004d548f49c9d0fb3642e72c69b0cf0b5ab06ba9f43212dc52767",
+      "proof_sha256": "4bf8ab22c5ebb506421203abfb2905b06d3f9cc39cd42fcd3899f288f98775a4"
+    },
+    {
+      "workload": "riscv_sha2_512b",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "e2cd2b3c255941cf1f79b8fb1701fde284975ba00d93dd2ccb2c20587429d37e",
+      "proof_sha256": "a5c7b4e54d0ba913b0ae1f58c77ea823826e0ba776a4a2673be2ab6dc3bcb74a"
+    },
+    {
+      "workload": "riscv_sha2_1024b",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "ac304e799af66c13c567cefd0cf0a14db2be3d477984d9b4269a66407d0007a2",
+      "proof_sha256": "63bbad02c8806622b99eba191ca9d1333ba77abd2f1486e2838525542d36cc50"
+    },
+    {
+      "workload": "riscv_sha2_2048b",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "547c886ed9ed0669642b273191ad5a45da7d15c0fceb99a9ecf38cff08a9c402",
+      "proof_sha256": "adaa94716e7010c04814b2b574b3b7cb788f76f31f8258ad2a737bae68f1b851"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "pr6_supremacy",
+      "reason": "PR6 Supremacy remains disabled until every exact workload port, log22 oracle vector, both timing boundaries, locked-M5 statistical gate, and authenticated judged verdict are complete."
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "riscv_xorshift_prng": {
+        "round_ratios": [
+          0.985022,
+          0.984361,
+          0.978183
+        ],
+        "proof_digest": "c32a74186749f640a1b5b2a558768e9f6e60bcd58bc30595411e1722d5ead0e9",
+        "request_ratio": 0.983282,
+        "rss_ratio": 1.000006,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.952583,
+            "ci": [
+              0.951998,
+              0.953176
+            ],
+            "observations": 3,
+            "candidate": 44.35597928
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000006,
+            "ci": [
+              0.999432,
+              1.001112
+            ],
+            "observations": 3,
+            "candidate": 1265.6893997192383
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 61123.0
+          }
+        },
+        "report_sha256s": [
+          "050a98933a8186daf462af6ad57e771e60e1c86e70e1b86409dfb297e4738000",
+          "73ed38f5c8302f8cc1a2db48638c8d3f9374d3866b8c43c46e0c91eca1c66aeb",
+          "8dc51f755305146c16822451fc096737a6f5ea173f6cfb92b2740e9c8101705e",
+          "84db46f25f37372466b0df622f88882792596755f5fb4a1673e321681c6ba9a2",
+          "019c42a51f46fc998535d6665a69d08855b33c4db488fea6a6138f108dee9580",
+          "d6ca113afa3b4a96625445cc5eb83ab4a725853aef4f75db61e28abf23a06364"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_fib_iter": {
+        "round_ratios": [
+          0.994662,
+          0.972023,
+          0.966713,
+          0.981406,
+          0.991862
+        ],
+        "proof_digest": "100f0251e29fa5bbd58dfca387f52b776c0fa387ca0c2250a2f5534235bedc02",
+        "request_ratio": 0.981533,
+        "rss_ratio": 0.999722,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.958424,
+            "ci": [
+              0.954623,
+              0.960595
+            ],
+            "observations": 5,
+            "candidate": 48.448860116
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999722,
+            "ci": [
+              0.999534,
+              0.999939
+            ],
+            "observations": 5,
+            "candidate": 1291.8768768310547
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 60003.0
+          }
+        },
+        "report_sha256s": [
+          "e35a2f2db66345317c2389f7551731da7a95895f7b38cc1c5ca30530ff7a967b",
+          "3a6dcb245ee2f29a96dec7c08296224f9103235541d6d33e66997d3c65828f09",
+          "93a9759ac11d9fe3348fae7f84817276590fdbabe891813de368203461f9582c",
+          "e83f32bbbe7e9de975c1ea3844147d7202efc343e6927c88dea10e6ce2a9f3d6",
+          "79fa90bdfa9fcb4fc58f0f5451070bafec374b2dc745108f071577caa517995a",
+          "f167544cd8495ca7a947a355cab764b120627ea662957dd32ad6e703cdf6bd9a",
+          "640a935c349526c7e9bbc478c814ef265ff9c7d0e5464673f861c50c600de69c",
+          "0969917a8bf4f42cc2cde37d0bb9056f9708084f014a2a4efe9ba0de1dd44fb6",
+          "81460509fbcac19bff74cfe476b35baa22a70624fd492d9a03787a8b50322132",
+          "1710d96ba05a46f2ef9b4ee08805166f2c5c4ab9ff1a892aacf0bea1c5fc2638"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_gcd_euclid": {
+        "round_ratios": [
+          0.988914,
+          0.983609,
+          0.98474
+        ],
+        "proof_digest": "7cfa5df8529186cc005ad38e86f5aae1fc0cb150a2d4c899a42bebac5f46778b",
+        "request_ratio": 0.98941,
+        "rss_ratio": 1.000352,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.958297,
+            "ci": [
+              0.957486,
+              0.958833
+            ],
+            "observations": 3,
+            "candidate": 45.546822514
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000352,
+            "ci": [
+              0.998926,
+              1.001602
+            ],
+            "observations": 3,
+            "candidate": 1279.4862518310547
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 62582.0
+          }
+        },
+        "report_sha256s": [
+          "a58c8f8e26c214feb7c63bb779903be53d924b5cda74c033c9934602e8bad13b",
+          "883fac5089669afb2e3e4b4eda9cd6cf014ddda7b5d4aa635e040fb5731c41ee",
+          "2793c186f012985b71c083b2e4bd7e0e1c86fe7345aa2c6ebc5f9020755992aa",
+          "f2b1f0b1dc4f5ab29772ccb46c574982ec907603ddbb309850be901a20254c2e",
+          "c482413771dac58a0a0099e2828baf00d2e5e915fa4ddf424c83072e57f62a19",
+          "d1de7d04f19f12bde2681b131141596565c2afdbd80c1a804946088654b791d2"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_multi_shard_addi": {
+        "round_ratios": [
+          0.993516,
+          0.984875,
+          0.996114
+        ],
+        "proof_digest": "4bf8ab22c5ebb506421203abfb2905b06d3f9cc39cd42fcd3899f288f98775a4",
+        "request_ratio": 0.995132,
+        "rss_ratio": 0.999528,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.958763,
+            "ci": [
+              0.956088,
+              0.960592
+            ],
+            "observations": 3,
+            "candidate": 47.319429709
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999528,
+            "ci": [
+              0.998911,
+              1.000654
+            ],
+            "observations": 3,
+            "candidate": 1289.6894226074219
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 58117.0
+          }
+        },
+        "report_sha256s": [
+          "7775dacb415ad2dd2ff4e8301b136bdc0f96ab752c64f3212ad721f0b758831b",
+          "0816018cb30085693ffbd019afb79ca8f06d12976492c9edebc77b477b6549f4",
+          "a931ce409c65323a152ec9da49b467c506ea2efdf529b7fa44221d3c018ee6ba",
+          "5701ae17c1977712f8da806b1d3e76396e69d32784db5e12deb99fbd518568f0",
+          "e6a2fcce3bdd3b6396646a842c3a8a279e83db369eb95c5a6f96ceca32c8fc8a",
+          "a60d1a49f95acbe709bae0e320e57bda01816ae724c215547b61b3ad2027a9c6"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_sha2_512b": {
+        "round_ratios": [
+          0.979567,
+          0.969623,
+          0.972213
+        ],
+        "proof_digest": "a5c7b4e54d0ba913b0ae1f58c77ea823826e0ba776a4a2673be2ab6dc3bcb74a",
+        "request_ratio": 0.979339,
+        "rss_ratio": 1.000122,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.943475,
+            "ci": [
+              0.938928,
+              0.947806
+            ],
+            "observations": 3,
+            "candidate": 58.58960113
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000122,
+            "ci": [
+              0.999875,
+              1.000273
+            ],
+            "observations": 3,
+            "candidate": 1375.1116409301758
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 78496.0
+          }
+        },
+        "report_sha256s": [
+          "b0a06c3ed9332ec347c40ed20c4b31890194d22575fc492a46203ad9093c53a4",
+          "904f125f01dab346e7f4eabd250abed7548cb341138a3b6ac6efede7fabafee0",
+          "5e9490c0cfde699995e758bfa8d228f106b7ce90143c658df16131c3c4b1ff8e",
+          "6853bc084e4a5616065882ba2d1417d46de928171d381f47c49a737abe9f897c",
+          "524ba2d40228e85dafea58c3544f72fa38eda09701ea9ede85f9f105eabbbfc9",
+          "fdc851df5773bcc3d21d5914d150a47abf362979d8409f78fd822866f37cdb81"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_sha2_1024b": {
+        "round_ratios": [
+          0.975062,
+          0.972876,
+          0.984463
+        ],
+        "proof_digest": "63bbad02c8806622b99eba191ca9d1333ba77abd2f1486e2838525542d36cc50",
+        "request_ratio": 0.98187,
+        "rss_ratio": 0.992117,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.943813,
+            "ci": [
+              0.94241,
+              0.946041
+            ],
+            "observations": 3,
+            "candidate": 66.137494135
+          },
+          "peak_rss_mib": {
+            "ratio": 0.992117,
+            "ci": [
+              0.967997,
+              1.000405
+            ],
+            "observations": 3,
+            "candidate": 1429.2992553710938
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 76677.0
+          }
+        },
+        "report_sha256s": [
+          "78d87d37d206e860d0de2cfd34f641fa4aa2227592083ad2ec2e95544cbe3436",
+          "303b819d9da20ee5b56a629d818f1bde8be00330db33b3325d40328f9704abb0",
+          "5fd49281d6a980d4207da27b6b65abe4f074c9b594214bde38f89e1bc2ac3ab0",
+          "8f976765c4e14aba62b62a75f9f8fe065b74afe94ca9cb855da740c1ba2dff88",
+          "9e1be4d623327c920b842eb0dd7b385a02e6cfe6b7be79495959016843babea2",
+          "86ad8fb5ef697ad7bc77dd7c952e078ee308894cf1510ea7a1d1c082278df3ce"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_sha2_2048b": {
+        "round_ratios": [
+          0.981023,
+          0.98414,
+          0.990123
+        ],
+        "proof_digest": "adaa94716e7010c04814b2b574b3b7cb788f76f31f8258ad2a737bae68f1b851",
+        "request_ratio": 0.979232,
+        "rss_ratio": 0.99867,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.950196,
+            "ci": [
+              0.945784,
+              0.954617
+            ],
+            "observations": 3,
+            "candidate": 73.877817906
+          },
+          "peak_rss_mib": {
+            "ratio": 0.99867,
+            "ci": [
+              0.994072,
+              1.00448
+            ],
+            "observations": 3,
+            "candidate": 1498.549301147461
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 81115.0
+          }
+        },
+        "report_sha256s": [
+          "30592558bae4ccb85335ce04ac068f4f887cf86430631f2e4e3e8f91f60ba7d4",
+          "d1f72364c2560796c7249db5723eb8bed154a65fbe2f5d2677a153b7c288b5d6",
+          "b42070dd6f99a70639c4d2defe63420b557bb72c2a004485ad99f2b7388e471b",
+          "a248ff05fa50ce399537fd1f58034ce63e2aad6fcacd13ea5f37c62ecec7af2e",
+          "0fefa1dd638706756ea040d1bd6547dc4a5de6693ee21e309ba710e0cb48533f",
+          "8e2b89864dc3a14ced2aa9762e4a76cc24a9f4ca249a99e76eab9719b22bfd0a"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_xorshift_prng.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_xorshift_prng.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_xorshift_prng.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_xorshift_prng.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_xorshift_prng.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_xorshift_prng.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_fib_iter.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_fib_iter.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_fib_iter.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_fib_iter.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_fib_iter.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_fib_iter.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_fib_iter.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_fib_iter.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_fib_iter.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_fib_iter.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_gcd_euclid.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_gcd_euclid.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_gcd_euclid.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_gcd_euclid.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_gcd_euclid.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_gcd_euclid.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_multi_shard_addi.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_multi_shard_addi.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_multi_shard_addi.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_multi_shard_addi.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_multi_shard_addi.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_multi_shard_addi.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_sha2_512b.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_sha2_512b.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_sha2_512b.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_sha2_512b.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_sha2_512b.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_sha2_512b.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_sha2_1024b.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_sha2_1024b.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_sha2_1024b.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_sha2_1024b.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_sha2_1024b.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_sha2_1024b.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_sha2_2048b.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_sha2_2048b.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_sha2_2048b.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_sha2_2048b.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_sha2_2048b.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-deep-epoch6/autoresearch/.runs/latest/riscv_sha2_2048b.b3.json"
+    ]
+  }
+}

--- a/src/backends/metal/kernels.metal
+++ b/src/backends/metal/kernels.metal
@@ -309,6 +309,30 @@ kernel void stwo_zig_fri_fold_circle(
     destination[index] = qm_add(sum, qm_mul(alpha, difference));
 }
 
+// Runtime quotient requests precompute prx*piy - pry*pix once per sample.
+// Since domain x/y are base-field values, each row then needs only two CM31
+// by M31 products instead of two full CM31 products.
+inline Cm31Value quotient_denominator_precomputed(
+    device const uint *sample_components,
+    uint sample_base,
+    uint domain_x,
+    uint domain_y
+) {
+    Cm31Value determinant = {
+        sample_components[sample_base], sample_components[sample_base + 1u]
+    };
+    Cm31Value pix = {
+        sample_components[sample_base + 4u], sample_components[sample_base + 5u]
+    };
+    Cm31Value piy = {
+        sample_components[sample_base + 6u], sample_components[sample_base + 7u]
+    };
+    return cm_add(
+        cm_sub(determinant, cm_mul_m31(piy, domain_x)),
+        cm_mul_m31(pix, domain_y)
+    );
+}
+
 kernel void stwo_zig_quotient_rows(
     device const uint *flat_views [[buffer(0)]],
     device const QuotientView *views [[buffer(1)]],
@@ -343,13 +367,9 @@ kernel void stwo_zig_quotient_rows(
         }
 
         uint sample_base = batch * 8u;
-        Cm31Value prx = { sample_components[sample_base], sample_components[sample_base + 1u] };
-        Cm31Value pry = { sample_components[sample_base + 2u], sample_components[sample_base + 3u] };
-        Cm31Value pix = { sample_components[sample_base + 4u], sample_components[sample_base + 5u] };
-        Cm31Value piy = { sample_components[sample_base + 6u], sample_components[sample_base + 7u] };
-        Cm31Value dx = { domain_x[row], 0u };
-        Cm31Value dy = { domain_y[row], 0u };
-        Cm31Value denominator = cm_sub(cm_mul(cm_sub(prx, dx), piy), cm_mul(cm_sub(pry, dy), pix));
+        Cm31Value denominator = quotient_denominator_precomputed(
+            sample_components, sample_base, domain_x[row], domain_y[row]
+        );
         Cm31Value denominator_inverse = cm_inv(denominator);
 
         uint linear_base = batch * 8u;
@@ -397,13 +417,8 @@ kernel void stwo_zig_quotient_rows_raw(
         }
 
         uint sample_base = batch * 8u;
-        Cm31Value prx = { sample_components[sample_base], sample_components[sample_base + 1u] };
-        Cm31Value pry = { sample_components[sample_base + 2u], sample_components[sample_base + 3u] };
-        Cm31Value pix = { sample_components[sample_base + 4u], sample_components[sample_base + 5u] };
-        Cm31Value piy = { sample_components[sample_base + 6u], sample_components[sample_base + 7u] };
-        Cm31Value denominator = cm_sub(
-            cm_mul(cm_sub(prx, { domain_x[row], 0u }), piy),
-            cm_mul(cm_sub(pry, { domain_y[row], 0u }), pix)
+        Cm31Value denominator = quotient_denominator_precomputed(
+            sample_components, sample_base, domain_x[row], domain_y[row]
         );
         Cm31Value denominator_inverse = cm_inv(denominator);
         uint linear_base = batch * 8u;
@@ -463,13 +478,8 @@ kernel void stwo_zig_quotient_finalize(
     Qm31Value accumulator = { 0u, 0u, 0u, 0u };
     for (uint batch = 0; batch < batch_count; ++batch) {
         uint sample_base = batch * 8u;
-        Cm31Value prx = { sample_components[sample_base], sample_components[sample_base + 1u] };
-        Cm31Value pry = { sample_components[sample_base + 2u], sample_components[sample_base + 3u] };
-        Cm31Value pix = { sample_components[sample_base + 4u], sample_components[sample_base + 5u] };
-        Cm31Value piy = { sample_components[sample_base + 6u], sample_components[sample_base + 7u] };
-        Cm31Value denominator = cm_sub(
-            cm_mul(cm_sub(prx, { domain_x[row], 0u }), piy),
-            cm_mul(cm_sub(pry, { domain_y[row], 0u }), pix)
+        Cm31Value denominator = quotient_denominator_precomputed(
+            sample_components, sample_base, domain_x[row], domain_y[row]
         );
         uint linear_base = batch * 8u;
         Qm31Value sum_a = { linear_terms[linear_base], linear_terms[linear_base + 1u],

--- a/src/backends/metal/runtime/polynomial_operations.zig
+++ b/src/backends/metal/runtime/polynomial_operations.zig
@@ -204,10 +204,10 @@ fn computeQuotientsConfigured(
     for (samples, 0..) |sample, index| {
         const base = index * 8;
         sample_words[base..][0..8].* = .{
-            sample.prx.a.v, sample.prx.b.v,
-            sample.pry.a.v, sample.pry.b.v,
-            sample.pix.a.v, sample.pix.b.v,
-            sample.piy.a.v, sample.piy.b.v,
+            sample.determinant.a.v, sample.determinant.b.v,
+            0,                      0,
+            sample.pix.a.v,         sample.pix.b.v,
+            sample.piy.a.v,         sample.piy.b.v,
         };
     }
 

--- a/src/core/crypto/blake2s_backend.zig
+++ b/src/core/crypto/blake2s_backend.zig
@@ -1,29 +1,14 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const contract = @import("blake2s_contract.zig");
+const parallel4 = @import("blake2s_parallel4.zig");
 const stream4 = @import("blake2s_stream4.zig");
 
 pub const Blake2sHash = [32]u8;
 
-pub const BackendMode = enum(u8) {
-    auto,
-    scalar,
-    simd,
-};
-
-pub const BackendSelection = struct {
-    requested: BackendMode,
-    effective: BackendMode,
-    simd_supported: bool,
-    explicit_simd_width: usize,
-};
-
-pub const SimdContract = struct {
-    pub const explicit_width = 4;
-    pub const input_alignment = @alignOf(u8);
-    pub const scalar_tail_supported = true;
-    pub const read_only_input_aliasing_supported = true;
-    pub const caller_scratch_bytes = 0;
-};
+pub const BackendMode = contract.BackendMode;
+pub const BackendSelection = contract.BackendSelection;
+pub const SimdContract = contract.SimdContract;
 
 /// Test-only dispatch evidence. Recording is compiled out of production
 /// artifacts so observing the contract cannot perturb benchmark results.
@@ -762,47 +747,6 @@ fn g4(a: *V4, b: *V4, c: *V4, d: *V4, x: V4, y: V4) void {
     b.* = rotr32x4(b.* ^ c.*, 7);
 }
 
-/// Advances four independent BLAKE2s G functions in lockstep. AArch64 has
-/// enough vector arithmetic throughput to execute several of these operations
-/// per cycle, but a source-level sequence of four complete G calls leaves the
-/// scheduler following one long dependency chain at a time. Grouping each
-/// dependency level exposes the four-way instruction-level parallelism while
-/// retaining the same four-message SIMD lane layout.
-inline fn g4Interleaved(
-    v: *[16]V4,
-    comptime a_indices: [4]u8,
-    comptime b_indices: [4]u8,
-    comptime c_indices: [4]u8,
-    comptime d_indices: [4]u8,
-    x: [4]V4,
-    y: [4]V4,
-) void {
-    inline for (0..4) |i| {
-        v[a_indices[i]] = v[a_indices[i]] +% v[b_indices[i]] +% x[i];
-    }
-    inline for (0..4) |i| {
-        v[d_indices[i]] = rotr32x4(v[d_indices[i]] ^ v[a_indices[i]], 16);
-    }
-    inline for (0..4) |i| {
-        v[c_indices[i]] +%= v[d_indices[i]];
-    }
-    inline for (0..4) |i| {
-        v[b_indices[i]] = rotr32x4(v[b_indices[i]] ^ v[c_indices[i]], 12);
-    }
-    inline for (0..4) |i| {
-        v[a_indices[i]] = v[a_indices[i]] +% v[b_indices[i]] +% y[i];
-    }
-    inline for (0..4) |i| {
-        v[d_indices[i]] = rotr32x4(v[d_indices[i]] ^ v[a_indices[i]], 8);
-    }
-    inline for (0..4) |i| {
-        v[c_indices[i]] +%= v[d_indices[i]];
-    }
-    inline for (0..4) |i| {
-        v[b_indices[i]] = rotr32x4(v[b_indices[i]] ^ v[c_indices[i]], 7);
-    }
-}
-
 fn compressSimd(h: *[8]u32, m: *const [16]u32, t0: u32, t1: u32, f0: u32) void {
     if (comptime builtin.is_test) _ = test_simd_compressions.fetchAdd(1, .monotonic);
     var v: [16]u32 = undefined;
@@ -872,7 +816,9 @@ fn compressParallel4(h: *[8]V4, m: *const [16]V4, t0: u32, t1: u32, f0: u32) voi
     v[14] ^= @as(V4, @splat(f0));
 
     inline for (BLAKE2S_SIGMA) |s| {
-        g4Interleaved(
+        parallel4.g4Interleaved(
+            V4,
+            rotr32x4,
             &v,
             .{ 0, 1, 2, 3 },
             .{ 4, 5, 6, 7 },
@@ -881,7 +827,9 @@ fn compressParallel4(h: *[8]V4, m: *const [16]V4, t0: u32, t1: u32, f0: u32) voi
             .{ m[s[0]], m[s[2]], m[s[4]], m[s[6]] },
             .{ m[s[1]], m[s[3]], m[s[5]], m[s[7]] },
         );
-        g4Interleaved(
+        parallel4.g4Interleaved(
+            V4,
+            rotr32x4,
             &v,
             .{ 0, 1, 2, 3 },
             .{ 5, 6, 7, 4 },

--- a/src/core/crypto/blake2s_backend.zig
+++ b/src/core/crypto/blake2s_backend.zig
@@ -762,6 +762,47 @@ fn g4(a: *V4, b: *V4, c: *V4, d: *V4, x: V4, y: V4) void {
     b.* = rotr32x4(b.* ^ c.*, 7);
 }
 
+/// Advances four independent BLAKE2s G functions in lockstep. AArch64 has
+/// enough vector arithmetic throughput to execute several of these operations
+/// per cycle, but a source-level sequence of four complete G calls leaves the
+/// scheduler following one long dependency chain at a time. Grouping each
+/// dependency level exposes the four-way instruction-level parallelism while
+/// retaining the same four-message SIMD lane layout.
+inline fn g4Interleaved(
+    v: *[16]V4,
+    comptime a_indices: [4]u8,
+    comptime b_indices: [4]u8,
+    comptime c_indices: [4]u8,
+    comptime d_indices: [4]u8,
+    x: [4]V4,
+    y: [4]V4,
+) void {
+    inline for (0..4) |i| {
+        v[a_indices[i]] = v[a_indices[i]] +% v[b_indices[i]] +% x[i];
+    }
+    inline for (0..4) |i| {
+        v[d_indices[i]] = rotr32x4(v[d_indices[i]] ^ v[a_indices[i]], 16);
+    }
+    inline for (0..4) |i| {
+        v[c_indices[i]] +%= v[d_indices[i]];
+    }
+    inline for (0..4) |i| {
+        v[b_indices[i]] = rotr32x4(v[b_indices[i]] ^ v[c_indices[i]], 12);
+    }
+    inline for (0..4) |i| {
+        v[a_indices[i]] = v[a_indices[i]] +% v[b_indices[i]] +% y[i];
+    }
+    inline for (0..4) |i| {
+        v[d_indices[i]] = rotr32x4(v[d_indices[i]] ^ v[a_indices[i]], 8);
+    }
+    inline for (0..4) |i| {
+        v[c_indices[i]] +%= v[d_indices[i]];
+    }
+    inline for (0..4) |i| {
+        v[b_indices[i]] = rotr32x4(v[b_indices[i]] ^ v[c_indices[i]], 7);
+    }
+}
+
 fn compressSimd(h: *[8]u32, m: *const [16]u32, t0: u32, t1: u32, f0: u32) void {
     if (comptime builtin.is_test) _ = test_simd_compressions.fetchAdd(1, .monotonic);
     var v: [16]u32 = undefined;
@@ -831,14 +872,24 @@ fn compressParallel4(h: *[8]V4, m: *const [16]V4, t0: u32, t1: u32, f0: u32) voi
     v[14] ^= @as(V4, @splat(f0));
 
     inline for (BLAKE2S_SIGMA) |s| {
-        g4(&v[0], &v[4], &v[8], &v[12], m[s[0]], m[s[1]]);
-        g4(&v[1], &v[5], &v[9], &v[13], m[s[2]], m[s[3]]);
-        g4(&v[2], &v[6], &v[10], &v[14], m[s[4]], m[s[5]]);
-        g4(&v[3], &v[7], &v[11], &v[15], m[s[6]], m[s[7]]);
-        g4(&v[0], &v[5], &v[10], &v[15], m[s[8]], m[s[9]]);
-        g4(&v[1], &v[6], &v[11], &v[12], m[s[10]], m[s[11]]);
-        g4(&v[2], &v[7], &v[8], &v[13], m[s[12]], m[s[13]]);
-        g4(&v[3], &v[4], &v[9], &v[14], m[s[14]], m[s[15]]);
+        g4Interleaved(
+            &v,
+            .{ 0, 1, 2, 3 },
+            .{ 4, 5, 6, 7 },
+            .{ 8, 9, 10, 11 },
+            .{ 12, 13, 14, 15 },
+            .{ m[s[0]], m[s[2]], m[s[4]], m[s[6]] },
+            .{ m[s[1]], m[s[3]], m[s[5]], m[s[7]] },
+        );
+        g4Interleaved(
+            &v,
+            .{ 0, 1, 2, 3 },
+            .{ 5, 6, 7, 4 },
+            .{ 10, 11, 8, 9 },
+            .{ 15, 12, 13, 14 },
+            .{ m[s[8]], m[s[10]], m[s[12]], m[s[14]] },
+            .{ m[s[9]], m[s[11]], m[s[13]], m[s[15]] },
+        );
     }
 
     for (0..8) |i| h[i] ^= v[i] ^ v[i + 8];

--- a/src/core/crypto/blake2s_contract.zig
+++ b/src/core/crypto/blake2s_contract.zig
@@ -1,0 +1,20 @@
+pub const BackendMode = enum(u8) {
+    auto,
+    scalar,
+    simd,
+};
+
+pub const BackendSelection = struct {
+    requested: BackendMode,
+    effective: BackendMode,
+    simd_supported: bool,
+    explicit_simd_width: usize,
+};
+
+pub const SimdContract = struct {
+    pub const explicit_width = 4;
+    pub const input_alignment = @alignOf(u8);
+    pub const scalar_tail_supported = true;
+    pub const read_only_input_aliasing_supported = true;
+    pub const caller_scratch_bytes = 0;
+};

--- a/src/core/crypto/blake2s_parallel4.zig
+++ b/src/core/crypto/blake2s_parallel4.zig
@@ -1,0 +1,39 @@
+/// Advances four independent BLAKE2s G functions in lockstep. Grouping each
+/// dependency level exposes four-way instruction-level parallelism while
+/// retaining the caller's four-message SIMD lane layout.
+pub inline fn g4Interleaved(
+    comptime V: type,
+    comptime rotate: anytype,
+    v: *[16]V,
+    comptime a_indices: [4]u8,
+    comptime b_indices: [4]u8,
+    comptime c_indices: [4]u8,
+    comptime d_indices: [4]u8,
+    x: [4]V,
+    y: [4]V,
+) void {
+    inline for (0..4) |i| {
+        v[a_indices[i]] = v[a_indices[i]] +% v[b_indices[i]] +% x[i];
+    }
+    inline for (0..4) |i| {
+        v[d_indices[i]] = rotate(v[d_indices[i]] ^ v[a_indices[i]], 16);
+    }
+    inline for (0..4) |i| {
+        v[c_indices[i]] +%= v[d_indices[i]];
+    }
+    inline for (0..4) |i| {
+        v[b_indices[i]] = rotate(v[b_indices[i]] ^ v[c_indices[i]], 12);
+    }
+    inline for (0..4) |i| {
+        v[a_indices[i]] = v[a_indices[i]] +% v[b_indices[i]] +% y[i];
+    }
+    inline for (0..4) |i| {
+        v[d_indices[i]] = rotate(v[d_indices[i]] ^ v[a_indices[i]], 8);
+    }
+    inline for (0..4) |i| {
+        v[c_indices[i]] +%= v[d_indices[i]];
+    }
+    inline for (0..4) |i| {
+        v[b_indices[i]] = rotate(v[b_indices[i]] ^ v[c_indices[i]], 7);
+    }
+}

--- a/src/core/fields/m31.zig
+++ b/src/core/fields/m31.zig
@@ -148,17 +148,16 @@ pub const M31 = struct {
 
 /// Reduce a 64-bit integer modulo p = 2^31 - 1.
 ///
-/// For x <= (p-1)^2 < 2^62, two Mersenne folds suffice.
-fn reduce64(x: u64) u32 {
+/// Two Mersenne folds reduce every `u64` input to at most `p + 3`. The
+/// wrapping subtraction is then smaller exactly when canonicalization is
+/// required, avoiding a compare/select chain on AArch64.
+inline fn reduce64(x: u64) u32 {
     const p: u64 = Modulus;
     var t: u64 = (x & p) + (x >> 31);
     t = (t & p) + (t >> 31);
 
     const r: u32 = @intCast(t);
-    // t is in [0, p+1].
-    if (r == Modulus) return 0;
-    if (r > Modulus) return r - Modulus;
-    return r;
+    return @min(r, r -% Modulus);
 }
 
 /// Reduce a product of two canonical M31 values. Unlike `reduce64`, the input
@@ -520,6 +519,30 @@ test "m31: bounded product reduction matches generic reduction" {
     const packed_result: [PACK_WIDTH]u32 = mulPacked(lhs_packed, rhs_packed);
     for (lhs_packed, rhs_packed, packed_result) |a, b, result| {
         try std.testing.expectEqual(reduceProduct(@as(u64, a) * b), result);
+    }
+}
+
+test "m31: generic reduction canonicalizes the full u64 range" {
+    const p: u64 = Modulus;
+    const edge = [_]u64{
+        0,
+        1,
+        p - 1,
+        p,
+        p + 1,
+        p * p,
+        4 * (p - 1) * (p - 1),
+        std.math.maxInt(u64),
+    };
+    for (edge) |value| {
+        try std.testing.expectEqual(@as(u32, @intCast(value % p)), reduce64(value));
+    }
+
+    var prng = std.Random.DefaultPrng.init(0x243f_6a88_85a3_08d3);
+    const random = prng.random();
+    for (0..4096) |_| {
+        const value = random.int(u64);
+        try std.testing.expectEqual(@as(u32, @intCast(value % p)), reduce64(value));
     }
 }
 

--- a/src/core/fields/m31.zig
+++ b/src/core/fields/m31.zig
@@ -389,6 +389,19 @@ pub inline fn dot4Packed(
     );
 }
 
+/// Four-term scalar dot product with one final Mersenne reduction.
+///
+/// Four canonical products sum to less than `2^64`, so the accumulation is
+/// exact in `u64`. This is the scalar-gather counterpart to `dot4Packed` for
+/// reducers whose four terms come from independent borrowed columns.
+pub inline fn dot4(values: [4]M31, coefficients: [4]M31) M31 {
+    var sum: u64 = 0;
+    inline for (0..4) |term| {
+        sum += @as(u64, values[term].v) * @as(u64, coefficients[term].v);
+    }
+    return M31.fromU64(sum);
+}
+
 /// Native-width form of `reduceProduct`; every lane is a canonical product.
 inline fn reduceProductPacked(x: PackedU64) PackedM31 {
     const p64: PackedU64 = @splat(@as(u64, Modulus));
@@ -529,15 +542,18 @@ test "m31: packed four-term dot product matches scalar accumulation" {
 
     const actual: [PACK_WIDTH]u32 = dot4Packed(packed_values, packed_coefficients);
     for (0..PACK_WIDTH) |lane| {
+        var scalar_values: [4]M31 = undefined;
+        var scalar_coefficients: [4]M31 = undefined;
         var expected = M31.zero();
         inline for (0..4) |term| {
+            scalar_values[term] = M31.fromCanonical(values[term][lane]);
+            scalar_coefficients[term] = M31.fromCanonical(coefficients[term][lane]);
             expected = expected.add(
-                M31.fromCanonical(values[term][lane]).mul(
-                    M31.fromCanonical(coefficients[term][lane]),
-                ),
+                scalar_values[term].mul(scalar_coefficients[term]),
             );
         }
         try std.testing.expectEqual(expected.v, actual[lane]);
+        try std.testing.expectEqual(expected.v, dot4(scalar_values, scalar_coefficients).v);
     }
 }
 

--- a/src/core/fields/mod.zig
+++ b/src/core/fields/mod.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 
 pub const m31 = @import("m31.zig");
 pub const cm31 = @import("cm31.zig");
@@ -13,21 +14,33 @@ pub const qm31 = @import("qm31.zig");
 /// Failure modes:
 /// - Returns an error if any element inversion fails.
 pub fn batchInverseInPlace(comptime F: type, column: []const F, dst: []F) !void {
-    const width: usize = 4;
     std.debug.assert(dst.len >= column.len);
     const n = column.len;
 
-    if (n <= width or (n % width) != 0) {
-        try batchInverseClassic(F, column, dst);
-        return;
+    if (comptime F == cm31.CM31 and builtin.cpu.arch == .aarch64 and builtin.zig_backend != .stage2_c) {
+        if (n >= 32 and (n & 31) == 0) return batchInverseCM31Packed(column, dst, 32);
+        if (n >= 16 and (n & 15) == 0) return batchInverseCM31Packed(column, dst, 16);
+        if (n >= 8 and (n & 7) == 0) return batchInverseCM31Packed(column, dst, 8);
     }
+    if (n > 8 and (n & 7) == 0) return batchInverseStriped(F, column, dst, 8);
+    if (n > 4 and (n & 3) == 0) return batchInverseStriped(F, column, dst, 4);
+    return batchInverseClassic(F, column, dst);
+}
 
+fn batchInverseStriped(
+    comptime F: type,
+    column: []const F,
+    dst: []F,
+    comptime width: usize,
+) !void {
+    const n = column.len;
+    std.debug.assert(n > width and (n & (width - 1)) == 0);
     var cum_prod: [width]F = undefined;
     for (&cum_prod) |*v| v.* = F.one();
 
     var i: usize = 0;
     while (i < n) : (i += 1) {
-        const lane = i % width;
+        const lane = i & (width - 1);
         cum_prod[lane] = cum_prod[lane].mul(column[i]);
         dst[i] = cum_prod[lane];
     }
@@ -38,12 +51,114 @@ pub fn batchInverseInPlace(comptime F: type, column: []const F, dst: []F) !void 
     i = n;
     while (i > width) {
         i -= 1;
-        const lane = i % width;
+        const lane = i & (width - 1);
         dst[i] = dst[i - width].mul(tail_inverses[lane]);
         tail_inverses[lane] = tail_inverses[lane].mul(column[i]);
     }
 
     @memcpy(dst[0..width], tail_inverses[0..]);
+}
+
+const PackedCM31x4 = struct {
+    a: m31.Vec4u32,
+    b: m31.Vec4u32,
+};
+
+inline fn loadPackedCM31x4(ptr: [*]const cm31.CM31) PackedCM31x4 {
+    comptime {
+        std.debug.assert(@sizeOf(cm31.CM31) == 2 * @sizeOf(u32));
+        std.debug.assert(@offsetOf(cm31.CM31, "a") == 0);
+        std.debug.assert(@offsetOf(cm31.CM31, "b") == @sizeOf(u32));
+    }
+    const raw: *const [8]u32 = @ptrCast(ptr);
+    const lo: m31.Vec4u32 = raw[0..4].*;
+    const hi: m31.Vec4u32 = raw[4..8].*;
+    return .{
+        .a = @shuffle(u32, lo, hi, @Vector(4, i32){ 0, 2, -1, -3 }),
+        .b = @shuffle(u32, lo, hi, @Vector(4, i32){ 1, 3, -2, -4 }),
+    };
+}
+
+inline fn storePackedCM31x4(ptr: [*]cm31.CM31, value: PackedCM31x4) void {
+    const lo = @shuffle(u32, value.a, value.b, @Vector(4, i32){ 0, -1, 1, -2 });
+    const hi = @shuffle(u32, value.a, value.b, @Vector(4, i32){ 2, -3, 3, -4 });
+    const raw: *[8]u32 = @ptrCast(ptr);
+    raw[0..4].* = lo;
+    raw[4..8].* = hi;
+}
+
+inline fn mulPackedCM31x4(lhs: PackedCM31x4, rhs: PackedCM31x4) PackedCM31x4 {
+    const ac = m31.mulVec4(lhs.a, rhs.a);
+    const bd = m31.mulVec4(lhs.b, rhs.b);
+    const cross = m31.mulVec4(
+        m31.addVec4(lhs.a, lhs.b),
+        m31.addVec4(rhs.a, rhs.b),
+    );
+    return .{
+        .a = m31.subVec4(ac, bd),
+        .b = m31.subVec4(m31.subVec4(cross, ac), bd),
+    };
+}
+
+/// Montgomery inversion with independent prefix chains packed across CM31
+/// values. Each four-element group maps the real and imaginary coordinates to
+/// AdvSIMD lanes, so one Karatsuba product advances four chains. Wider batches
+/// interleave several vector chains to cover multiply latency; the measured
+/// AArch64 optimum is capped at 32 elements to avoid register-spill growth.
+fn batchInverseCM31Packed(
+    column: []const cm31.CM31,
+    dst: []cm31.CM31,
+    comptime width: usize,
+) !void {
+    comptime std.debug.assert(width == 8 or width == 16 or width == 32);
+    std.debug.assert(dst.len >= column.len and column.len >= width and (column.len & (width - 1)) == 0);
+    const groups = width / 4;
+    const one = PackedCM31x4{
+        .a = @splat(1),
+        .b = @splat(0),
+    };
+    var cumulative = [_]PackedCM31x4{one} ** groups;
+    var base: usize = 0;
+    while (base < column.len) : (base += width) {
+        inline for (0..groups) |group| {
+            cumulative[group] = mulPackedCM31x4(
+                cumulative[group],
+                loadPackedCM31x4(column.ptr + base + 4 * group),
+            );
+            storePackedCM31x4(dst.ptr + base + 4 * group, cumulative[group]);
+        }
+    }
+
+    const tail_products: [width]cm31.CM31 = dst[column.len - width ..][0..width].*;
+    var tail_inverses: [width]cm31.CM31 = undefined;
+    try batchInverseClassic(cm31.CM31, &tail_products, &tail_inverses);
+    var inverse: [groups]PackedCM31x4 = undefined;
+    inline for (0..groups) |group| {
+        inverse[group] = loadPackedCM31x4((&tail_inverses).ptr + 4 * group);
+    }
+
+    var block = column.len;
+    while (block > width) {
+        block -= width;
+        inline for (0..groups) |group| {
+            storePackedCM31x4(
+                dst.ptr + block + 4 * group,
+                mulPackedCM31x4(
+                    loadPackedCM31x4(dst.ptr + block - width + 4 * group),
+                    inverse[group],
+                ),
+            );
+        }
+        inline for (0..groups) |group| {
+            inverse[group] = mulPackedCM31x4(
+                inverse[group],
+                loadPackedCM31x4(column.ptr + block + 4 * group),
+            );
+        }
+    }
+    inline for (0..groups) |group| {
+        storePackedCM31x4(dst.ptr + 4 * group, inverse[group]);
+    }
 }
 
 pub fn batchInverse(comptime F: type, allocator: std.mem.Allocator, column: []const F) ![]F {

--- a/src/core/pcs/quotients/row_evaluation.zig
+++ b/src/core/pcs/quotients/row_evaluation.zig
@@ -141,8 +141,7 @@ fn denominatorInversesInto(
 }
 
 const SamplePointComponents = struct {
-    prx: CM31,
-    pry: CM31,
+    determinant: CM31,
     pix: CM31,
     piy: CM31,
 };
@@ -168,11 +167,14 @@ pub const RowQuotientWorkspace = struct {
         errdefer allocator.free(batch_numerators);
 
         for (sample_batches, 0..) |batch, i| {
+            const prx = batch.point.x.c0;
+            const pry = batch.point.y.c0;
+            const pix = batch.point.x.c1;
+            const piy = batch.point.y.c1;
             sample_point_components[i] = .{
-                .prx = batch.point.x.c0,
-                .pry = batch.point.y.c0,
-                .pix = batch.point.x.c1,
-                .piy = batch.point.y.c1,
+                .determinant = prx.mul(piy).sub(pry.mul(pix)),
+                .pix = pix,
+                .piy = piy,
             };
         }
 
@@ -229,6 +231,34 @@ pub const RowQuotientWorkspace = struct {
         try batchInverseIntoCM31(denominators, denominator_inverses);
     }
 
+    /// Computes batch-major denominator inverses for several domain points.
+    /// Keeping adjacent rows contiguous lets quotient finalization load four
+    /// CM31 values without gathering from a row-major batch stride.
+    pub fn prepareDenominatorInversesForRowsBatchMajor(
+        self: *const RowQuotientWorkspace,
+        domain_points: []const CirclePointM31,
+        denominators: []CM31,
+        denominator_inverses: []CM31,
+    ) !void {
+        const cell_count = std.math.mul(
+            usize,
+            domain_points.len,
+            self.sample_point_components.len,
+        ) catch return error.ScratchSizeOverflow;
+        if (denominators.len != cell_count) return error.ShapeMismatch;
+        if (denominator_inverses.len != cell_count) return error.ShapeMismatch;
+
+        for (self.sample_point_components, 0..) |sample, batch| {
+            const start = batch * domain_points.len;
+            denominatorValuesForSampleBatch(
+                sample,
+                domain_points,
+                denominators[start..][0..domain_points.len],
+            );
+        }
+        try batchInverseIntoCM31(denominators, denominator_inverses);
+    }
+
     pub inline fn resetNumerators(self: *RowQuotientWorkspace) void {
         @memset(self.batch_numerators, QM31.zero());
     }
@@ -254,11 +284,84 @@ fn denominatorValuesIntoFromComponents(
     denominators: []CM31,
 ) void {
     std.debug.assert(denominators.len == sample_point_components.len);
-    const domain_x = CM31.fromBase(domain_point.x);
-    const domain_y = CM31.fromBase(domain_point.y);
-
     for (sample_point_components, 0..) |sample, i| {
-        denominators[i] = sample.prx.sub(domain_x).mul(sample.piy).sub(sample.pry.sub(domain_y).mul(sample.pix));
+        denominators[i] = denominatorValue(sample, domain_point);
+    }
+}
+
+inline fn denominatorValue(sample: SamplePointComponents, domain_point: CirclePointM31) CM31 {
+    // (prx - x) * piy - (pry - y) * pix
+    // = prx*piy - pry*pix - x*piy + y*pix.
+    return sample.determinant
+        .sub(sample.piy.mulM31(domain_point.x))
+        .add(sample.pix.mulM31(domain_point.y));
+}
+
+/// Evaluates one sample-point denominator across adjacent domain rows. The
+/// sample terms are constant, so the four base-field coordinate multiplies
+/// are issued as packed row vectors instead of repeating two CM31 products.
+fn denominatorValuesForSampleBatch(
+    sample: SamplePointComponents,
+    domain_points: []const CirclePointM31,
+    denominators: []CM31,
+) void {
+    std.debug.assert(denominators.len == domain_points.len);
+    comptime {
+        if (@sizeOf(CirclePointM31) != 2 * @sizeOf(M31) or
+            @offsetOf(CirclePointM31, "y") != @sizeOf(M31))
+        {
+            @compileError("packed circle-point layout changed");
+        }
+        if (@sizeOf(CM31) != 2 * @sizeOf(M31) or
+            @offsetOf(CM31, "b") != @sizeOf(M31))
+        {
+            @compileError("packed CM31 layout changed");
+        }
+    }
+
+    const point_words: [*]const M31 = @ptrCast(domain_points.ptr);
+    const denominator_words: [*]M31 = @ptrCast(denominators.ptr);
+    const determinant_re: m31_mod.Vec4u32 = @splat(sample.determinant.a.v);
+    const determinant_im: m31_mod.Vec4u32 = @splat(sample.determinant.b.v);
+    const piy_re: m31_mod.Vec4u32 = @splat(sample.piy.a.v);
+    const piy_im: m31_mod.Vec4u32 = @splat(sample.piy.b.v);
+    const pix_re: m31_mod.Vec4u32 = @splat(sample.pix.a.v);
+    const pix_im: m31_mod.Vec4u32 = @splat(sample.pix.b.v);
+
+    var row: usize = 0;
+    while (row + m31_mod.VEC_WIDTH <= domain_points.len) : (row += m31_mod.VEC_WIDTH) {
+        const raw_lo = m31_mod.loadVec4(point_words + row * 2);
+        const raw_hi = m31_mod.loadVec4(point_words + row * 2 + m31_mod.VEC_WIDTH);
+        const xs = @shuffle(u32, raw_lo, raw_hi, @Vector(4, i32){ 0, 2, -1, -3 });
+        const ys = @shuffle(u32, raw_lo, raw_hi, @Vector(4, i32){ 1, 3, -2, -4 });
+        const real = m31_mod.addVec4(
+            m31_mod.subVec4(determinant_re, m31_mod.mulVec4(xs, piy_re)),
+            m31_mod.mulVec4(ys, pix_re),
+        );
+        const imaginary = m31_mod.addVec4(
+            m31_mod.subVec4(determinant_im, m31_mod.mulVec4(xs, piy_im)),
+            m31_mod.mulVec4(ys, pix_im),
+        );
+        const interleaved_lo = @shuffle(
+            u32,
+            real,
+            imaginary,
+            @Vector(4, i32){ 0, -1, 1, -2 },
+        );
+        const interleaved_hi = @shuffle(
+            u32,
+            real,
+            imaginary,
+            @Vector(4, i32){ 2, -3, 3, -4 },
+        );
+        m31_mod.storeVec4(denominator_words + row * 2, interleaved_lo);
+        m31_mod.storeVec4(
+            denominator_words + row * 2 + m31_mod.VEC_WIDTH,
+            interleaved_hi,
+        );
+    }
+    while (row < domain_points.len) : (row += 1) {
+        denominators[row] = denominatorValue(sample, domain_points[row]);
     }
 }
 

--- a/src/core/pcs/quotients/row_evaluation.zig
+++ b/src/core/pcs/quotients/row_evaluation.zig
@@ -8,7 +8,8 @@ const std = @import("std");
 const circle = @import("../../circle.zig");
 const constraints = @import("../../constraints.zig");
 const cm31_mod = @import("../../fields/cm31.zig");
-const m31_mod = @import("../../fields/m31.zig");
+const fields = @import("../../fields/mod.zig");
+const m31_mod = fields.m31;
 const qm31_mod = @import("../../fields/qm31.zig");
 const samples = @import("samples.zig");
 
@@ -263,25 +264,35 @@ fn denominatorValuesIntoFromComponents(
 
 fn batchInverseIntoCM31(values: []const CM31, out: []CM31) !void {
     if (values.len != out.len) return error.ShapeMismatch;
-    if (values.len == 0) return;
+    fields.batchInverseInPlace(CM31, values, out) catch return error.DivisionByZero;
+}
 
-    out[0] = CM31.one();
-    var i: usize = 1;
-    while (i < values.len) : (i += 1) {
-        out[i] = out[i - 1].mul(values[i - 1]);
+test "CM31 batch inversion matches independent inverses" {
+    const lengths = [_]usize{ 1, 2, 3, 7, 8, 16, 24, 31, 32, 40, 63, 64 };
+    var values: [64]CM31 = undefined;
+    var inverses: [64]CM31 = undefined;
+    for (&values, 0..) |*value, i| {
+        value.* = CM31.fromM31(
+            M31.fromU64(17 * i + 3),
+            M31.fromU64(29 * i + 5),
+        );
     }
-
-    var inv_total = out[values.len - 1].mul(values[values.len - 1]).inv() catch {
-        return error.DivisionByZero;
-    };
-
-    var j: usize = values.len;
-    while (j > 0) {
-        j -= 1;
-        const prefix = if (j == 0) CM31.one() else out[j];
-        out[j] = inv_total.mul(prefix);
-        inv_total = inv_total.mul(values[j]);
+    for (lengths) |len| {
+        try batchInverseIntoCM31(values[0..len], inverses[0..len]);
+        for (values[0..len], inverses[0..len]) |value, inverse| {
+            try std.testing.expect(value.mul(inverse).eql(CM31.one()));
+        }
     }
+}
+
+test "CM31 batch inversion rejects a zero lane product" {
+    var values = [_]CM31{CM31.one()} ** 16;
+    var inverses: [16]CM31 = undefined;
+    values[11] = CM31.zero();
+    try std.testing.expectError(
+        error.DivisionByZero,
+        batchInverseIntoCM31(&values, &inverses),
+    );
 }
 
 /// Computes one quotient row using caller-provided reusable scratch.

--- a/src/prover/pcs/quotient_compact_groups.zig
+++ b/src/prover/pcs/quotient_compact_groups.zig
@@ -48,7 +48,31 @@ pub fn accumulate(
 
         var sums: [qm31.SECURE_EXTENSION_DEGREE][2]M31 =
             @splat(@splat(M31.zero()));
-        for (group.members) |member| {
+        var member_index: usize = 0;
+        while (member_index + 4 <= group.members.len) : (member_index += 4) {
+            var even_values: [4]M31 = undefined;
+            var odd_values: [4]M31 = undefined;
+            inline for (0..4) |term| {
+                const member = group.members[member_index + term];
+                std.debug.assert(source_index + 1 < member.values.len);
+                even_values[term] = member.values[source_index];
+                odd_values[term] = member.values[source_index + 1];
+            }
+            inline for (0..qm31.SECURE_EXTENSION_DEGREE) |coordinate| {
+                var coefficients: [4]M31 = undefined;
+                inline for (0..4) |term| {
+                    coefficients[term] = group.members[member_index + term].coefficients[coordinate];
+                }
+                sums[coordinate][0] = sums[coordinate][0].add(
+                    m31.dot4(even_values, coefficients),
+                );
+                sums[coordinate][1] = sums[coordinate][1].add(
+                    m31.dot4(odd_values, coefficients),
+                );
+            }
+        }
+        while (member_index < group.members.len) : (member_index += 1) {
+            const member = group.members[member_index];
             std.debug.assert(source_index + 1 < member.values.len);
             inline for (0..qm31.SECURE_EXTENSION_DEGREE) |coordinate| {
                 sums[coordinate][0] = sums[coordinate][0].add(
@@ -116,23 +140,25 @@ pub fn scalarValueAt(group: Group, position: usize) QM31 {
     return combined;
 }
 
-test "compact grouped lifting matches scalar member reduction" {
+test "compact grouped lifting matches scalar member reduction with dot tail" {
     const row_capacity: usize = 37;
     var numerators = [_]M31{M31.zero()} ** (2 * qm31.SECURE_EXTENSION_DEGREE * row_capacity);
-    var values_a: [64]M31 = undefined;
-    var values_b: [64]M31 = undefined;
-    for (&values_a, 0..) |*value, index| value.* = M31.fromCanonical(@intCast(19 + index * 97));
-    for (&values_b, 0..) |*value, index| value.* = M31.fromCanonical(@intCast(23 + index * 131));
-    const members = [_]Member{
-        .{ .values = &values_a, .coefficients = .{
-            M31.fromCanonical(3), M31.fromCanonical(5),
-            M31.fromCanonical(7), M31.fromCanonical(11),
-        } },
-        .{ .values = &values_b, .coefficients = .{
-            M31.fromCanonical(13), M31.fromCanonical(17),
-            M31.fromCanonical(19), M31.fromCanonical(23),
-        } },
-    };
+    var member_values: [5][64]M31 = undefined;
+    var members: [5]Member = undefined;
+    for (&member_values, &members, 0..) |*values, *member, member_index| {
+        for (values, 0..) |*value, index| {
+            value.* = M31.fromCanonical(@intCast(19 + member_index * 17 + index * 97));
+        }
+        member.* = .{
+            .values = values,
+            .coefficients = .{
+                M31.fromCanonical(@intCast(3 + member_index * 11)),
+                M31.fromCanonical(@intCast(5 + member_index * 13)),
+                M31.fromCanonical(@intCast(7 + member_index * 17)),
+                M31.fromCanonical(@intCast(11 + member_index * 19)),
+            },
+        };
+    }
     const Case = struct { shift: u6, start: usize, len: usize };
     for ([_]Case{
         .{ .shift = 2, .start = 0, .len = 37 },
@@ -149,9 +175,12 @@ test "compact grouped lifting matches scalar member reduction" {
             const position = case.start + row;
             const source_index = ((position >> case.shift) << 1) + (position & 1);
             inline for (0..qm31.SECURE_EXTENSION_DEGREE) |coordinate| {
-                const expected = values_a[source_index].mul(members[0].coefficients[coordinate]).add(
-                    values_b[source_index].mul(members[1].coefficients[coordinate]),
-                );
+                var expected = M31.zero();
+                for (members) |member| {
+                    expected = expected.add(
+                        member.values[source_index].mul(member.coefficients[coordinate]),
+                    );
+                }
                 const plane = qm31.SECURE_EXTENSION_DEGREE + coordinate;
                 try std.testing.expectEqual(expected.v, numerators[plane * row_capacity + row].v);
             }

--- a/src/prover/pcs/quotient_compact_groups.zig
+++ b/src/prover/pcs/quotient_compact_groups.zig
@@ -1,6 +1,7 @@
 //! Register-resident reduction of compact quotient contribution groups.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const m31 = @import("stwo_core").fields.m31;
 const qm31 = @import("stwo_core").fields.qm31;
 const planning = @import("quotients/planning.zig");
@@ -48,39 +49,91 @@ pub fn accumulate(
 
         var sums: [qm31.SECURE_EXTENSION_DEGREE][2]M31 =
             @splat(@splat(M31.zero()));
-        var member_index: usize = 0;
-        while (member_index + 4 <= group.members.len) : (member_index += 4) {
-            var even_values: [4]M31 = undefined;
-            var odd_values: [4]M31 = undefined;
-            inline for (0..4) |term| {
-                const member = group.members[member_index + term];
-                std.debug.assert(source_index + 1 < member.values.len);
-                even_values[term] = member.values[source_index];
-                odd_values[term] = member.values[source_index + 1];
-            }
-            inline for (0..qm31.SECURE_EXTENSION_DEGREE) |coordinate| {
-                var coefficients: [4]M31 = undefined;
+        if (comptime builtin.cpu.arch == .aarch64 and
+            builtin.zig_backend != .stage2_c)
+        {
+            var even_sum: m31.Vec4u32 = @splat(0);
+            var odd_sum: m31.Vec4u32 = @splat(0);
+            var member_index: usize = 0;
+            while (member_index + 4 <= group.members.len) : (member_index += 4) {
+                var even_products: [4]m31.Vec4u32 = undefined;
+                var odd_products: [4]m31.Vec4u32 = undefined;
                 inline for (0..4) |term| {
-                    coefficients[term] = group.members[member_index + term].coefficients[coordinate];
+                    const member = group.members[member_index + term];
+                    std.debug.assert(source_index + 1 < member.values.len);
+                    const coefficients = m31.loadVec4(member.coefficients[0..].ptr);
+                    even_products[term] = m31.mulVec4(
+                        coefficients,
+                        @splat(member.values[source_index].v),
+                    );
+                    odd_products[term] = m31.mulVec4(
+                        coefficients,
+                        @splat(member.values[source_index + 1].v),
+                    );
                 }
-                sums[coordinate][0] = sums[coordinate][0].add(
-                    m31.dot4(even_values, coefficients),
+                const even_batch = m31.addVec4(
+                    m31.addVec4(even_products[0], even_products[1]),
+                    m31.addVec4(even_products[2], even_products[3]),
                 );
-                sums[coordinate][1] = sums[coordinate][1].add(
-                    m31.dot4(odd_values, coefficients),
+                const odd_batch = m31.addVec4(
+                    m31.addVec4(odd_products[0], odd_products[1]),
+                    m31.addVec4(odd_products[2], odd_products[3]),
+                );
+                even_sum = m31.addVec4(even_sum, even_batch);
+                odd_sum = m31.addVec4(odd_sum, odd_batch);
+            }
+            while (member_index < group.members.len) : (member_index += 1) {
+                const member = group.members[member_index];
+                std.debug.assert(source_index + 1 < member.values.len);
+                const coefficients = m31.loadVec4(member.coefficients[0..].ptr);
+                even_sum = m31.addVec4(
+                    even_sum,
+                    m31.mulVec4(coefficients, @splat(member.values[source_index].v)),
+                );
+                odd_sum = m31.addVec4(
+                    odd_sum,
+                    m31.mulVec4(coefficients, @splat(member.values[source_index + 1].v)),
                 );
             }
-        }
-        while (member_index < group.members.len) : (member_index += 1) {
-            const member = group.members[member_index];
-            std.debug.assert(source_index + 1 < member.values.len);
             inline for (0..qm31.SECURE_EXTENSION_DEGREE) |coordinate| {
-                sums[coordinate][0] = sums[coordinate][0].add(
-                    member.values[source_index].mul(member.coefficients[coordinate]),
-                );
-                sums[coordinate][1] = sums[coordinate][1].add(
-                    member.values[source_index + 1].mul(member.coefficients[coordinate]),
-                );
+                sums[coordinate][0] = M31.fromCanonical(even_sum[coordinate]);
+                sums[coordinate][1] = M31.fromCanonical(odd_sum[coordinate]);
+            }
+        } else {
+            var member_index: usize = 0;
+            while (member_index + 4 <= group.members.len) : (member_index += 4) {
+                var even_values: [4]M31 = undefined;
+                var odd_values: [4]M31 = undefined;
+                inline for (0..4) |term| {
+                    const member = group.members[member_index + term];
+                    std.debug.assert(source_index + 1 < member.values.len);
+                    even_values[term] = member.values[source_index];
+                    odd_values[term] = member.values[source_index + 1];
+                }
+                inline for (0..qm31.SECURE_EXTENSION_DEGREE) |coordinate| {
+                    var coefficients: [4]M31 = undefined;
+                    inline for (0..4) |term| {
+                        coefficients[term] = group.members[member_index + term].coefficients[coordinate];
+                    }
+                    sums[coordinate][0] = sums[coordinate][0].add(
+                        m31.dot4(even_values, coefficients),
+                    );
+                    sums[coordinate][1] = sums[coordinate][1].add(
+                        m31.dot4(odd_values, coefficients),
+                    );
+                }
+            }
+            while (member_index < group.members.len) : (member_index += 1) {
+                const member = group.members[member_index];
+                std.debug.assert(source_index + 1 < member.values.len);
+                inline for (0..qm31.SECURE_EXTENSION_DEGREE) |coordinate| {
+                    sums[coordinate][0] = sums[coordinate][0].add(
+                        member.values[source_index].mul(member.coefficients[coordinate]),
+                    );
+                    sums[coordinate][1] = sums[coordinate][1].add(
+                        member.values[source_index + 1].mul(member.coefficients[coordinate]),
+                    );
+                }
             }
         }
 

--- a/src/prover/pcs/quotient_row_executor.zig
+++ b/src/prover/pcs/quotient_row_executor.zig
@@ -56,6 +56,7 @@ pub const Scratch = struct {
     denominator_inverses: []CM31,
     batch_count: usize,
     prepared_rows: usize,
+    inverse_layout: enum { row_major, batch_major },
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -79,6 +80,7 @@ pub const Scratch = struct {
             .denominator_inverses = denominator_inverses,
             .batch_count = batch_count,
             .prepared_rows = 0,
+            .inverse_layout = .row_major,
         };
     }
 
@@ -109,13 +111,45 @@ pub const Scratch = struct {
             self.denominator_inverses[0..cell_count],
         );
         self.prepared_rows = row_count;
+        self.inverse_layout = .row_major;
+    }
+
+    pub fn prepareBatchMajor(
+        self: *Scratch,
+        workspace: *const quotients.RowQuotientWorkspace,
+        row_count: usize,
+    ) !void {
+        if (row_count == 0 or row_count > self.rowCapacity()) return error.InvalidChunkSize;
+        if (workspace.batch_numerators.len != self.batch_count) return error.ShapeMismatch;
+        self.prepared_rows = 0;
+        const cell_count = std.math.mul(usize, row_count, self.batch_count) catch
+            return error.ScratchSizeOverflow;
+        try workspace.prepareDenominatorInversesForRowsBatchMajor(
+            self.domain_points[0..row_count],
+            self.denominators[0..cell_count],
+            self.denominator_inverses[0..cell_count],
+        );
+        self.prepared_rows = row_count;
+        self.inverse_layout = .batch_major;
     }
 
     pub fn inversesForRow(self: Scratch, row: usize) ![]const CM31 {
-        if (row >= self.prepared_rows) return error.InvalidChunkSize;
+        if (self.inverse_layout != .row_major or row >= self.prepared_rows) {
+            return error.InvalidChunkSize;
+        }
         const start = std.math.mul(usize, row, self.batch_count) catch
             return error.ScratchSizeOverflow;
         return self.denominator_inverses[start..][0..self.batch_count];
+    }
+
+    pub inline fn batchMajorInversePtr(self: *const Scratch, batch: usize, row: usize) [*]const CM31 {
+        std.debug.assert(self.inverse_layout == .batch_major);
+        std.debug.assert(batch < self.batch_count and row < self.prepared_rows);
+        return self.denominator_inverses.ptr + batch * self.prepared_rows + row;
+    }
+
+    pub inline fn batchMajorInverse(self: *const Scratch, batch: usize, row: usize) CM31 {
+        return self.batchMajorInversePtr(batch, row)[0];
     }
 
     pub fn retainedBytes(self: Scratch) usize {
@@ -470,6 +504,33 @@ test "quotient row inverses match scalar rows across batch counts and domains" {
                 );
                 try std.testing.expect(scalar_quotient.eql(chunked_quotient));
             }
+
+            try scratch.prepareBatchMajor(&workspace, scratch.rowCapacity());
+            try std.testing.expectError(error.InvalidChunkSize, scratch.inversesForRow(0));
+            for (scratch.domain_points, 0..) |domain_point, row| {
+                try workspace.beginRow(domain_point);
+                for (workspace.denominator_inverses, 0..) |scalar, batch| {
+                    try std.testing.expect(scalar.eql(scratch.batchMajorInverse(batch, row)));
+                }
+            }
+        }
+
+        // Exercise packed groups, scalar tails, and changing batch-major
+        // strides in the same retained scratch allocation.
+        const tail_domain = canonic.CanonicCoset.new(6).circleDomain();
+        var tail_scratch = try Scratch.init(allocator, batch_count, 17);
+        defer tail_scratch.deinit(allocator);
+        for (tail_scratch.domain_points, 0..) |*point, row| {
+            point.* = tail_domain.at(row);
+        }
+        for ([_]usize{ 1, 2, 3, 4, 7, 8, 17 }) |row_count| {
+            try tail_scratch.prepareBatchMajor(&workspace, row_count);
+            for (tail_scratch.domain_points[0..row_count], 0..) |domain_point, row| {
+                try workspace.beginRow(domain_point);
+                for (workspace.denominator_inverses, 0..) |scalar, batch| {
+                    try std.testing.expect(scalar.eql(tail_scratch.batchMajorInverse(batch, row)));
+                }
+            }
         }
     }
 }
@@ -492,6 +553,7 @@ test "quotient row scratch reports a zero denominator" {
     scratch.domain_points[0] = domain_point;
 
     try std.testing.expectError(error.DivisionByZero, scratch.prepare(&workspace, 1));
+    try std.testing.expectError(error.DivisionByZero, scratch.prepareBatchMajor(&workspace, 1));
 }
 
 test "quotient row scratch policy honors cost boundary and memory fallback" {

--- a/src/prover/pcs/quotient_tile_executor.zig
+++ b/src/prover/pcs/quotient_tile_executor.zig
@@ -191,7 +191,7 @@ fn executeBatched(work: *Work, scratch: *Scratch) !void {
         for (scratch.row_scratch.domain_points[0..row_count]) |*point| {
             point.* = walk.next();
         }
-        try scratch.row_scratch.prepare(work.workspace, row_count);
+        try scratch.row_scratch.prepareBatchMajor(work.workspace, row_count);
         try scratch.clearNumerators(row_count);
         accumulateTile(work, scratch, tile_start, row_count);
 
@@ -201,17 +201,11 @@ fn executeBatched(work: *Work, scratch: *Scratch) !void {
             inline for (0..m31.VEC_WIDTH) |lane| {
                 ys[lane] = scratch.row_scratch.domain_points[row + lane].y;
             }
-            var row_inverses: [m31.VEC_WIDTH][]const CM31 = undefined;
-            inline for (0..m31.VEC_WIDTH) |lane| {
-                row_inverses[lane] = scratch.row_scratch.inversesForRow(row + lane) catch
-                    return error.InvalidChunkSize;
-            }
             const quotient = finalizeGroupVec4(
                 work.quotient_constants,
                 m31.loadVec4(&ys),
                 scratch,
                 row,
-                row_inverses,
             );
             inline for (0..qm31.SECURE_EXTENSION_DEGREE) |coordinate| {
                 m31.storeVec4(
@@ -228,12 +222,14 @@ fn executeBatched(work: *Work, scratch: *Scratch) !void {
                     scratch.numerator(batch, 2, row).*,
                     scratch.numerator(batch, 3, row).*,
                 );
+                work.workspace.denominator_inverses[batch] =
+                    scratch.row_scratch.batchMajorInverse(batch, row);
             }
             try writeRow(
                 work,
                 tile_start + row,
                 scratch.row_scratch.domain_points[row].y,
-                try scratch.row_scratch.inversesForRow(row),
+                work.workspace.denominator_inverses,
             );
         }
         try emitTile(work, tile_start, tile_start + row_count);
@@ -496,7 +492,6 @@ fn finalizeGroupVec4(
     ys: m31.Vec4u32,
     scratch: *const Scratch,
     row: usize,
-    row_inverses: [m31.VEC_WIDTH][]const CM31,
 ) [qm31.SECURE_EXTENSION_DEGREE]m31.Vec4u32 {
     var acc: [qm31.SECURE_EXTENSION_DEGREE]m31.Vec4u32 = @splat(@splat(0));
     for (quotient_constants.batch_linear_terms, 0..) |linear_term, batch| {
@@ -514,12 +509,23 @@ fn finalizeGroupVec4(
                 lt,
             );
         }
-        var inv_re: [m31.VEC_WIDTH]u32 = undefined;
-        var inv_im: [m31.VEC_WIDTH]u32 = undefined;
-        inline for (0..m31.VEC_WIDTH) |lane| {
-            inv_re[lane] = row_inverses[lane][batch].a.v;
-            inv_im[lane] = row_inverses[lane][batch].b.v;
-        }
+        const inverse_words: [*]const M31 = @ptrCast(
+            scratch.row_scratch.batchMajorInversePtr(batch, row),
+        );
+        const inverse_lo = m31.loadVec4(inverse_words);
+        const inverse_hi = m31.loadVec4(inverse_words + m31.VEC_WIDTH);
+        const inv_re = @shuffle(
+            u32,
+            inverse_lo,
+            inverse_hi,
+            @Vector(4, i32){ 0, 2, -1, -3 },
+        );
+        const inv_im = @shuffle(
+            u32,
+            inverse_lo,
+            inverse_hi,
+            @Vector(4, i32){ 1, 3, -2, -4 },
+        );
         const q0 = mulCM31Vec4(diff[0], diff[1], inv_re, inv_im);
         const q1 = mulCM31Vec4(diff[2], diff[3], inv_re, inv_im);
         acc[0] = m31.addVec4(acc[0], q0.re);
@@ -788,18 +794,21 @@ test "packed finalize matches scalar finalizeRowQuotients for all batch counts" 
                 inverses[row][batch] = CM31.fromM31(nextM31(&rng_state), nextM31(&rng_state));
             }
         }
+        scratch.row_scratch.prepared_rows = row_capacity;
+        scratch.row_scratch.inverse_layout = .batch_major;
+        for (0..batch_count) |batch| {
+            for (0..row_capacity) |row| {
+                scratch.row_scratch.denominator_inverses[batch * row_capacity + row] =
+                    inverses[row][batch];
+            }
+        }
 
         for ([_]usize{ 0, 4 }) |row| {
-            var row_inverses: [m31.VEC_WIDTH][]const CM31 = undefined;
-            inline for (0..m31.VEC_WIDTH) |lane| {
-                row_inverses[lane] = inverses[row + lane];
-            }
             const packed_q = finalizeGroupVec4(
                 &constants,
                 m31.loadVec4(ys[row..].ptr),
                 &scratch,
                 row,
-                row_inverses,
             );
             inline for (0..m31.VEC_WIDTH) |lane| {
                 var numerators: [3]QM31 = undefined;

--- a/src/prover/poly/circle/fft_kernels.zig
+++ b/src/prover/poly/circle/fft_kernels.zig
@@ -148,11 +148,16 @@ fn fftThreeLayersPackedM31(
     stage: u32,
     twiddles: []const M31,
     comptime inverse: bool,
+    comptime normalize: bool,
+    normalization: M31,
+    comptime duplicate_upper_from_lower: bool,
 ) void {
     std.debug.assert(log_size < @bitSizeOf(usize));
     std.debug.assert(values.len == @as(usize, 1) << @intCast(log_size));
     const pair_count = values.len / 2;
     std.debug.assert(twiddles.len >= pair_count);
+    std.debug.assert(!normalize or inverse);
+    std.debug.assert(!duplicate_upper_from_lower or (!inverse and !normalize));
 
     const lowest_stage = if (inverse) stage else stage - 2;
     std.debug.assert(canFuseThreeLayersPacked(lowest_stage));
@@ -160,16 +165,24 @@ fn fftThreeLayersPackedM31(
 
     const distance = @as(usize, 1) << @intCast(lowest_stage);
     const group_count = values.len >> @intCast(lowest_stage + 3);
+    std.debug.assert(!duplicate_upper_from_lower or group_count == 2);
     const PW = m31.PACK_WIDTH;
+    const normalization_packed: m31.PackedM31 = @splat(normalization.v);
 
-    var group: usize = 0;
-    while (group < group_count) : (group += 1) {
+    // Expansion starts with the upper group while the source lower half is
+    // still untouched, then transforms the lower group in place. Normal
+    // transforms retain their ascending traversal.
+    var group_cursor: usize = if (duplicate_upper_from_lower) group_count else 0;
+    while (if (duplicate_upper_from_lower) group_cursor > 0 else group_cursor < group_count) {
+        if (duplicate_upper_from_lower) group_cursor -= 1;
+        const group = group_cursor;
         const base = group << @intCast(lowest_stage + 3);
+        const load_base = if (duplicate_upper_from_lower and group == 1) 0 else base;
         var lane: usize = 0;
         while (lane < distance) : (lane += PW) {
             var tuple: [8]m31.PackedM31 = undefined;
             inline for (0..8) |item| {
-                tuple[item] = m31.loadPacked(values.ptr + base + lane + item * distance);
+                tuple[item] = m31.loadPacked(values.ptr + load_base + lane + item * distance);
             }
 
             inline for (0..3) |step| {
@@ -186,8 +199,12 @@ fn fftThreeLayersPackedM31(
                     (@as(usize, 1) << @intCast(log_size - substage));
 
                 inline for (0..block_count) |block| {
+                    const raw_twiddle = twiddles[twiddle_offset + group * block_count + block];
                     const twiddle: m31.PackedM31 = @splat(
-                        twiddles[twiddle_offset + group * block_count + block].v,
+                        if (inverse and normalize and step == 2)
+                            raw_twiddle.mul(normalization).v
+                        else
+                            raw_twiddle.v,
                     );
                     const block_start = block * (half_span * 2);
                     inline for (0..half_span) |item| {
@@ -196,7 +213,10 @@ fn fftThreeLayersPackedM31(
                         const lhs = tuple[lo];
                         const rhs = tuple[hi];
                         if (inverse) {
-                            tuple[lo] = m31.addPacked(lhs, rhs);
+                            tuple[lo] = if (normalize and step == 2)
+                                m31.mulPacked(m31.addPacked(lhs, rhs), normalization_packed)
+                            else
+                                m31.addPacked(lhs, rhs);
                             tuple[hi] = m31.mulPacked(m31.subPacked(lhs, rhs), twiddle);
                         } else {
                             const product = m31.mulPacked(rhs, twiddle);
@@ -211,6 +231,7 @@ fn fftThreeLayersPackedM31(
                 m31.storePacked(values.ptr + base + lane + item * distance, tuple[item]);
             }
         }
+        if (!duplicate_upper_from_lower) group_cursor += 1;
     }
 }
 
@@ -220,7 +241,20 @@ pub fn fftThreeLayersForwardPackedM31(
     highest_stage: u32,
     twiddles: []const M31,
 ) void {
-    fftThreeLayersPackedM31(values, log_size, highest_stage, twiddles, false);
+    fftThreeLayersPackedM31(values, log_size, highest_stage, twiddles, false, false, M31.one(), false);
+}
+
+/// Starts a 2x extension without materializing the degenerate first layer.
+/// The upper half is logically identical to the lower half; processing that
+/// destination group first keeps its source intact and removes one complete
+/// coefficient-buffer copy.
+pub fn fftThreeLayersForwardPackedM31FromDuplicatedHalf(
+    values: []M31,
+    log_size: u32,
+    highest_stage: u32,
+    twiddles: []const M31,
+) void {
+    fftThreeLayersPackedM31(values, log_size, highest_stage, twiddles, false, false, M31.one(), true);
 }
 
 pub fn fftThreeLayersInversePackedM31(
@@ -229,7 +263,20 @@ pub fn fftThreeLayersInversePackedM31(
     lowest_stage: u32,
     itwiddles: []const M31,
 ) void {
-    fftThreeLayersPackedM31(values, log_size, lowest_stage, itwiddles, true);
+    fftThreeLayersPackedM31(values, log_size, lowest_stage, itwiddles, true, false, M31.one(), false);
+}
+
+/// Runs three inverse stages and absorbs whole-transform normalization into
+/// the final stage. Every output is already resident in the radix-8 tuple, so
+/// this avoids a separate read/modify/write pass over the coefficient column.
+pub fn fftThreeLayersInversePackedM31Normalized(
+    values: []M31,
+    log_size: u32,
+    lowest_stage: u32,
+    itwiddles: []const M31,
+    normalization: M31,
+) void {
+    fftThreeLayersPackedM31(values, log_size, lowest_stage, itwiddles, true, true, normalization, false);
 }
 
 /// Fused forward pass over the three smallest-block layers (half-block 4, 2,
@@ -793,6 +840,16 @@ test "packed radix-8 pass matches three independent stages" {
         try std.testing.expectEqualSlices(M31, expected, actual);
     }
 
+    // A 2x extension's first active group sees two identical halves. The
+    // expansion kernel must synthesize the upper group without reading its
+    // deliberately unrelated contents.
+    @memcpy(expected, input);
+    @memcpy(expected[value_count / 2 ..], expected[0 .. value_count / 2]);
+    @memcpy(actual, input);
+    fftThreeLayersForwardPackedM31(expected, log_size, 8, twiddles);
+    fftThreeLayersForwardPackedM31FromDuplicatedHalf(actual, log_size, 8, twiddles);
+    try std.testing.expectEqualSlices(M31, expected, actual);
+
     const inverse_stages = [_]u32{ 3, 7 };
     for (inverse_stages) |lowest_stage| {
         @memcpy(expected, input);
@@ -807,6 +864,18 @@ test "packed radix-8 pass matches three independent stages" {
             }
         }
         fftThreeLayersInversePackedM31(actual, log_size, lowest_stage, twiddles);
+        try std.testing.expectEqualSlices(M31, expected, actual);
+
+        const normalization = M31.fromCanonical(1_234_567);
+        for (expected) |*value| value.* = value.mul(normalization);
+        @memcpy(actual, input);
+        fftThreeLayersInversePackedM31Normalized(
+            actual,
+            log_size,
+            lowest_stage,
+            twiddles,
+            normalization,
+        );
         try std.testing.expectEqualSlices(M31, expected, actual);
     }
 }

--- a/src/prover/poly/circle/fft_kernels.zig
+++ b/src/prover/poly/circle/fft_kernels.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const m31 = @import("stwo_core").fields.m31;
+const radix8 = @import("fft_radix8.zig");
 
 const M31 = m31.M31;
 
@@ -127,157 +128,11 @@ pub inline fn fftLayerLoopForwardM31(
     }
 }
 
-/// Whether three adjacent stages can be fused while retaining packed,
-/// contiguous lanes. The tuple elements are separated by 2^lowest_stage,
-/// while each packed load spans PACK_WIDTH adjacent lanes.
-pub fn canFuseThreeLayersPacked(lowest_stage: u32) bool {
-    if (lowest_stage >= @bitSizeOf(usize)) return false;
-    const distance = @as(usize, 1) << @intCast(lowest_stage);
-    return distance >= m31.PACK_WIDTH and distance % m31.PACK_WIDTH == 0;
-}
-
-/// Runs three adjacent FFT stages in one packed radix-8 pass.
-///
-/// Each packed lane represents adjacent positions inside one stage group.
-/// Eight vectors therefore hold eight strided tuple elements while retaining
-/// native SIMD within each element. All intermediates stay in registers, so
-/// the three-stage cascade reads and writes the column only once.
-fn fftThreeLayersPackedM31(
-    values: []M31,
-    log_size: u32,
-    stage: u32,
-    twiddles: []const M31,
-    comptime inverse: bool,
-    comptime normalize: bool,
-    normalization: M31,
-    comptime duplicate_upper_from_lower: bool,
-) void {
-    std.debug.assert(log_size < @bitSizeOf(usize));
-    std.debug.assert(values.len == @as(usize, 1) << @intCast(log_size));
-    const pair_count = values.len / 2;
-    std.debug.assert(twiddles.len >= pair_count);
-    std.debug.assert(!normalize or inverse);
-    std.debug.assert(!duplicate_upper_from_lower or (!inverse and !normalize));
-
-    const lowest_stage = if (inverse) stage else stage - 2;
-    std.debug.assert(canFuseThreeLayersPacked(lowest_stage));
-    std.debug.assert(if (inverse) stage + 2 < log_size else stage >= 2 and stage < log_size);
-
-    const distance = @as(usize, 1) << @intCast(lowest_stage);
-    const group_count = values.len >> @intCast(lowest_stage + 3);
-    std.debug.assert(!duplicate_upper_from_lower or group_count == 2);
-    const PW = m31.PACK_WIDTH;
-    const normalization_packed: m31.PackedM31 = @splat(normalization.v);
-
-    // Expansion starts with the upper group while the source lower half is
-    // still untouched, then transforms the lower group in place. Normal
-    // transforms retain their ascending traversal.
-    var group_cursor: usize = if (duplicate_upper_from_lower) group_count else 0;
-    while (if (duplicate_upper_from_lower) group_cursor > 0 else group_cursor < group_count) {
-        if (duplicate_upper_from_lower) group_cursor -= 1;
-        const group = group_cursor;
-        const base = group << @intCast(lowest_stage + 3);
-        const load_base = if (duplicate_upper_from_lower and group == 1) 0 else base;
-        var lane: usize = 0;
-        while (lane < distance) : (lane += PW) {
-            var tuple: [8]m31.PackedM31 = undefined;
-            inline for (0..8) |item| {
-                tuple[item] = m31.loadPacked(values.ptr + load_base + lane + item * distance);
-            }
-
-            inline for (0..3) |step| {
-                const substage = if (inverse)
-                    stage + @as(u32, @intCast(step))
-                else
-                    stage - @as(u32, @intCast(step));
-                const half_span: usize = if (inverse)
-                    @as(usize, 1) << @intCast(step)
-                else
-                    @as(usize, 4) >> @intCast(step);
-                const block_count = 4 / half_span;
-                const twiddle_offset = pair_count -
-                    (@as(usize, 1) << @intCast(log_size - substage));
-
-                inline for (0..block_count) |block| {
-                    const raw_twiddle = twiddles[twiddle_offset + group * block_count + block];
-                    const twiddle: m31.PackedM31 = @splat(
-                        if (inverse and normalize and step == 2)
-                            raw_twiddle.mul(normalization).v
-                        else
-                            raw_twiddle.v,
-                    );
-                    const block_start = block * (half_span * 2);
-                    inline for (0..half_span) |item| {
-                        const lo = block_start + item;
-                        const hi = lo + half_span;
-                        const lhs = tuple[lo];
-                        const rhs = tuple[hi];
-                        if (inverse) {
-                            tuple[lo] = if (normalize and step == 2)
-                                m31.mulPacked(m31.addPacked(lhs, rhs), normalization_packed)
-                            else
-                                m31.addPacked(lhs, rhs);
-                            tuple[hi] = m31.mulPacked(m31.subPacked(lhs, rhs), twiddle);
-                        } else {
-                            const product = m31.mulPacked(rhs, twiddle);
-                            tuple[lo] = m31.addPacked(lhs, product);
-                            tuple[hi] = m31.subPacked(lhs, product);
-                        }
-                    }
-                }
-            }
-
-            inline for (0..8) |item| {
-                m31.storePacked(values.ptr + base + lane + item * distance, tuple[item]);
-            }
-        }
-        if (!duplicate_upper_from_lower) group_cursor += 1;
-    }
-}
-
-pub fn fftThreeLayersForwardPackedM31(
-    values: []M31,
-    log_size: u32,
-    highest_stage: u32,
-    twiddles: []const M31,
-) void {
-    fftThreeLayersPackedM31(values, log_size, highest_stage, twiddles, false, false, M31.one(), false);
-}
-
-/// Starts a 2x extension without materializing the degenerate first layer.
-/// The upper half is logically identical to the lower half; processing that
-/// destination group first keeps its source intact and removes one complete
-/// coefficient-buffer copy.
-pub fn fftThreeLayersForwardPackedM31FromDuplicatedHalf(
-    values: []M31,
-    log_size: u32,
-    highest_stage: u32,
-    twiddles: []const M31,
-) void {
-    fftThreeLayersPackedM31(values, log_size, highest_stage, twiddles, false, false, M31.one(), true);
-}
-
-pub fn fftThreeLayersInversePackedM31(
-    values: []M31,
-    log_size: u32,
-    lowest_stage: u32,
-    itwiddles: []const M31,
-) void {
-    fftThreeLayersPackedM31(values, log_size, lowest_stage, itwiddles, true, false, M31.one(), false);
-}
-
-/// Runs three inverse stages and absorbs whole-transform normalization into
-/// the final stage. Every output is already resident in the radix-8 tuple, so
-/// this avoids a separate read/modify/write pass over the coefficient column.
-pub fn fftThreeLayersInversePackedM31Normalized(
-    values: []M31,
-    log_size: u32,
-    lowest_stage: u32,
-    itwiddles: []const M31,
-    normalization: M31,
-) void {
-    fftThreeLayersPackedM31(values, log_size, lowest_stage, itwiddles, true, true, normalization, false);
-}
+pub const canFuseThreeLayersPacked = radix8.canFuseThreeLayersPacked;
+pub const fftThreeLayersForwardPackedM31 = radix8.forward;
+pub const fftThreeLayersForwardPackedM31FromDuplicatedHalf = radix8.forwardFromDuplicatedHalf;
+pub const fftThreeLayersInversePackedM31 = radix8.inverse;
+pub const fftThreeLayersInversePackedM31Normalized = radix8.inverseNormalized;
 
 /// Fused forward pass over the three smallest-block layers (half-block 4, 2,
 /// and the adjacent-pair circle layer). All three operate strictly within

--- a/src/prover/poly/circle/fft_radix8.zig
+++ b/src/prover/poly/circle/fft_radix8.zig
@@ -1,0 +1,141 @@
+const std = @import("std");
+const m31 = @import("stwo_core").fields.m31;
+
+const M31 = m31.M31;
+
+/// Whether three adjacent stages can be fused while retaining packed,
+/// contiguous lanes.
+pub fn canFuseThreeLayersPacked(lowest_stage: u32) bool {
+    if (lowest_stage >= @bitSizeOf(usize)) return false;
+    const distance = @as(usize, 1) << @intCast(lowest_stage);
+    return distance >= m31.PACK_WIDTH and distance % m31.PACK_WIDTH == 0;
+}
+
+fn run(
+    values: []M31,
+    log_size: u32,
+    stage: u32,
+    twiddles: []const M31,
+    comptime inverse_transform: bool,
+    comptime normalize: bool,
+    normalization: M31,
+    comptime duplicate_upper_from_lower: bool,
+) void {
+    std.debug.assert(log_size < @bitSizeOf(usize));
+    std.debug.assert(values.len == @as(usize, 1) << @intCast(log_size));
+    const pair_count = values.len / 2;
+    std.debug.assert(twiddles.len >= pair_count);
+    std.debug.assert(!normalize or inverse_transform);
+    std.debug.assert(!duplicate_upper_from_lower or (!inverse_transform and !normalize));
+
+    const lowest_stage = if (inverse_transform) stage else stage - 2;
+    std.debug.assert(canFuseThreeLayersPacked(lowest_stage));
+    std.debug.assert(if (inverse_transform) stage + 2 < log_size else stage >= 2 and stage < log_size);
+
+    const distance = @as(usize, 1) << @intCast(lowest_stage);
+    const group_count = values.len >> @intCast(lowest_stage + 3);
+    std.debug.assert(!duplicate_upper_from_lower or group_count == 2);
+    const PW = m31.PACK_WIDTH;
+    const normalization_packed: m31.PackedM31 = @splat(normalization.v);
+
+    // Expansion starts with the upper group while its lower-half source is
+    // intact. Normal transforms retain ascending traversal.
+    var group_cursor: usize = if (duplicate_upper_from_lower) group_count else 0;
+    while (if (duplicate_upper_from_lower) group_cursor > 0 else group_cursor < group_count) {
+        if (duplicate_upper_from_lower) group_cursor -= 1;
+        const group = group_cursor;
+        const base = group << @intCast(lowest_stage + 3);
+        const load_base = if (duplicate_upper_from_lower and group == 1) 0 else base;
+        var lane: usize = 0;
+        while (lane < distance) : (lane += PW) {
+            var tuple: [8]m31.PackedM31 = undefined;
+            inline for (0..8) |item| {
+                tuple[item] = m31.loadPacked(values.ptr + load_base + lane + item * distance);
+            }
+
+            inline for (0..3) |step| {
+                const substage = if (inverse_transform)
+                    stage + @as(u32, @intCast(step))
+                else
+                    stage - @as(u32, @intCast(step));
+                const half_span: usize = if (inverse_transform)
+                    @as(usize, 1) << @intCast(step)
+                else
+                    @as(usize, 4) >> @intCast(step);
+                const block_count = 4 / half_span;
+                const twiddle_offset = pair_count -
+                    (@as(usize, 1) << @intCast(log_size - substage));
+
+                inline for (0..block_count) |block| {
+                    const raw_twiddle = twiddles[twiddle_offset + group * block_count + block];
+                    const twiddle: m31.PackedM31 = @splat(
+                        if (inverse_transform and normalize and step == 2)
+                            raw_twiddle.mul(normalization).v
+                        else
+                            raw_twiddle.v,
+                    );
+                    const block_start = block * (half_span * 2);
+                    inline for (0..half_span) |item| {
+                        const lo = block_start + item;
+                        const hi = lo + half_span;
+                        const lhs = tuple[lo];
+                        const rhs = tuple[hi];
+                        if (inverse_transform) {
+                            tuple[lo] = if (normalize and step == 2)
+                                m31.mulPacked(m31.addPacked(lhs, rhs), normalization_packed)
+                            else
+                                m31.addPacked(lhs, rhs);
+                            tuple[hi] = m31.mulPacked(m31.subPacked(lhs, rhs), twiddle);
+                        } else {
+                            const product = m31.mulPacked(rhs, twiddle);
+                            tuple[lo] = m31.addPacked(lhs, product);
+                            tuple[hi] = m31.subPacked(lhs, product);
+                        }
+                    }
+                }
+            }
+
+            inline for (0..8) |item| {
+                m31.storePacked(values.ptr + base + lane + item * distance, tuple[item]);
+            }
+        }
+        if (!duplicate_upper_from_lower) group_cursor += 1;
+    }
+}
+
+pub fn forward(
+    values: []M31,
+    log_size: u32,
+    highest_stage: u32,
+    twiddles: []const M31,
+) void {
+    run(values, log_size, highest_stage, twiddles, false, false, M31.one(), false);
+}
+
+pub fn forwardFromDuplicatedHalf(
+    values: []M31,
+    log_size: u32,
+    highest_stage: u32,
+    twiddles: []const M31,
+) void {
+    run(values, log_size, highest_stage, twiddles, false, false, M31.one(), true);
+}
+
+pub fn inverse(
+    values: []M31,
+    log_size: u32,
+    lowest_stage: u32,
+    itwiddles: []const M31,
+) void {
+    run(values, log_size, lowest_stage, itwiddles, true, false, M31.one(), false);
+}
+
+pub fn inverseNormalized(
+    values: []M31,
+    log_size: u32,
+    lowest_stage: u32,
+    itwiddles: []const M31,
+    normalization: M31,
+) void {
+    run(values, log_size, lowest_stage, itwiddles, true, true, normalization, false);
+}

--- a/src/prover/poly/circle/transforms.zig
+++ b/src/prover/poly/circle/transforms.zig
@@ -27,6 +27,36 @@ inline fn layerTwiddles(
     return twiddles[twiddles.len - count * 2 .. twiddles.len - count];
 }
 
+/// Multiplies a complete coefficient buffer by one field scalar. Four
+/// independent packed products are issued together to cover AdvSIMD multiply
+/// latency; arbitrary lengths retain an exact scalar tail.
+fn scaleM31(values: []M31, scalar: M31) void {
+    var index: usize = 0;
+    if (comptime m31.PACK_WIDTH > 1) {
+        const width = m31.PACK_WIDTH;
+        const scalar_packed = m31.splatPacked(scalar);
+        while (index + 4 * width <= values.len) : (index += 4 * width) {
+            const a = m31.mulPacked(m31.loadPacked(values.ptr + index), scalar_packed);
+            const b = m31.mulPacked(m31.loadPacked(values.ptr + index + width), scalar_packed);
+            const c = m31.mulPacked(m31.loadPacked(values.ptr + index + 2 * width), scalar_packed);
+            const d = m31.mulPacked(m31.loadPacked(values.ptr + index + 3 * width), scalar_packed);
+            m31.storePacked(values.ptr + index, a);
+            m31.storePacked(values.ptr + index + width, b);
+            m31.storePacked(values.ptr + index + 2 * width, c);
+            m31.storePacked(values.ptr + index + 3 * width, d);
+        }
+        while (index + width <= values.len) : (index += width) {
+            m31.storePacked(
+                values.ptr + index,
+                m31.mulPacked(m31.loadPacked(values.ptr + index), scalar_packed),
+            );
+        }
+    }
+    while (index < values.len) : (index += 1) {
+        values[index] = values[index].mul(scalar);
+    }
+}
+
 fn forwardBottomLayers(
     values: []M31,
     line_log_size: u32,
@@ -314,9 +344,7 @@ pub fn interpolateIntoBufferWithTwiddles(
     }
 
     const n_inv = M31.fromCanonical(@intCast(n)).inv() catch return PolyError.SingularSystem;
-    for (coeffs) |*coeff| {
-        coeff.* = coeff.*.mul(n_inv);
-    }
+    scaleM31(coeffs, n_inv);
 }
 
 /// Interpolates a batch in place while sharing twiddle traversal.
@@ -432,9 +460,7 @@ pub fn interpolateBuffersWithTwiddles(
 
     const n_inv = M31.fromCanonical(@intCast(coeffs_batch[0].len)).inv() catch return PolyError.SingularSystem;
     for (coeffs_batch) |coeffs| {
-        for (coeffs) |*coeff| {
-            coeff.* = coeff.*.mul(n_inv);
-        }
+        scaleM31(coeffs, n_inv);
     }
 }
 

--- a/src/prover/poly/circle/transforms.zig
+++ b/src/prover/poly/circle/transforms.zig
@@ -291,6 +291,7 @@ pub fn interpolateIntoBufferWithTwiddles(
         return;
     }
 
+    const n_inv = M31.fromCanonical(@intCast(n)).inv() catch return PolyError.SingularSystem;
     const line_log_size = domain.half_coset.logSize();
     const itwiddle_len = twiddle_tree.itwiddles.len;
     const fuse_bottom = line_log_size >= 3;
@@ -319,17 +320,29 @@ pub fn interpolateIntoBufferWithTwiddles(
         }
     }
 
+    var normalization_fused = false;
     while (layer_idx < line_log_size) {
         const lowest_stage = layer_idx + 1;
         if (lowest_stage + 2 <= line_log_size and
             fft_kernels.canFuseThreeLayersPacked(lowest_stage))
         {
-            fft_kernels.fftThreeLayersInversePackedM31(
-                coeffs,
-                domain.logSize(),
-                lowest_stage,
-                twiddle_tree.itwiddles,
-            );
+            if (lowest_stage + 2 == line_log_size) {
+                fft_kernels.fftThreeLayersInversePackedM31Normalized(
+                    coeffs,
+                    domain.logSize(),
+                    lowest_stage,
+                    twiddle_tree.itwiddles,
+                    n_inv,
+                );
+                normalization_fused = true;
+            } else {
+                fft_kernels.fftThreeLayersInversePackedM31(
+                    coeffs,
+                    domain.logSize(),
+                    lowest_stage,
+                    twiddle_tree.itwiddles,
+                );
+            }
             layer_idx += 3;
             continue;
         }
@@ -343,8 +356,7 @@ pub fn interpolateIntoBufferWithTwiddles(
         layer_idx += 1;
     }
 
-    const n_inv = M31.fromCanonical(@intCast(n)).inv() catch return PolyError.SingularSystem;
-    scaleM31(coeffs, n_inv);
+    if (!normalization_fused) scaleM31(coeffs, n_inv);
 }
 
 /// Interpolates a batch in place while sharing twiddle traversal.
@@ -396,6 +408,7 @@ pub fn interpolateBuffersWithTwiddles(
         return;
     }
 
+    const n_inv = M31.fromCanonical(@intCast(coeffs_batch[0].len)).inv() catch return PolyError.SingularSystem;
     const line_log_size = domain.half_coset.logSize();
     const itwiddle_len = twiddle_tree.itwiddles.len;
     const fuse_bottom = line_log_size >= 3;
@@ -430,18 +443,32 @@ pub fn interpolateBuffersWithTwiddles(
         }
     }
 
+    var normalization_fused = false;
     while (layer_idx < line_log_size) {
         const lowest_stage = layer_idx + 1;
         if (lowest_stage + 2 <= line_log_size and
             fft_kernels.canFuseThreeLayersPacked(lowest_stage))
         {
-            for (coeffs_batch) |coeffs| {
-                fft_kernels.fftThreeLayersInversePackedM31(
-                    coeffs,
-                    domain.logSize(),
-                    lowest_stage,
-                    twiddle_tree.itwiddles,
-                );
+            if (lowest_stage + 2 == line_log_size) {
+                for (coeffs_batch) |coeffs| {
+                    fft_kernels.fftThreeLayersInversePackedM31Normalized(
+                        coeffs,
+                        domain.logSize(),
+                        lowest_stage,
+                        twiddle_tree.itwiddles,
+                        n_inv,
+                    );
+                }
+                normalization_fused = true;
+            } else {
+                for (coeffs_batch) |coeffs| {
+                    fft_kernels.fftThreeLayersInversePackedM31(
+                        coeffs,
+                        domain.logSize(),
+                        lowest_stage,
+                        twiddle_tree.itwiddles,
+                    );
+                }
             }
             layer_idx += 3;
             continue;
@@ -458,9 +485,10 @@ pub fn interpolateBuffersWithTwiddles(
         layer_idx += 1;
     }
 
-    const n_inv = M31.fromCanonical(@intCast(coeffs_batch[0].len)).inv() catch return PolyError.SingularSystem;
-    for (coeffs_batch) |coeffs| {
-        scaleM31(coeffs, n_inv);
+    if (!normalization_fused) {
+        for (coeffs_batch) |coeffs| {
+            scaleM31(coeffs, n_inv);
+        }
     }
 }
 
@@ -503,7 +531,7 @@ pub fn evaluateBuffersWithTwiddles(
         return;
     }
 
-    try evaluateBuffersTailLayers(values_batch, domain, twiddle_tree, 0);
+    try evaluateBuffersTailLayers(values_batch, domain, twiddle_tree, 0, false);
 }
 
 /// Batched forward evaluation for buffers whose upper halves are known to be
@@ -524,11 +552,7 @@ pub fn evaluateExtensionBuffersWithTwiddles(
         }
         return evaluateBuffersWithTwiddles(values_batch, domain, twiddle_tree);
     }
-    for (values_batch) |values| {
-        const half = values.len / 2;
-        @memcpy(values[half..], values[0..half]);
-    }
-    try evaluateBuffersTailLayers(values_batch, domain, twiddle_tree, 1);
+    try evaluateBuffersTailLayers(values_batch, domain, twiddle_tree, 1, true);
 }
 
 fn evaluateBuffersTailLayers(
@@ -536,6 +560,7 @@ fn evaluateBuffersTailLayers(
     domain: CircleDomain,
     twiddle_tree: M31TwiddleTree,
     skip_layers: u32,
+    duplicate_upper_from_lower: bool,
 ) PolyError!void {
     const line_log_size = domain.half_coset.logSize();
     const twiddle_len = twiddle_tree.twiddles.len;
@@ -549,18 +574,39 @@ fn evaluateBuffersTailLayers(
     const fuse_bottom = line_log_size >= 3 and active_layers >= 3;
     const bottom_layers = if (fuse_bottom) fusedBottomLayerCount(active_layers) else 0;
     const stop: u32 = if (fuse_bottom) bottom_layers - 1 else 0;
+    var expand_on_first_radix = duplicate_upper_from_lower;
+    const first_pass_is_packed_radix8 = layer_idx > stop and
+        layer_idx >= 5 and
+        fft_kernels.canFuseThreeLayersPacked(layer_idx - 2);
+    if (expand_on_first_radix and !first_pass_is_packed_radix8) {
+        for (values_batch) |values| {
+            const half = values.len / 2;
+            @memcpy(values[half..], values[0..half]);
+        }
+        expand_on_first_radix = false;
+    }
     while (layer_idx > stop) {
         if (layer_idx >= 5 and
             fft_kernels.canFuseThreeLayersPacked(layer_idx - 2))
         {
             for (values_batch) |values| {
-                fft_kernels.fftThreeLayersForwardPackedM31(
-                    values,
-                    domain.logSize(),
-                    layer_idx,
-                    twiddle_tree.twiddles,
-                );
+                if (expand_on_first_radix) {
+                    fft_kernels.fftThreeLayersForwardPackedM31FromDuplicatedHalf(
+                        values,
+                        domain.logSize(),
+                        layer_idx,
+                        twiddle_tree.twiddles,
+                    );
+                } else {
+                    fft_kernels.fftThreeLayersForwardPackedM31(
+                        values,
+                        domain.logSize(),
+                        layer_idx,
+                        twiddle_tree.twiddles,
+                    );
+                }
             }
+            expand_on_first_radix = false;
             layer_idx -= 3;
             continue;
         }
@@ -575,6 +621,7 @@ fn evaluateBuffersTailLayers(
             }
         }
     }
+    std.debug.assert(!expand_on_first_radix);
 
     if (fuse_bottom) {
         for (values_batch) |values| {


### PR DESCRIPTION
## Outcome

Moves the complete RISC-V `deep/time` portfolio by vectorizing shared prover
hot paths, with the largest new layer transposing quotient denominators across
adjacent rows and sharing their algebraic reduction with Metal.

Final clean claimed verdict against `0a04f85af1e2`:

- portfolio proving ratio: **0.982416**
- 95% CI: **[0.980101, 0.984837]**
- energy ratio: **0.952201**
- RSS ratio: **0.998642** (upper-CI geomean 1.001208)
- proof bytes: **1.0**
- every one of seven workloads faster; oracle 7/7; G1-G5 pass

SHA2-2048's new denominator layer removes 2.82B instructions (1.21%) and 653M
cycles (0.95%) while retaining byte-identical proofs.

## Architecture

- precompute `prx*piy - pry*pix` once per sample point;
- evaluate `det - x*piy + y*pix` for four CPU rows in M31 SIMD;
- retain inverses batch-major for contiguous quotient finalization;
- apply the same reduced formula to direct/raw/finalize Metal shaders;
- stack packed CM31 inversion, exact dot4 reduction, coordinate SIMD, fused FFT
  normalization, direct 2x-LDE expansion, and BLAKE2 ILP scheduling.

Paths are selected by field/layout/transform structure, never workload names,
digests, or target sizes.

## Validation

- aggregate ReleaseFast test closure: 377 sources
- RISC-V CPU product closure: 352 sources
- Native CPU product closure: 210 sources
- Native Metal product closure: 256 sources
- Metal source-JIT, device-only proof lifecycle, independent verify, no fallback
- source conformance clean apart from five pre-existing explained findings
- full transcript, rejected experiments, raw-verdict identity, and submission
  note included under `2026-07-23-riscv-shared-prover-vectorization`

The local verdict is claimed/advisory until the authenticated judge reruns it.

**PR6 Supremacy: not achieved.**
