### PR TITLE
perf(cpu): admit recurrence composition at latency sizes

### DIFF
--- a/autoresearch/submissions/2026-07-23-2026-07-23-cpu-latency-recurrence-plan/delta.json
+++ b/autoresearch/submissions/2026-07-23-2026-07-23-cpu-latency-recurrence-plan/delta.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "4259c8486593",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "wide",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/backends/cpu_scalar/secure_composition.zig": "sha256:5e2df25830df28a442fd11913f28d91e5453aa33a942370f687b352a3525a3f6"
+  },
+  "transcripts": {
+    "transcripts/session.md": {
+      "sha256": "a0afea822670ad98a9bd98f6d66c25cbe7ce7f138ca5fedff01494ac17bc7a86",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-23-2026-07-23-cpu-latency-recurrence-plan/note.md
+++ b/autoresearch/submissions/2026-07-23-2026-07-23-cpu-latency-recurrence-plan/note.md
@@ -1,0 +1,84 @@
+# Admit packed recurrence composition in the latency regime
+
+## Model and harness
+
+Model: GPT-5 Codex. Harness: repository-resident `stwo-perf` at identity
+`8b24d0b2eb96`, Zig 0.15.2 ReleaseFast, on the same arm64 macOS M5 Max host.
+The clean candidate is `932aa7d2458b`; the paired predecessor is current main
+`4259c8486593`. The claimed board is Native CPU `wide/time` at S3. The final
+diff changes only `src/backends/cpu_scalar/secure_composition.zig`.
+
+The session began by measuring the fixed-protocol width-100 series at logs 14,
+16, 18, 20, and 22, then profiling CPU logs 14/18/22 and Metal logs
+14/16/18/22. The final scored experiment used seven ABBA rounds, retained all
+samples, independently verified every proof, and passed the pinned Rust Stwo
+oracle.
+
+## Hypothesis
+
+The CPU backend already has a proof-wide execution plan for structurally
+identified quadratic sum-of-squares recurrence AIRs. It traverses contiguous
+trace columns directly, evaluates two independent packed row groups, reuses
+squares across adjacent recurrence constraints, pre-packs secure powers, and
+partitions rows across the persistent worker pool. Its old admission threshold
+excluded the latency regime even though profiling showed generic component
+evaluation consuming about 4.18 ms at width 100, log14.
+
+The hypothesis was that a 2^15 evaluation domain and at least 32 contiguous
+recurrence columns are sufficient to amortize worker fan-out. Admission remains
+structural: one declared recurrence capability, one trace tree, exact
+constraint/column relationship, uniform domains, contiguous storage, and
+power-of-two packed rows. It does not inspect a workload name, benchmark size,
+input, or digest.
+
+## Changes
+
+Lower the packed recurrence plan's evaluation-domain threshold from log17 to
+log15 and express a minimum of 32 structurally matched columns. No arithmetic,
+statement, trace, transcript, PCS, FRI, security parameter, proof encoding, or
+fallback behavior changes.
+
+Several broader experiments were deliberately removed before submission. A
+CPU commitment-input ownership transfer screened favorably for request time
+and some RSS points but produced a clean paired xlarge prove ratio of 1.0147
+with CI [1.0003, 1.0294]. Metal combined/deferred admission at log14/16,
+smaller transform tiles, and a split recurrence/IFFT command all lost to the
+existing small-shape plan. Static contiguous CPU column ranges improved log14
+but regressed log16 because heterogeneous-core load balancing was worse. The
+submitted diff contains none of those rejected mechanisms.
+
+## Results
+
+The scored `wf_log14x32` prove median falls from 6.286708 ms to 4.960083 ms:
+ratio **0.791173**, 95% CI **[0.783665, 0.801629]**. Verified-request ratio is
+0.807709. Energy ratio is 0.943872 with upper CI 0.948983; RSS ratio is
+0.998743 with upper CI 1.000721. Proof size is exactly unchanged at 41,840
+bytes.
+
+All G1-G5 checks pass. Every timed proof verified, cross-arm proof digests
+were byte-identical in every round, and the pinned Rust oracle accepted the
+scored proof. All 13 impact-mapped guards pass, covering wide Fibonacci,
+Blake, Plonk, Poseidon, state machine, and XOR. The separate holistic smoke
+also produced identical CPU/Metal canonical bytes for all 13 rows. Native CPU
+product closure, prover closure, and source-conformance checks pass.
+
+For the task's width-100 log14 point, the clean candidate records 7.436208 ms
+verified request versus the frozen 10.876250 ms baseline, ratio 0.683711,
+with seven identical verified 48,180-byte proofs. This is useful portfolio
+evidence, but it is not substituted for the manifest-owned scored verdict.
+
+## Caveats
+
+This submission advances one latency/wide cell; it does not by itself satisfy
+the system-level 2x contract. The diagnostic best-backend envelope across the
+five fixed-protocol sizes reaches ratio 0.497667, but log16 remains at
+0.937481 and therefore fails the per-cell ceiling. Cold-process ABBA evidence
+and an automatic backend execution plan are also still outstanding.
+
+The packed plan intentionally stays off traces with fewer than 32 columns or
+without the exact recurrence capability and layout. A future change should
+derive the crossover from measured plan cost or a more general compiled
+component plan rather than repeatedly lowering this constant. PR6's full
+exact workload and cold-process matrix is still incomplete.
+
+**PR6 Supremacy: not achieved.**

--- a/autoresearch/submissions/2026-07-23-2026-07-23-cpu-latency-recurrence-plan/transcripts/session.md
+++ b/autoresearch/submissions/2026-07-23-2026-07-23-cpu-latency-recurrence-plan/transcripts/session.md
@@ -1,0 +1,202 @@
+# System-level 2x session transcript
+
+## Research request and operating contract
+
+The requested objective was a fixed-protocol, system-level 2x acceleration
+against frozen commit `0cca924`, scored by geometric mean over width-100 logs
+14, 16, 18, 20, and 22. Promotion requires at least 1.5x, every point must
+improve, no point may exceed ratio 0.80, and correctness, proof identity,
+security parameters, trace work, and request boundaries must remain fixed.
+The user explicitly requested profiling before implementation, structural
+rather than benchmark-specific work, broad guards, complete notes and
+transcripts, and immediate submission once a significant result existed.
+
+I updated the canonical checkout before work. At final scoring the remote main
+advanced only in the automerge workflow, so I refreshed the repository and
+rebased the candidate onto `4259c8486593` before producing clean evidence.
+
+## Grounding measurements
+
+The immutable CPU baseline medians were 10.876250, 20.534459, 69.961875,
+268.833292, and 1145.818167 ms. Each point retained protocol identity,
+executable/source identity, resource data, and deterministic proof bytes.
+
+Unmodified current-main CPU requests were:
+
+| log rows | request ms | ratio to frozen CPU |
+| ---: | ---: | ---: |
+| 14 | 10.545875 | 0.969624 |
+| 16 | 20.428583 | 0.994844 |
+| 18 | 71.573542 | 1.023036 |
+| 20 | 280.025042 | 1.041631 |
+| 22 | 1142.079583 | 0.996737 |
+
+The unmodified promoted Metal path was already the throughput plan:
+
+| log rows | request ms | ratio to frozen CPU | peak physical bytes |
+| ---: | ---: | ---: | ---: |
+| 14 | 9.311083 | 0.856093 | 198,558,896 |
+| 16 | 19.250667 | 0.937481 | 347,211,000 |
+| 18 | 26.434292 | 0.377839 | 341,706,120 |
+| 20 | 100.104875 | 0.372368 | 920,995,496 |
+| 22 | 387.879875 | 0.338518 | 2,843,989,224 |
+
+Every measured Metal proof matched CPU canonical bytes and reported zero CPU
+fallbacks. Metal already reduced log22 physical footprint about 58.7% versus
+the frozen CPU result. Its five-point geometric ratio was 0.520557, so the
+largest leverage was the fixed-cost log14/log16 end rather than another large
+throughput kernel.
+
+## Profiles and architectural interpretation
+
+CPU stage profiles and CPU Time Profiler samples were captured at logs 14, 18,
+and 22 before edits.
+
+- At log14, generic secure-composition evaluation cost about 4.18 ms. This
+  was a fixed-cost opportunity large enough to change the whole request.
+- At log18, main commitment cost about 27.4 ms, including about 11 ms of
+  Merkle work; the proof core was about 39 ms and quotient/FRI about 20 ms.
+- At log22, main commitment was about 480 ms (Merkle about 170 ms),
+  composition evaluation about 60 ms, composition commitment about 89 ms,
+  sampled-value evaluation about 65 ms, and FRI about 278 ms. Blake hashing,
+  FFT passes, and memory traffic dominated.
+
+Metal stage and command-buffer telemetry was captured at logs 14, 16, 18, and
+22. Log14 paid ten command buffers per request and roughly 5.58 ms of GPU
+time; line FRI, Merkle, and LDE were the largest GPU slices. Log16 paid seven
+buffers and about 4.6 ms for combined LDE/Merkle. Logs 18 and 22 were
+throughput-dominated and benefited from the already-promoted resident pipeline.
+
+The resulting execution-plan map was:
+
+```text
+latency/cache-resident                 bandwidth/capacity
+log14 -------- log16 -------- log18 -------- log20 -------- log22
+ CPU packed       unresolved       promoted resident Metal pipeline
+ recurrence
+```
+
+The guiding conclusion was that one backend should not be forced across every
+regime. CPU has lower dispatch/fixed cost, while Metal wins decisively once
+resident full-domain work amortizes command submission.
+
+## Rejected experiments
+
+All rejected edits were reverted before the final commit.
+
+1. **Lower the combined/deferred Metal threshold to log14.** Proofs were exact,
+   trace synchronization stayed absent, and fallbacks stayed zero, but request
+   time worsened to 10.858 ms at log14 and 23.590 ms at log16 versus 9.311 and
+   19.251 ms. Fixed command and transform overhead exceeded the saved copy.
+
+2. **Smaller fused trace tiles.** Tile 11 and tile 10 produced exact log16
+   requests of 22.612 and 22.377 ms. Both lost to the split plan.
+
+3. **Split recurrence generation and inverse FFT in one deferred command.**
+   An initial normalization mistake correctly failed constraint verification.
+   After fixing normalization, proof bytes were exact and fallback count was
+   zero, but paired request time was 21.079 ms versus 19.442 ms current. The
+   extra global pass and synchronization outweighed the producer benefit.
+
+4. **Static contiguous CPU column ranges.** Eighteen fixed jobs made one log14
+   screen about 7 ms but regressed log16 to 22.53 ms versus about 20.28 ms.
+   Worker sweeps at 4/8/12/16 threads gave 48.35/30.33/24.18/20.74 ms; the
+   default 18-worker dynamic schedule was best. Merkle worker sweeps also
+   favored the default. Apple heterogeneous cores need fine-grained work
+   stealing here.
+
+5. **Adopt one contiguous CPU trace arena as coefficient storage.** This
+   removed a detach copy and screened with lower RSS at log16/log18/log20,
+   while requests moved only modestly. The decisive clean S3 xlarge run was a
+   regression: ratio 1.0147, CI [1.0003, 1.0294], 66.007 ms predecessor versus
+   67.444 ms candidate. The entire ownership implementation and extraction
+   were removed rather than carried as uncredited complexity.
+
+The rejection ledger matters because several mechanisms looked attractive in
+isolated stage timing. Full verified requests and paired scheduling reversed
+those conclusions.
+
+## Accepted mechanism
+
+Main already contained a specialized recurrence composition evaluator, but it
+admitted only evaluation logs at least 17 and traces with at least 64 columns.
+It is not a benchmark shortcut. Admission requires:
+
+- exactly one component with the quadratic-sum-of-squares backend capability;
+- the declared trace-tree index and no unrelated nonempty tree;
+- `constraints == columns - 2`;
+- a uniform power-of-two evaluation domain;
+- packed row divisibility;
+- strictly contiguous columns with one stable stride.
+
+Once admitted, it walks trace storage directly, reuses adjacent squares,
+evaluates two independent packed row groups to break the multiply dependency
+chain, pre-packs random secure powers, uses the two coset denominator values,
+and partitions rows over the persistent worker pool. The generic evaluator
+otherwise pays component/constraint abstraction overhead across the full
+domain.
+
+Profiling predicted that worker fan-out would amortize at an evaluation domain
+of 2^15. A width-100 screen confirmed a request near 7 ms. Lowering only the
+domain threshold admitted that point. A second structural screen lowered the
+minimum column count to 32, which admitted the manifest-owned width-32 shape
+and changed prove time from about 6.18 ms to 4.93 ms while retaining exact
+proof bytes. The final diff therefore changes only the two admission bounds
+and comments.
+
+## Clean scored result
+
+Candidate `932aa7d2458b` was built ReleaseFast from a clean tree and paired with
+current main `4259c8486593`.
+
+| metric | predecessor | candidate | ratio / CI |
+| --- | ---: | ---: | ---: |
+| prove median | 6.286708 ms | 4.960083 ms | 0.791173 [0.783665, 0.801629] |
+| verified request | — | — | ratio 0.807709 |
+| energy | — | 1.283553 J | 0.943872 [0.809603, 0.948983] |
+| peak RSS | — | 21.7196 MiB | 0.998743 [0.996406, 1.000721] |
+| proof bytes | 41,840 | 41,840 | 1.0 |
+
+Seven ABBA rounds were retained. G1-G5 passed, the pinned Rust Stwo oracle
+accepted the workload, and all 13 impact-mapped regression guards stayed
+inside their 1.05 upper-CI budgets. Proof digest was
+`57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374`.
+
+The final clean width-100 log14 diagnostic recorded 7.436208 ms verified
+request, ratio 0.683711 against the frozen 10.876250 ms baseline, with seven
+identical verified 48,180-byte proofs and digest
+`ee3cb0957a56876a3d4c0ce6332115137ddb9b9766ac902beafd002fbe0b74ed`.
+
+Correctness validation included:
+
+- Native CPU product closure;
+- prover source closure;
+- source-conformance checks with no new findings;
+- a 13-row holistic Native CPU/Metal smoke across wide Fibonacci, XOR, Plonk,
+  state machine, Blake, and Poseidon;
+- identical CPU/Metal canonical proof bytes on all 13 rows;
+- the scored Rust-oracle acceptance and paired proof equality.
+
+## System-level status and next bottleneck
+
+Using the clean CPU log14 result and the already-promoted Metal medians for
+logs 16 through 22 gives ratios:
+
+```text
+log14  0.683711  CPU packed recurrence
+log16  0.937481  Metal — blocking cell
+log18  0.377839  Metal resident pipeline
+log20  0.372368  Metal resident pipeline
+log22  0.338518  Metal resident pipeline
+geomean 0.497667 = 2.0094x
+```
+
+That geometric mean crosses 2x diagnostically, but the task is not complete:
+log16 violates the required 0.80 individual ceiling, cold-process ABBA has not
+been run, and the product does not yet expose one automatic structurally
+selected CPU/Metal execution plan. The next material target is therefore
+log16 fixed overhead: fewer FRI/Merkle command-buffer waits or a CPU compiled
+component plan that also reduces commitment and FRI cost. Repeating large
+resident-pipeline work has much less portfolio leverage.
+
+**PR6 Supremacy: not achieved.**

--- a/autoresearch/submissions/2026-07-23-2026-07-23-cpu-latency-recurrence-plan/verdict.json
+++ b/autoresearch/submissions/2026-07-23-2026-07-23-cpu-latency-recurrence-plan/verdict.json
@@ -1,0 +1,424 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "8b24d0b2eb96",
+  "repo_commit": "932aa7d2458b",
+  "predecessor_commit": "4259c8486593",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "wide",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 3.78
+    }
+  },
+  "search_health": {
+    "schema_version": 1,
+    "decision": {
+      "schema_version": 1,
+      "board": "core_cpu",
+      "workload_class": "wide",
+      "trailing_window": 8,
+      "trailing_evidence_count": 2,
+      "trailing_median_gradient_snr": 2.9465412870423178,
+      "gradient_snr_threshold": 2.0,
+      "configured_rounds": 15,
+      "auto_boost_rounds": 5,
+      "maximum_rounds": 25,
+      "target_rounds": 15,
+      "workload_count": 1,
+      "class_wall_deadline_seconds": 600.0,
+      "estimated_seconds_per_round": 2.6940686777670635,
+      "deadline_round_limit": 222,
+      "auto_boost_applied": false,
+      "auto_boost_reason": "trailing_median_at_or_above_threshold",
+      "recorded_before_measurement": true
+    },
+    "decision_sha256": "sha256:221216090b64842317e59d92833c1808483f64164f2780ecb9e373a1a656abee",
+    "actual_rounds": 7,
+    "actual_rounds_per_workload": {
+      "wf_log14x32": 7
+    },
+    "objective_wall_seconds": 2.4232360830064863,
+    "measurement_wall_seconds": 20.249045457923785,
+    "measurement_wall_hours": 0.005624734849423273,
+    "gradient_snr": null,
+    "credited_ln_improvement": null,
+    "credited_ln_improvement_per_measurement_hour": null,
+    "credit_status": "pending_ledger_adjudication",
+    "decision_record": "/Users/theodorepender/code/auto-researching/ws-system2x-epoch1/autoresearch/.runs/latest/search-health-decision.json"
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned correctness oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "native mechanism telemetry policy unchanged"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.2809 vs targeted budget x1.02; matrix row upper CIs 1/1 within budget x1.05; regression guards 13/13 within budget; request ratios 1/1 present rows within budget x1.05; resource vectors 1/1 within named budgets"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log14x32": {
+        "r": 0.791173,
+        "ci": [
+          0.783665,
+          0.801629
+        ],
+        "rounds": 7,
+        "a_median_ms": 6.286708,
+        "b_median_ms": 4.960083,
+        "request_ratio": 0.807709,
+        "rss_ratio": 0.998743,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.943872,
+            "ci": [
+              0.809603,
+              0.948983
+            ],
+            "observations": 7,
+            "candidate": 1.283552529
+          },
+          "peak_rss_mib": {
+            "ratio": 0.998743,
+            "ci": [
+              0.996406,
+              1.000721
+            ],
+            "observations": 7,
+            "candidate": 21.719619750976562
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 41840.0
+          }
+        },
+        "mechanism_verified": null,
+        "proof_bytes": 41840,
+        "measurement_seconds": 2.386707,
+        "resources_complete": null
+      }
+    },
+    "R_geomean": 0.791173,
+    "portfolio": {
+      "ci_method": "independent_workload_round_bootstrap_percentile_v1",
+      "ci_level": 0.95,
+      "bootstrap_iterations": 4000,
+      "seed": 4133880075,
+      "ci": [
+        0.784577,
+        0.8021
+      ],
+      "prove_ms_method": "geometric_mean_candidate_workload_medians_ms_v1",
+      "b_median_ms_geomean": 4.960083,
+      "proof_bytes_method": "rounded_geometric_mean_candidate_proof_bytes_v1",
+      "proof_bytes": 41840,
+      "measurement_seconds": 2.386707,
+      "measurement_rounds": 7
+    },
+    "theta": 0.02929,
+    "aa_dispersion": 0.014645,
+    "significant": true,
+    "neutral": false,
+    "promotion_significance": {
+      "eligible": true,
+      "method": "independent_workload_round_bootstrap_percentile_v1",
+      "reason": "prove-time objective uses the deterministic workload portfolio CI"
+    },
+    "resource_portfolio": {
+      "peak_rss_mib": {
+        "ratio_geomean": 0.9987428006966466,
+        "upper_ci_geomean": 1.000720968875306,
+        "candidate_geomean": 21.719619750976562
+      },
+      "energy_j": {
+        "ratio_geomean": 0.9438717593142061,
+        "upper_ci_geomean": 0.9489826270283089,
+        "candidate_geomean": 1.283552529
+      },
+      "proof_bytes": {
+        "ratio_geomean": 1.0,
+        "upper_ci_geomean": 1.0,
+        "candidate_geomean": 41840.00000000004
+      }
+    }
+  },
+  "tiebreakers": {
+    "rss_ratio": 0.998743,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": 1.283552529,
+    "proof_bytes": 41840.00000000004
+  },
+  "holdout": null,
+  "guards": {
+    "guard_blake_10x10": {
+      "r": 1.005546,
+      "ci": [
+        0.99646,
+        1.018703
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "4153acd6e32a98b9d240730062f7fa35e2e31eca915f01c179337f04d409cbd2"
+    },
+    "guard_blake_12x16": {
+      "r": 0.966413,
+      "ci": [
+        0.95739,
+        0.98557
+      ],
+      "rounds": 6,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "70e516957d2d38ed78214bfda5b0b2bdfe41f1c93439fb68e124bfef096fbc9f"
+    },
+    "guard_plonk_14": {
+      "r": 0.973975,
+      "ci": [
+        0.969832,
+        0.976679
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf"
+    },
+    "guard_plonk_16": {
+      "r": 0.996337,
+      "ci": [
+        0.975873,
+        1.013406
+      ],
+      "rounds": 7,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "cfb36bf17fb3526bf1bdd9401fb885fd91ca46b9982fee1ca5fad33a1d574b72"
+    },
+    "guard_poseidon_10": {
+      "r": 1.012153,
+      "ci": [
+        1.005818,
+        1.02825
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "af33240da8e7947362fdf7e78d306f2e11cb2e3df7e1b6f498a6e86ac3ae7b1b"
+    },
+    "guard_poseidon_13": {
+      "r": 1.001408,
+      "ci": [
+        0.998675,
+        1.003332
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "f196835da5d4a155c6311bafb44335c2863cc028879d69a7ae53b802321200f1"
+    },
+    "guard_sm_14": {
+      "r": 0.998769,
+      "ci": [
+        0.979296,
+        1.018423
+      ],
+      "rounds": 6,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "488fadeeb4e5d76b6fc0a9c10ab258bab6673de8e912ae5de927561650920b37"
+    },
+    "guard_sm_16": {
+      "r": 1.014959,
+      "ci": [
+        0.988428,
+        1.02931
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "88ec35ee88a05ce0a5db4b6cb063f4cf7824ee65284db0908a62a9362879af73"
+    },
+    "guard_wf_10x8": {
+      "r": 1.000648,
+      "ci": [
+        0.970012,
+        1.017211
+      ],
+      "rounds": 6,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700"
+    },
+    "guard_wf_14x32": {
+      "r": 0.785384,
+      "ci": [
+        0.767329,
+        0.81413
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374"
+    },
+    "guard_wf_16x64": {
+      "r": 1.012642,
+      "ci": [
+        1.002679,
+        1.020024
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "42086545b7a170c5868afcc390f83d964e06d528e2d1039420fc6bfd7a6aac74"
+    },
+    "guard_xor_14": {
+      "r": 1.002796,
+      "ci": [
+        0.986687,
+        1.015537
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "35bb35714e10888c786a71ccdfe31d2b9b4651c567fac5ba4c9543bc247cad80"
+    },
+    "guard_xor_16": {
+      "r": 1.02833,
+      "ci": [
+        1.003679,
+        1.032171
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "56163b8ea3d877b3b9bf15753b7c0175d4a6ead493640eef8210c59ba7e5215c"
+    }
+  },
+  "rust_oracle": [
+    {
+      "workload": "wf_log14x32",
+      "verified": true,
+      "oracle": "pinned-rust-stwo",
+      "artifact_sha256": "d32393fe3b1f9abbc4795d87c3b3316e06111f014ec30f0635f13ec0ff0587f9"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "pr6_supremacy",
+      "reason": "PR6 Supremacy remains disabled until every exact workload port, log22 oracle vector, both timing boundaries, locked-M5 statistical gate, and authenticated judged verdict are complete."
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "wf_log14x32": {
+        "round_ratios": [
+          0.813124,
+          0.795598,
+          0.787231,
+          0.79492,
+          0.776059,
+          0.791271,
+          0.784668
+        ],
+        "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374",
+        "request_ratio": 0.807709,
+        "rss_ratio": 0.998743,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.943872,
+            "ci": [
+              0.809603,
+              0.948983
+            ],
+            "observations": 7,
+            "candidate": 1.283552529
+          },
+          "peak_rss_mib": {
+            "ratio": 0.998743,
+            "ci": [
+              0.996406,
+              1.000721
+            ],
+            "observations": 7,
+            "candidate": 21.719619750976562
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 41840.0
+          }
+        },
+        "report_sha256s": [
+          "6aaa0ee75cfca4169b01e6814939618714899ecf6a4614f9410932e1f1129ce1",
+          "40bfee3d7594e861871ce258292d7a1c6694f5b5e9bdae45bccc93411645a3e4",
+          "0bc804ea1e58498137737d0a54ccac2e3eaf014af01608ebaec9d9c47867d9cd",
+          "7738b0af2d1065f0d32bbd0aae6aff9477702d9a7ef9988edb0acb871f4fa40b",
+          "a096f65adf58867ee700d48a5658e9752e263377dc34032bd57cee707d948db3",
+          "ee2374e7cb60d0d4563770af65138a9d863aa2d27a718a0bec83bac56029d89d",
+          "8e55a742e2c7256866da98e6fa8df76d3a67b9153f0294358ee1f2bf48955b21",
+          "e564c984c30ff91dd59b75738ad559679ab42cd567f93a5e8f17638e594097e6",
+          "dd94754a6758fc11fa1097acec7e34637e1ea9b80c76a00e4df350fd851425fb",
+          "397cb6ff318ffd31d37ef1711a21a738e3a21f8766a7a82618570aafd35be54f",
+          "d7849d35497048d42c4894af97582928a75db8f7534c89342ddec7386b0a70a3",
+          "dcdb5fdeb589f5b3b5fcd77db13ebc1eaa1ad5dd6205cc2a218c2f41e62963c9",
+          "2214b9a9afe189e70ad4fdefe30a1cf3c265590c09dd558c3dd91f0d9079360a",
+          "8e7134536e48626f4a0e8230f4a5161606a293bc9395c98fd39a699bff4f9b80"
+        ],
+        "mechanism_verified": null,
+        "resources_complete": null
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-system2x-epoch1/autoresearch/.runs/latest/wf_log14x32.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-system2x-epoch1/autoresearch/.runs/latest/wf_log14x32.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-system2x-epoch1/autoresearch/.runs/latest/wf_log14x32.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-system2x-epoch1/autoresearch/.runs/latest/wf_log14x32.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-system2x-epoch1/autoresearch/.runs/latest/wf_log14x32.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-system2x-epoch1/autoresearch/.runs/latest/wf_log14x32.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-system2x-epoch1/autoresearch/.runs/latest/wf_log14x32.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-system2x-epoch1/autoresearch/.runs/latest/wf_log14x32.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-system2x-epoch1/autoresearch/.runs/latest/wf_log14x32.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-system2x-epoch1/autoresearch/.runs/latest/wf_log14x32.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-system2x-epoch1/autoresearch/.runs/latest/wf_log14x32.a6.json",
+      "/Users/theodorepender/code/auto-researching/ws-system2x-epoch1/autoresearch/.runs/latest/wf_log14x32.b6.json",
+      "/Users/theodorepender/code/auto-researching/ws-system2x-epoch1/autoresearch/.runs/latest/wf_log14x32.a7.json",
+      "/Users/theodorepender/code/auto-researching/ws-system2x-epoch1/autoresearch/.runs/latest/wf_log14x32.b7.json"
+    ]
+  }
+}

--- a/src/backends/cpu_scalar/secure_composition.zig
+++ b/src/backends/cpu_scalar/secure_composition.zig
@@ -14,9 +14,11 @@ const ComponentProver = prover.air.component_prover.ComponentProver;
 const Trace = prover.air.component_prover.Trace;
 const SecureColumnByCoords = prover.secure_column.SecureColumnByCoords;
 
-// Keep short/small proofs on the reference loop: their fan-out cost is a
-// meaningful fraction of the whole request. This admits trace logs >= 16.
-const min_eval_log_size: u32 = 17;
+// The recurrence plan amortizes worker fan-out from a 2^15 evaluation domain
+// onward. Narrow AIRs never reach this implementation because admission also
+// requires a structurally matched, contiguous recurrence trace.
+const min_eval_log_size: u32 = 15;
+const min_recurrence_columns: usize = 32;
 
 const RecurrenceShape = struct {
     first_column: [*]const M31,
@@ -245,7 +247,7 @@ fn recurrenceShape(components: []const ComponentProver, trace: *const Trace) ?Re
         if (tree_index != recurrence.trace_tree_index and tree.len != 0) return null;
     }
     const columns = trace.polys.items[recurrence.trace_tree_index];
-    if (columns.len < 64 or component.nConstraints() != columns.len - 2) return null;
+    if (columns.len < min_recurrence_columns or component.nConstraints() != columns.len - 2) return null;
     const eval_log_size = component.maxConstraintLogDegreeBound();
     if (eval_log_size < min_eval_log_size or eval_log_size >= @bitSizeOf(usize)) return null;
     const row_count = @as(usize, 1) << @intCast(eval_log_size);


### PR DESCRIPTION
Structurally admits the existing packed, row-parallel recurrence composition plan at a 2^15 evaluation domain and 32 contiguous recurrence columns.

Claimed core_cpu/wide S3 result: ratio 0.791173, 95% CI [0.783665, 0.801629], with seven ABBA rounds, pinned Rust-oracle acceptance, unchanged 41,840-byte proofs, and 13/13 guards passing.

The submission includes the complete profiling and rejection transcript. The rejected CPU ownership and small-shape Metal experiments are absent from the final one-file source diff.

System-level 2x remains open because log16 still fails the per-cell ceiling and cold-process evidence remains outstanding.