### PR TITLE
cpu wide: size work pool to performance-core count (0.963 + RSS 0.889)

### DIFF
--- a/autoresearch/submissions/2026-07-23-apple-performance-core-work-pool/delta.json
+++ b/autoresearch/submissions/2026-07-23-apple-performance-core-work-pool/delta.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "799efe87a9ec",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "wide",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/prover/work_pool.zig": "sha256:fbbb0fb41877ed06ccef3cd8e6176abb3679b971d63ebac0b7f04ac0edef1508"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "e241f056bebd3be539150ad8e2065fc855d59eec6cdf287b4d2e85cbc4723022",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-23-apple-performance-core-work-pool/note.md
+++ b/autoresearch/submissions/2026-07-23-apple-performance-core-work-pool/note.md
@@ -1,0 +1,62 @@
+# Size the Apple work pool to performance cores
+
+## Model and harness
+
+Claude Fable 5 developed this mechanism with CODEX ANVIL providing an
+independent source and verdict review. The repo-resident `stwo-perf` harness is
+`7efe3b1abd72`; the immutable candidate is
+`9888ea2a4da0cae00a7b1e525d1d4ebf762ef583` over clean current-main
+predecessor `799efe87a9eccd6ae9a2e19c815e82bfbf1d4198`. The claimed result is
+Native CPU `wide/time` at S3, measured ReleaseFast on a quiet Apple M4 Max
+Studio. The canonical launch preflight bound both SHAs and candidate tree
+`b64a60125bc5b18b4dae73a6c94ce5c9f4b6fe29` before timing. Every sample
+verified, proof digests matched across arms, and the pinned Rust Stwo oracle
+accepted the workload.
+
+## Hypothesis
+
+Static worker spans finish at the speed of their slowest participating core.
+On asymmetric Apple CPUs, adding efficiency cores can therefore extend the
+critical path even though it raises the logical-core count. A direct worker
+sweep showed eight workers beating twelve on an 8P+4E host. Hardcoding eight
+would be a transfer error on a larger judge, so the portable mechanism is to
+size the process-global pool from the machine's performance-core cluster.
+
+## Changes
+
+On macOS, work-pool initialization queries
+`hw.perflevel0.logicalcpu` through `sysctlbyname` and uses that positive value
+as the worker count, bounded by the existing maximum. Probe failure, invalid
+values, and non-Apple systems fall back to the prior total-logical-CPU query.
+The existing `STWO_ZIG_WORKERS` override retains priority, so testing and
+operator control are unchanged. No workload, statement, benchmark size, or
+proof input is special-cased.
+
+## Results
+
+Native wide proving improves from median 4.588584 ms to 4.408292 ms:
+**R=0.962604**, workload 95% CI **[0.954890, 0.968034]**. The deterministic
+portfolio CI is **[0.955241, 0.967628]**, clearing theta 0.029290.
+Verified-request ratio is 0.965901.
+
+G1-G5 pass, including all **13/13 regression guards** under their 1.05
+upper-CI budgets. Proof-byte ratio is exactly 1.0. Peak RSS falls to ratio
+0.888580 with upper CI 0.889829. The pinned Rust oracle passes, and every
+timed proof digest is byte-identical across arms. The 380-source closure,
+three independent Native proof identities, and a forced-worker-count digest
+stability check were also green.
+
+## Caveats
+
+Energy increased to ratio 1.010550 with 95% CI [1.007874, 1.028698], within
+the named gate but a real measured tradeoff. Several guards are mildly slower
+while remaining below budget; the largest upper CIs are Poseidon-10 1.037991,
+Plonk-16 1.032914, and state-machine-16 1.032259. Only Native CPU wide is
+claimed here; no timing claim is inferred for small, deep, Metal, RISC-V, or a
+different Apple topology.
+
+The performance-core query is transfer-safe by construction, but the exact
+gain on the locked M5 judge remains for authenticated measurement. This is a
+local claimed verdict, not a judged or promoted record. The separate PR6
+all-cell matrix, log22 oracle vector, both timing boundaries, and locked-M5
+judged verdict remain incomplete. **PR6 Supremacy: not achieved.**

--- a/autoresearch/submissions/2026-07-23-apple-performance-core-work-pool/note.md
+++ b/autoresearch/submissions/2026-07-23-apple-performance-core-work-pool/note.md
@@ -2,8 +2,9 @@
 
 ## Model and harness
 
-Claude Fable 5 developed this mechanism with CODEX ANVIL providing an
-independent source and verdict review. The repo-resident `stwo-perf` harness is
+Claude Fable 5, operating as lane MERSENNE-B, authored the mechanism, branch,
+and submission note, with CODEX ANVIL providing an independent source and
+verdict review. The repo-resident `stwo-perf` harness is
 `7efe3b1abd72`; the immutable candidate is
 `9888ea2a4da0cae00a7b1e525d1d4ebf762ef583` over clean current-main
 predecessor `799efe87a9eccd6ae9a2e19c815e82bfbf1d4198`. The claimed result is

--- a/autoresearch/submissions/2026-07-23-apple-performance-core-work-pool/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-23-apple-performance-core-work-pool/transcripts/session-01.md
@@ -1,0 +1,40 @@
+# Sanitized research transcript: Apple performance-core work-pool sizing
+
+Model: Claude Fable 5, with CODEX ANVIL independent review.
+
+## Attribution and hypothesis
+
+A quiet worker-count battery on an 8P+4E Apple host found that eight workers
+beat twelve on Native wide in every ABBA pair. The first interpretation was
+not accepted as a shippable constant: eight would idle performance cores on a
+larger M5 topology. The hypothesis was reformulated as a transfer-safe runtime
+policy—use the highest-performance Apple core cluster, not a host-specific
+number.
+
+## Implementation and critique
+
+The candidate queries `hw.perflevel0.logicalcpu` on macOS and preserves the
+existing total-logical fallback elsewhere. The explicit environment override
+still takes precedence. Live detection returned the expected performance-core
+count on the development host. Proofs generated with default detection and a
+forced worker count were byte-identical, confirming that worker topology
+changes scheduling rather than protocol output.
+
+An M4 Pro magnitude screen retained the winning direction but its two nominally
+equivalent eight-worker arms differed too much to grade. That result was not
+promoted. The final battery was moved to the quieter Studio rather than
+rerolled on the noisy host.
+
+## Validation
+
+Before timing, the canonical launch preflight checked live upstream main,
+candidate and predecessor HEADs, direct merge-base, clean trees, canonical
+`origin/main`, and empty run state. It emitted:
+
+`S3_PREFLIGHT_OK main=799efe87... candidate=9888ea2... tree=b64a6012...`
+
+The exact-current Studio S3 produced R=0.962604 with workload 95% CI
+[0.954890, 0.968034], all 13 guards green, pinned Rust oracle success,
+cross-arm proof identity, proof-byte ratio 1.0, and peak-RSS ratio 0.888580.
+The measured energy ratio 1.010550 and the mildly slower but in-budget guards
+are disclosed in the submission note.

--- a/autoresearch/submissions/2026-07-23-apple-performance-core-work-pool/verdict.json
+++ b/autoresearch/submissions/2026-07-23-apple-performance-core-work-pool/verdict.json
@@ -1,0 +1,424 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "7efe3b1abd72",
+  "repo_commit": "9888ea2a4da0",
+  "predecessor_commit": "799efe87a9ec",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "wide",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "da0daaba4b15",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 5.87
+    }
+  },
+  "search_health": {
+    "schema_version": 1,
+    "decision": {
+      "schema_version": 1,
+      "board": "core_cpu",
+      "workload_class": "wide",
+      "trailing_window": 8,
+      "trailing_evidence_count": 3,
+      "trailing_median_gradient_snr": 5.8930825740846355,
+      "gradient_snr_threshold": 2.0,
+      "configured_rounds": 15,
+      "auto_boost_rounds": 5,
+      "maximum_rounds": 25,
+      "target_rounds": 15,
+      "workload_count": 1,
+      "class_wall_deadline_seconds": 600.0,
+      "estimated_seconds_per_round": 2.892720779703398,
+      "deadline_round_limit": 207,
+      "auto_boost_applied": false,
+      "auto_boost_reason": "trailing_median_at_or_above_threshold",
+      "recorded_before_measurement": true
+    },
+    "decision_sha256": "sha256:ab12881e2adaf5cd4c844186d0f2e6e2fdae6103dc07bb6dcc968e70dca6db56",
+    "actual_rounds": 7,
+    "actual_rounds_per_workload": {
+      "wf_log14x32": 7
+    },
+    "objective_wall_seconds": 1.9813267500139773,
+    "measurement_wall_seconds": 30.577319292002358,
+    "measurement_wall_hours": 0.008493699803333988,
+    "gradient_snr": null,
+    "credited_ln_improvement": null,
+    "credited_ln_improvement_per_measurement_hour": null,
+    "credit_status": "pending_ledger_adjudication",
+    "decision_record": "/Users/odin/stwo-pcore-cand-9888/autoresearch/.runs/latest/search-health-decision.json"
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned correctness oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "native mechanism telemetry policy unchanged"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.2497 vs targeted budget x1.02; matrix row upper CIs 1/1 within budget x1.05; regression guards 13/13 within budget; request ratios 1/1 present rows within budget x1.05; resource vectors 1/1 within named budgets"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log14x32": {
+        "r": 0.962604,
+        "ci": [
+          0.95489,
+          0.968034
+        ],
+        "rounds": 7,
+        "a_median_ms": 4.588584,
+        "b_median_ms": 4.408292,
+        "request_ratio": 0.965901,
+        "rss_ratio": 0.88858,
+        "resources": {
+          "energy_j": {
+            "ratio": 1.01055,
+            "ci": [
+              1.007874,
+              1.028698
+            ],
+            "observations": 7,
+            "candidate": 1.273212364
+          },
+          "peak_rss_mib": {
+            "ratio": 0.88858,
+            "ci": [
+              0.887657,
+              0.889829
+            ],
+            "observations": 7,
+            "candidate": 21.313232421875
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 41840.0
+          }
+        },
+        "mechanism_verified": null,
+        "proof_bytes": 41840,
+        "measurement_seconds": 1.941009,
+        "resources_complete": null
+      }
+    },
+    "R_geomean": 0.962604,
+    "portfolio": {
+      "ci_method": "independent_workload_round_bootstrap_percentile_v1",
+      "ci_level": 0.95,
+      "bootstrap_iterations": 4000,
+      "seed": 4133880075,
+      "ci": [
+        0.955241,
+        0.967628
+      ],
+      "prove_ms_method": "geometric_mean_candidate_workload_medians_ms_v1",
+      "b_median_ms_geomean": 4.408292,
+      "proof_bytes_method": "rounded_geometric_mean_candidate_proof_bytes_v1",
+      "proof_bytes": 41840,
+      "measurement_seconds": 1.941009,
+      "measurement_rounds": 7
+    },
+    "theta": 0.02929,
+    "aa_dispersion": 0.014645,
+    "significant": true,
+    "neutral": false,
+    "promotion_significance": {
+      "eligible": true,
+      "method": "independent_workload_round_bootstrap_percentile_v1",
+      "reason": "prove-time objective uses the deterministic workload portfolio CI"
+    },
+    "resource_portfolio": {
+      "peak_rss_mib": {
+        "ratio_geomean": 0.8885800409544868,
+        "upper_ci_geomean": 0.889828671536787,
+        "candidate_geomean": 21.313232421875
+      },
+      "energy_j": {
+        "ratio_geomean": 1.010549588281512,
+        "upper_ci_geomean": 1.028698062693038,
+        "candidate_geomean": 1.273212364
+      },
+      "proof_bytes": {
+        "ratio_geomean": 1.0,
+        "upper_ci_geomean": 1.0,
+        "candidate_geomean": 41840.00000000004
+      }
+    }
+  },
+  "tiebreakers": {
+    "rss_ratio": 0.88858,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": 1.273212364,
+    "proof_bytes": 41840.00000000004
+  },
+  "holdout": null,
+  "guards": {
+    "guard_blake_10x10": {
+      "r": 0.996548,
+      "ci": [
+        0.987421,
+        1.00518
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "4153acd6e32a98b9d240730062f7fa35e2e31eca915f01c179337f04d409cbd2"
+    },
+    "guard_blake_12x16": {
+      "r": 0.921663,
+      "ci": [
+        0.871012,
+        0.973462
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "70e516957d2d38ed78214bfda5b0b2bdfe41f1c93439fb68e124bfef096fbc9f"
+    },
+    "guard_plonk_14": {
+      "r": 1.00646,
+      "ci": [
+        1.002399,
+        1.008899
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf"
+    },
+    "guard_plonk_16": {
+      "r": 1.018189,
+      "ci": [
+        1.000578,
+        1.032914
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "cfb36bf17fb3526bf1bdd9401fb885fd91ca46b9982fee1ca5fad33a1d574b72"
+    },
+    "guard_poseidon_10": {
+      "r": 1.008582,
+      "ci": [
+        0.981964,
+        1.037991
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "af33240da8e7947362fdf7e78d306f2e11cb2e3df7e1b6f498a6e86ac3ae7b1b"
+    },
+    "guard_poseidon_13": {
+      "r": 0.999786,
+      "ci": [
+        0.995928,
+        1.009567
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "f196835da5d4a155c6311bafb44335c2863cc028879d69a7ae53b802321200f1"
+    },
+    "guard_sm_14": {
+      "r": 1.005941,
+      "ci": [
+        1.000558,
+        1.010996
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "488fadeeb4e5d76b6fc0a9c10ab258bab6673de8e912ae5de927561650920b37"
+    },
+    "guard_sm_16": {
+      "r": 1.02305,
+      "ci": [
+        1.017743,
+        1.032259
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "88ec35ee88a05ce0a5db4b6cb063f4cf7824ee65284db0908a62a9362879af73"
+    },
+    "guard_wf_10x8": {
+      "r": 0.987753,
+      "ci": [
+        0.961398,
+        1.005545
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700"
+    },
+    "guard_wf_14x32": {
+      "r": 0.979119,
+      "ci": [
+        0.971156,
+        0.991867
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374"
+    },
+    "guard_wf_16x64": {
+      "r": 1.00526,
+      "ci": [
+        0.99782,
+        1.019007
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "42086545b7a170c5868afcc390f83d964e06d528e2d1039420fc6bfd7a6aac74"
+    },
+    "guard_xor_14": {
+      "r": 1.015127,
+      "ci": [
+        1.010711,
+        1.020648
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "35bb35714e10888c786a71ccdfe31d2b9b4651c567fac5ba4c9543bc247cad80"
+    },
+    "guard_xor_16": {
+      "r": 1.011764,
+      "ci": [
+        1.00883,
+        1.01359
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "56163b8ea3d877b3b9bf15753b7c0175d4a6ead493640eef8210c59ba7e5215c"
+    }
+  },
+  "rust_oracle": [
+    {
+      "workload": "wf_log14x32",
+      "verified": true,
+      "oracle": "pinned-rust-stwo",
+      "artifact_sha256": "d32393fe3b1f9abbc4795d87c3b3316e06111f014ec30f0635f13ec0ff0587f9"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "pr6_supremacy",
+      "reason": "PR6 Supremacy remains disabled until every exact workload port, log22 oracle vector, both timing boundaries, locked-M5 statistical gate, and authenticated judged verdict are complete."
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "wf_log14x32": {
+        "round_ratios": [
+          0.967628,
+          0.965714,
+          0.959004,
+          0.958069,
+          0.964309,
+          0.944769,
+          0.971759
+        ],
+        "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374",
+        "request_ratio": 0.965901,
+        "rss_ratio": 0.88858,
+        "resources": {
+          "energy_j": {
+            "ratio": 1.01055,
+            "ci": [
+              1.007874,
+              1.028698
+            ],
+            "observations": 7,
+            "candidate": 1.273212364
+          },
+          "peak_rss_mib": {
+            "ratio": 0.88858,
+            "ci": [
+              0.887657,
+              0.889829
+            ],
+            "observations": 7,
+            "candidate": 21.313232421875
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 41840.0
+          }
+        },
+        "report_sha256s": [
+          "49845e7bf621ea64fdc54fbfbd41820eae346d265981601914c5e898c9808d3b",
+          "ab485f3e4801d7a0808e7a3360d30137b73afa8be3a1cd4c4867482c0259ea3a",
+          "678f8f5345876cada420436423d2555de278acbbd0ee4633487a27de6cbb8dc2",
+          "ace22ef801cdaa44ec92a1abd8cba4e68305fb33ba8af11faf55fb93bee14e12",
+          "674346a3c25e046aec94617423ee8a6cc4a2aab4b861c7bc41b48a9edfa9dba3",
+          "04dde4eb50021f9497e3990a8d0df79b6e0bcdc06b079371fc20f828e053d13e",
+          "c7b6afdbc1d647e4b9bfc7720854e255d9e06651a5b900d9d3bd1195e536d0d9",
+          "daa69af352e57c3b09e365a1aec012b54e1e307a0a5161daa2c7d2afb03b1415",
+          "28bf1f30b265801d7913d27cd79ab50a2cd6020a4e272201f1f798ba84296791",
+          "129686241033a550e3c53977b7f07323094fc12d05586c7c0dc3020e906a6bb3",
+          "8993f4f255381d814b4b93c0d06285da705079e1b5faaef836b4b94b323666d9",
+          "8a5eaf35e954464c099581afaa24e88645ff222e964c0ab97e47b4e2ae379818",
+          "bd7dbb97b94e3fcd832a5c5ab7e8bc9451097e5f9c4dd1bef8824a3db06c46e2",
+          "0e904a3931f14d4349f0410b60d781e711c2f60a64d730c2265c18ae43914125"
+        ],
+        "mechanism_verified": null,
+        "resources_complete": null
+      }
+    },
+    "reports": [
+      "/Users/odin/stwo-pcore-cand-9888/autoresearch/.runs/latest/wf_log14x32.a1.json",
+      "/Users/odin/stwo-pcore-cand-9888/autoresearch/.runs/latest/wf_log14x32.b1.json",
+      "/Users/odin/stwo-pcore-cand-9888/autoresearch/.runs/latest/wf_log14x32.a2.json",
+      "/Users/odin/stwo-pcore-cand-9888/autoresearch/.runs/latest/wf_log14x32.b2.json",
+      "/Users/odin/stwo-pcore-cand-9888/autoresearch/.runs/latest/wf_log14x32.a3.json",
+      "/Users/odin/stwo-pcore-cand-9888/autoresearch/.runs/latest/wf_log14x32.b3.json",
+      "/Users/odin/stwo-pcore-cand-9888/autoresearch/.runs/latest/wf_log14x32.a4.json",
+      "/Users/odin/stwo-pcore-cand-9888/autoresearch/.runs/latest/wf_log14x32.b4.json",
+      "/Users/odin/stwo-pcore-cand-9888/autoresearch/.runs/latest/wf_log14x32.a5.json",
+      "/Users/odin/stwo-pcore-cand-9888/autoresearch/.runs/latest/wf_log14x32.b5.json",
+      "/Users/odin/stwo-pcore-cand-9888/autoresearch/.runs/latest/wf_log14x32.a6.json",
+      "/Users/odin/stwo-pcore-cand-9888/autoresearch/.runs/latest/wf_log14x32.b6.json",
+      "/Users/odin/stwo-pcore-cand-9888/autoresearch/.runs/latest/wf_log14x32.a7.json",
+      "/Users/odin/stwo-pcore-cand-9888/autoresearch/.runs/latest/wf_log14x32.b7.json"
+    ]
+  }
+}

--- a/src/prover/work_pool.zig
+++ b/src/prover/work_pool.zig
@@ -93,8 +93,28 @@ fn detectWorkerCount() usize {
         } else |_| {}
     }
 
-    const cpu_count = std.Thread.getCpuCount() catch return 1;
+    // Prefer the PERFORMANCE-core count over total logicals: E-cores drag
+    // statically-chunked parallel stages (measured: wide -5.8% at P-only on
+    // 8P+4E; the effect is a K3 static-scheduling artifact). Detected at
+    // runtime so it transfers across hosts (e.g. an M5's larger P-cluster)
+    // instead of hardcoding one machine's count. Falls back to total logical
+    // cores where the probe is unavailable (non-Apple / CI), preserving prior
+    // behavior there.
+    const performance_cores = detectPerformanceCores();
+    const cpu_count = performance_cores orelse (std.Thread.getCpuCount() catch return 1);
     return @min(cpu_count, MAX_WORKERS);
+}
+
+/// Apple-only: logical CPUs in the highest-performance core cluster
+/// (`hw.perflevel0.logicalcpu`). Returns null off Apple or on any probe
+/// failure, so callers fall back to the total logical count.
+fn detectPerformanceCores() ?usize {
+    if (builtin.os.tag != .macos) return null;
+    var value: c_int = 0;
+    var len: usize = @sizeOf(c_int);
+    const rc = std.c.sysctlbyname("hw.perflevel0.logicalcpu", &value, &len, null, 0);
+    if (rc != 0 or value <= 0) return null;
+    return @intCast(value);
 }
 
 // Tests


### PR DESCRIPTION
Atomic claim: the global work pool auto-sizes to the PERFORMANCE-core count (sysctl hw.perflevel0 on Apple platforms; falls back to total logicals elsewhere) instead of all logical cores — E-cores dragging statically-chunked stages was measured costing native wide ~5%. **R 0.962604, portfolio CI [0.955241, 0.967628]** vs θ 0.0293, 13/13 guards under budget, proof bytes exactly 1.0, oracle pass — and a bonus **peak-RSS ratio 0.8886** (fewer worker arenas), making the row a two-axis Pareto point. Transfer-safe by construction: sized to detected P-core count, not a tuned constant (relevant for the M5 judge's different topology; forced-worker-count digest stability verified).

Submission dir: `autoresearch/submissions/2026-07-23-apple-performance-core-work-pool`. Author lane: MERSENNE-B (fleet); reviews: ANVIL + A keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)