### PR TITLE
Batch eight terminal BLAKE2s Merkle hashes

### DIFF
--- a/autoresearch/submissions/2026-07-23-riscv-eight-way-terminal-blake2s/delta.json
+++ b/autoresearch/submissions/2026-07-23-riscv-eight-way-terminal-blake2s/delta.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "c3a7e8b36460",
+  "declared_objective": {
+    "board": "riscv",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/core/crypto/blake2s_backend.zig": "sha256:9c7ecd4be37d02f5cd7699adb2c8956d6fafebe35094528ce726e954044ad11f",
+    "src/core/crypto/tests/blake2s_backend.zig": "sha256:4329dfacab790b071df58a6ab49852352e90285e538188533fdffcb2ffc0175e",
+    "src/prover/vcs_lifted/blake2_stream4.zig": "sha256:42bbcd3e31be2c30f0a3114377223f5c1dbbdf4bdcfe528b4991d328f0ebf287",
+    "src/prover/vcs_lifted/layers.zig": "sha256:3908a6140da263e535dbb76f1c222183ab2aa731409bb4d8386abce2c553fcb6"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "b29a39654a129e882ca7bc64da9325d7b671d6a2638c51eead063995b8ab9cba",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-23-riscv-eight-way-terminal-blake2s/note.md
+++ b/autoresearch/submissions/2026-07-23-riscv-eight-way-terminal-blake2s/note.md
@@ -1,0 +1,101 @@
+# Batch eight independent terminal BLAKE2s Merkle hashes
+
+## Model and harness
+
+Model: GPT-5 Codex. Harness: repo-resident `stwo-perf` 0.1.0 at
+`481487ba7153`, clean candidate `e199fbf569a8`, clean predecessor
+`c3a7e8b36460`, immutable system-2x task baseline
+`2beae9d03b33bc9c5b0b21bb445439799786f2fb`, Zig 0.15.2 ReleaseFast on
+the 18-logical-CPU Apple M5 Max.
+
+The submitted S3 RISC-V deep verdict used isolated paired same-host
+processes. Every timed proof independently verified, cross-arm proof digests
+were byte-identical, and the pinned Stark-V oracle accepted all seven
+programs. The complete profiles, hypotheses, rejected variants, source-policy
+correction, and final evidence are recorded in `transcripts/session-01.md`.
+
+## Hypothesis
+
+The shared BLAKE2s Merkle implementation hashes four independent messages in
+one AArch64 vector. At each BLAKE dependency level, however, the machine can
+issue work from a second independent four-message group. A logical
+`@Vector(8, u32)` terminal compression exposes those two native NEON halves
+to LLVM in one operation graph. This is useful specifically for the
+single-compression internal-node path, where it increases instruction-level
+parallelism without retaining multi-block stream state.
+
+## Changes
+
+The shared crypto backend now provides an eight-message fixed-terminal
+BLAKE2s operation. It:
+
+- consumes eight independent 64-byte child payloads after one common
+  pre-hashed node-domain seed;
+- uses checked, fixed-size data flow and the existing exact ten-round BLAKE2s
+  permutation;
+- uses bit-cast halves for zero-cost native-vector splitting and joining;
+- preserves the scalar backend fallback for platforms without the SIMD path;
+- keeps four-way handling for the residual Merkle tail; and
+- is selected only from the generic lifted Merkle structure, never by
+  workload, input digest, row count, or proof size.
+
+The production routing is confined to manifest-editable
+`src/core/crypto/**` and `src/prover/vcs_lifted/**`. A first packaging attempt
+placed two convenience wrappers under non-editable shared-VCS directories;
+the harness rejected it mechanically. Those wrappers were removed and the
+same operation moved into the allowed prover adapter before this verdict.
+
+An attempted eight-way multi-block leaf/continuation path was also removed.
+It preserved proof bytes and reduced cycles, but its larger live vector state
+caused spill pressure and did not win both wall-time halves. The promoted
+patch therefore applies eight-way batching only to the one-compression node
+case.
+
+```text
+old:  4 parents -> terminal BLAKE2s V4
+      4 parents -> terminal BLAKE2s V4
+
+new:  8 parents -> one terminal BLAKE2s V8 operation graph
+      residual 4 parents -> existing terminal BLAKE2s V4
+```
+
+## Results
+
+The admissible RISC-V deep-class paired result is:
+
+| workload | candidate/predecessor | 95% CI |
+| --- | ---: | ---: |
+| xorshift PRNG | 0.9849 | [0.9834, 0.9870] |
+| iterative Fibonacci | 0.9917 | [0.9896, 0.9926] |
+| Euclidean GCD | 0.9919 | [0.9898, 0.9934] |
+| multi-shard ADDI | 0.9885 | [0.9863, 0.9906] |
+| SHA2-512 | 0.9839 | [0.9779, 0.9909] |
+| SHA2-1024 | 0.9963 | [0.9936, 1.0043] |
+| SHA2-2048 | 0.9878 | [0.9767, 1.0008] |
+
+The incremental deep portfolio ratio is **0.9893**. All seven medians improve,
+but the local harness correctly classifies the 1.07% aggregate change as
+confirmed-neutral because the class significance floor is 1.29%. The
+cumulative candidate-to-frozen-task-anchor ratio reported by the same verdict
+is **0.4688**.
+
+A separate admissible wide run passed all correctness, mechanism, resource,
+and source-policy gates at ratio 0.9911. It is retained as guard evidence, not
+claimed as a moved class: its Keccak row was noisy and the portfolio was
+confirmed-neutral.
+
+Short exact-proof screens showed 1.6--4% fewer cycles in the affected request
+path. Peak physical footprint remained effectively unchanged. Core and prover
+ReleaseFast tests, the full product build, exact SHA2-128/SHA2-2048 artifact
+comparisons, and the seven-workload oracle gate pass.
+
+## Caveats
+
+This is a local claimed/advisory checkpoint; only an authenticated judge can
+promote it. Its incremental effect is below the local significance threshold,
+so it must not be described as an independently significant speedup.
+
+The broader system-level task is not fully complete: although the cumulative
+deep result is below 0.50 versus the frozen baseline, the required per-cell
+CPU request/prove contract and genuine RISC-V Metal phase have not both been
+completed. **RISC-V system-level 2x: not achieved.**

--- a/autoresearch/submissions/2026-07-23-riscv-eight-way-terminal-blake2s/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-23-riscv-eight-way-terminal-blake2s/transcripts/session-01.md
@@ -1,0 +1,311 @@
+# RISC-V system-level 2x autoresearch — terminal BLAKE2s epoch
+
+## Objective and inherited state
+
+This epoch continued the fixed-protocol RISC-V system-level 2x task. The
+immutable authority is commit
+`2beae9d03b33bc9c5b0b21bb445439799786f2fb`; the epoch began from promoted
+main `c3a7e8b364604e117d292a3f7793918498d1a64d`. The target host is an Apple
+M5 Max with 18 logical CPUs and 64 GiB RAM, using Zig 0.15.2 ReleaseFast.
+
+The fixed contract requires exact RISC-V statement/AIR/protocol semantics,
+independent verification, pinned Rust/Stark-V oracle acceptance, identical
+proof bytes, unchanged proof shape and security parameters, no input- or
+workload-specific routing, resource telemetry, paired same-host processes,
+and broad RISC-V/native guards. The completion target remains 2x on every
+headline CPU prove and verified-request point, followed by a genuine RISC-V
+Metal backend. This transcript records a final requested architecture
+checkpoint, not a claim that those complete gates have all been achieved.
+
+The immediately preceding promotion preserved structurally base QM31
+operands. Its clean code candidate was `963f30da163a`; its submitted source
+closure was `e2b4926`. Against the frozen task baseline, the six headline
+proving geometric mean reached 0.665886 (1.502x), verified request reached
+0.750290 (1.333x), and all 20 RISC-V programs improved. That promotion was
+merged and the feed advanced main to `c3a7e8b`.
+
+## Repository and tooling state
+
+The canonical checkout contained three pre-existing untracked researcher
+notes. They were treated as user-owned and never modified. Work proceeded in
+clean worktree:
+
+`/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2`
+
+on branch `autoresearch/riscv-system2x-epoch2`. A separate clean detached
+predecessor worktree at `c3a7e8b` was created for paired evidence. The
+repo-resident CLI had already been refreshed at session start; its reported
+version is `stwo-perf 0.1.0`.
+
+No concurrent benchmark or autoresearch job ran. All candidate screens used
+prebuilt ReleaseFast products, retained proof artifacts, and the same
+ELF/input/protocol as their predecessor arm.
+
+## Promoted-main profile
+
+Production complete-request profiles were captured at three SHA2 input sizes:
+
+| input | request s | prove s | witness s | verify s | peak footprint |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| SHA2-128 | 1.39205 | 0.86349 | 0.43966 | 0.08382 | 1.402 GB |
+| SHA2-512 | 1.57479 | 1.03680 | 0.44037 | 0.08837 | 1.443 GB |
+| SHA2-2048 | 2.18607 | 1.51469 | 0.56809 | 0.08420 | 1.571 GB |
+
+Nested diagnostic profiles divided the proving path as follows:
+
+| stage | SHA2-128 ms | SHA2-2048 ms |
+| --- | ---: | ---: |
+| preprocessing | 80 | 84 |
+| opcode/infrastructure | 246 | 269 |
+| main commitment | 46 | 58 |
+| interaction | 396 | 620 |
+| composition evaluation | 282 | 292 |
+| composition interpolation | 8 | 7 |
+| composition commitment | 23 | 25 |
+| sampled values | 27 | 32 |
+| FRI | 84 | 89 |
+| decommit | 3 | 3 |
+
+A process sample kept BLAKE2s `compressParallel4` as the largest aggregate
+kernel (roughly 4,489--4,924 samples). Other large entries were FFT tails
+(1,206--1,400), quotient evaluation (974--1,213), memory movement
+(882--2,258), Merkle leaf work (about 700), and LogUp pair constraints
+(404--673).
+
+The RISC-V frontend itself is locked by the autoresearch manifest. The live
+editable frontier was therefore shared crypto, field, polynomial, PCS, and
+lifted-Merkle architecture.
+
+## Scheduler experiment
+
+Per-component composition timings showed a strongly heterogeneous set of 35
+components: the first main-thread component took about 0.006 ms, while late
+worker components ranged from about 61 to 233 ms. This motivated a structural
+longest-processing-time-first scheduler.
+
+The candidate reordered structurally derived component tasks and kept proof
+bytes exact. It did not survive paired complete proofs:
+
+- SHA2-128 split its two halves between a small loss and a small win.
+- SHA2-2048 split at about a 2% loss and a 1% win.
+
+The extra concurrently active 18th worker increased bandwidth contention and
+the scheduler did not shorten the joined critical path reliably. The complete
+patch was rejected and reverted. The rejected patch and all exact-proof
+reports are retained under the external session evidence directory
+`profile-scheduler`.
+
+This also confirmed earlier worker-count and oversubscription sweeps: the
+problem was not simply an insufficient number of runnable component tasks.
+
+## Eight-message BLAKE2s hypothesis
+
+The existing four-message BLAKE2s implementation maps four independent
+messages to one native AArch64 vector. Its ten-round dependency graph is
+carefully interleaved across BLAKE G functions, but a second independent
+four-message group can provide instruction-level parallelism at each
+dependency depth.
+
+The proposed architecture used a logical `@Vector(8, u32)`. LLVM legalizes
+that value to two native 128-bit NEON halves on Apple Silicon. The first
+target was the exact internal-Merkle-node operation:
+
+1. start from the common pre-hashed 64-byte node-domain seed;
+2. concatenate eight independent child pairs into eight 64-byte payloads;
+3. transpose them into an eight-lane BLAKE2s message schedule;
+4. execute one exact terminal compression operation graph; and
+5. split the eight resulting states back into canonical 32-byte hashes.
+
+This preserves every byte consumed by the transcript and does not alter
+Merkle shape, leaf values, protocol, query count, or proof encoding.
+
+## First upper-node screen
+
+The initial upper-node-only candidate built and passed its terminal
+differential test. SHA2-128 and SHA2-2048 proof artifacts matched the
+predecessor byte for byte:
+
+- SHA2-128 artifact:
+  `95629c69c53e0d0cf40d852a98cd14aec94caa4bc39d7a1a0093f0ebf3b05288`
+- SHA2-2048 artifact:
+  `807b69a2f4c383c5b73c5570aa6e94858bafb684ee5c7529f1cc1c71318c363c`
+
+The SHA2-128 proving halves improved by about 3.9% and 0.24%. SHA2-2048 split
+between a roughly 0.3% loss and a 1.6% win. Hardware cycles nevertheless fell
+consistently by roughly 2.4--3.2%, while instructions increased about 1%.
+That was promising architecture evidence but insufficient promotion evidence.
+
+## Rejected multi-block expansion
+
+The next hypothesis extended eight lanes into:
+
+- equal-length multi-block leaf hashing;
+- direct M31 column-major leaf hashing;
+- incremental leaf continuation;
+- lifted-tail finalization; and
+- batched leaf construction.
+
+New differential tests covered terminal blocks, equal messages at 4, 64, 68,
+and 3,296 bytes, direct column continuation, and scalar equivalence. Core and
+prover test products passed and exact RISC-V artifacts remained identical.
+
+The complete-proof result rejected the expansion. On SHA2-128, both proving
+halves were flat-to-worse (about +2.2% and +0.1%), although total cycles fell.
+The reason is architectural: one terminal compression has bounded live state,
+while multi-block eight-lane streams retain two native halves for all 16
+BLAKE working words and message state. That saturates the vector register file
+and introduces spill/reload traffic. The broad leaf path was removed.
+
+A terminal-finalization-only variant was also screened. One half improved
+about 1.2%, while the reverse half regressed about 6%. It too was removed.
+
+The retained scope is therefore deliberately narrow: eight lanes only for
+one-compression internal Merkle nodes, with the existing four-lane path used
+for all multi-block streams and residual parent groups.
+
+## Lowering refinements
+
+Several legalizations were compared:
+
+1. explicit `@shuffle` extraction/join around native V4 halves;
+2. direct V8 variable shifts; and
+3. zero-cost `@bitCast([2]V4, V8)` halves with existing immediate V4 rotates.
+
+Direct V8 shifts increased the instruction count. The final implementation
+uses bit-cast halves for message loading, rotate operations, and result
+splitting. This keeps the algorithm expressed as one V8 operation graph while
+giving LLVM the existing immediate V4 rotate idiom on each legalized half.
+
+The layer router handles groups of eight first, then explicitly retains the
+existing group-of-four tail. An earlier `else if` draft would have made
+four-parent residuals scalar whenever the eight-way declaration existed; that
+was caught during review and corrected before the clean candidate.
+
+## Short final screens
+
+The final narrowed source produced exact SHA2-128 and SHA2-2048 proofs.
+Representative paired screens showed:
+
+| input | predecessor prove s | candidate prove s | request result |
+| --- | ---: | ---: | ---: |
+| SHA2-128 | 0.80059 | 0.79457 | candidate about 1.5% faster |
+| SHA2-2048 | 1.43582 | 1.44127 | candidate about 0.3% faster request; prove noisy |
+
+Across short screens, whole-request cycles fell by roughly 1.6--4%.
+Wall-time movement was small enough that only the repository harness could
+decide the final claim.
+
+## Source-policy failure and correction
+
+The first clean implementation commit was `55e61a7`. Its initial wide S3 run
+verified all seven proofs and reported portfolio ratio 0.9836. However, G2
+correctly failed because convenience wrappers had been added under:
+
+- `src/core/vcs/blake2_hash.zig`
+- `src/core/vcs_lifted/blake2_merkle.zig`
+
+Those locations are not in `MANIFEST.json → editable_paths`, even though the
+underlying shared crypto and prover paths are editable. That verdict was
+discarded.
+
+The wrappers were removed. The allowed
+`src/prover/vcs_lifted/blake2_stream4.zig` adapter now packs the eight child
+payloads and calls the allowed `src/core/crypto/**` backend operation
+directly. The source diff became exactly:
+
+- `src/core/crypto/blake2s_backend.zig`
+- `src/core/crypto/tests/blake2s_backend.zig`
+- `src/prover/vcs_lifted/blake2_stream4.zig`
+- `src/prover/vcs_lifted/layers.zig`
+
+Core/prover tests and the full ReleaseFast product build passed again. The
+commit was amended and force-pushed as clean candidate `e199fbf569a8`.
+
+## Admissible wide evidence
+
+The corrected candidate passed all gates on the seven-program wide class:
+
+- G1: every sample verified; cross-arm proofs identical; oracle 7/7.
+- G2: no locked or out-of-scope paths.
+- G3: canonical stable RISC-V mechanism telemetry.
+- G4: all time/request/resource vectors within budgets.
+- G5: local claimed/advisory environment.
+
+| workload | ratio | 95% CI |
+| --- | ---: | ---: |
+| memcpy | 0.9855 | [0.9777, 0.9909] |
+| sieve | 0.9878 | [0.9845, 0.9918] |
+| bubble sort | 0.9921 | [0.9860, 1.0036] |
+| Collatz | 0.9868 | [0.9843, 0.9915] |
+| Keccak-128 | 1.0152 | [1.0075, 1.0349] |
+| SHA2-128 | 0.9972 | [0.9765, 1.0046] |
+| SHA2-256 | 0.9738 | [0.9498, 0.9972] |
+
+The wide portfolio ratio was 0.9911 versus current main and 0.4077 versus the
+frozen calibration anchor. Because the incremental result is
+confirmed-neutral and the noisy Keccak point lost, this class is retained as
+guard evidence and is not included as a moved-class submission verdict.
+
+## Submitted deep evidence
+
+The deep S3 run also passed G1--G5:
+
+| workload | ratio | 95% CI | rounds |
+| --- | ---: | ---: | ---: |
+| xorshift PRNG | 0.9849 | [0.9834, 0.9870] | 3 |
+| iterative Fibonacci | 0.9917 | [0.9896, 0.9926] | 3 |
+| Euclidean GCD | 0.9919 | [0.9898, 0.9934] | 3 |
+| multi-shard ADDI | 0.9885 | [0.9863, 0.9906] | 3 |
+| SHA2-512 | 0.9839 | [0.9779, 0.9909] | 5 |
+| SHA2-1024 | 0.9963 | [0.9936, 1.0043] | 3 |
+| SHA2-2048 | 0.9878 | [0.9767, 1.0008] | 5 |
+
+All seven medians improve. The current-main portfolio ratio is 0.9893, a
+1.07% improvement. The class significance effect size is 1.29%, so the
+harness honestly labels the incremental result confirmed-neutral. The
+cumulative candidate/frozen-anchor ratio is 0.4688.
+
+This deep verdict is the final requested checkpoint. It demonstrates exact
+architecture/correctness and preserves a small portfolio-wide improvement,
+but it is not represented as an independently significant promotion.
+
+## Final verification inventory
+
+The retained candidate passed:
+
+- `zig build test-stwo-core test-stwo-prover -Doptimize=ReleaseFast -j18`
+- `zig build -Doptimize=ReleaseFast -j18`
+- eight-way terminal BLAKE2s differential tests;
+- exact SHA2-128 and SHA2-2048 proof artifact comparisons;
+- seven-program wide S3 verification/oracle/resource/source gates; and
+- seven-program deep S3 verification/oracle/resource/source gates.
+
+Peak process footprint remained in the predecessor envelope. No AIR,
+statement, input, protocol, proof size, transcript ordering, security
+parameter, resource admission, or backend fallback changed.
+
+## Final status and rejection ledger
+
+Promoted candidate architecture:
+
+- eight-message terminal BLAKE2s for internal lifted Merkle nodes;
+- structural selection only;
+- V4 residual and multi-block paths retained;
+- exact canonical proofs.
+
+Rejected in this epoch:
+
+- longest-processing-time component scheduling: split A/B halves;
+- extra active worker: bandwidth contention;
+- eight-way multi-block/equal leaf hashing: register spills, prove regression;
+- eight-way direct M31 leaf hashing: same live-state problem;
+- eight-way incremental continuation: same live-state problem;
+- eight-way finalization across retained streams: split halves;
+- direct V8 variable shifts: excess instructions;
+- non-editable shared-VCS wrappers: mechanical G2 rejection;
+- wide-class claim: confirmed-neutral with noisy Keccak regression.
+
+The final checkpoint is committed, pushed, submitted with the deep verdict,
+and intended for merge at the user's explicit stopping point.
+
+**RISC-V system-level 2x: not achieved.**

--- a/autoresearch/submissions/2026-07-23-riscv-eight-way-terminal-blake2s/verdict.json
+++ b/autoresearch/submissions/2026-07-23-riscv-eight-way-terminal-blake2s/verdict.json
@@ -1,0 +1,950 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "481487ba7153",
+  "repo_commit": "e199fbf569a8",
+  "predecessor_commit": "c3a7e8b36460",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "riscv",
+    "workload_class": "deep",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "dc6522752aa8",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 4.78
+    }
+  },
+  "search_health": {
+    "schema_version": 1,
+    "decision": {
+      "schema_version": 1,
+      "board": "riscv",
+      "workload_class": "deep",
+      "trailing_window": 8,
+      "trailing_evidence_count": 5,
+      "trailing_median_gradient_snr": 20.501307668744357,
+      "gradient_snr_threshold": 2.0,
+      "configured_rounds": 5,
+      "auto_boost_rounds": 5,
+      "maximum_rounds": 25,
+      "target_rounds": 5,
+      "workload_count": 7,
+      "class_wall_deadline_seconds": 600.0,
+      "estimated_seconds_per_round": 8.12858650331851,
+      "deadline_round_limit": 10,
+      "auto_boost_applied": false,
+      "auto_boost_reason": "trailing_median_at_or_above_threshold",
+      "recorded_before_measurement": true
+    },
+    "decision_sha256": "sha256:da2bbe9efae1735a4427a1ccc8babdd6f128cff484e146b31dbb7da0bd91be82",
+    "actual_rounds": 25,
+    "actual_rounds_per_workload": {
+      "riscv_fib_iter": 3,
+      "riscv_gcd_euclid": 3,
+      "riscv_multi_shard_addi": 3,
+      "riscv_sha2_1024b": 3,
+      "riscv_sha2_2048b": 5,
+      "riscv_sha2_512b": 5,
+      "riscv_xorshift_prng": 3
+    },
+    "objective_wall_seconds": 158.7325030840002,
+    "measurement_wall_seconds": 159.92124116700143,
+    "measurement_wall_hours": 0.04442256699083373,
+    "gradient_snr": null,
+    "credited_ln_improvement": null,
+    "credited_ln_improvement_per_measurement_hour": null,
+    "credit_status": "pending_ledger_adjudication",
+    "decision_record": "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/search-health-decision.json"
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned correctness oracle verified 7/7 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "RISC-V mechanism telemetry present, canonical, and semantically stable for 7/7 workloads"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.4688 vs targeted budget x1.02; matrix row upper CIs 7/7 within budget x1.05; request ratios 7/7 present rows within budget x1.05; resource vectors 7/7 within named budgets"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "riscv_xorshift_prng": {
+        "r": 0.984864,
+        "ci": [
+          0.983366,
+          0.986986
+        ],
+        "rounds": 3,
+        "a_median_ms": 1112.253084,
+        "b_median_ms": 1093.751958,
+        "request_ratio": 0.984865,
+        "rss_ratio": 0.999728,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.997751,
+            "ci": [
+              0.99766,
+              0.997782
+            ],
+            "observations": 3,
+            "candidate": 39.852861869
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999728,
+            "ci": [
+              0.999543,
+              0.99984
+            ],
+            "observations": 3,
+            "candidate": 1265.142478942871
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 61123.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 61123,
+        "measurement_seconds": 14.464938,
+        "resources_complete": true
+      },
+      "riscv_fib_iter": {
+        "r": 0.991689,
+        "ci": [
+          0.989606,
+          0.99256
+        ],
+        "rounds": 3,
+        "a_median_ms": 1273.194417,
+        "b_median_ms": 1263.384417,
+        "request_ratio": 0.991112,
+        "rss_ratio": 1.000036,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.997598,
+            "ci": [
+              0.996391,
+              0.999971
+            ],
+            "observations": 3,
+            "candidate": 43.432730258
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000036,
+            "ci": [
+              0.99977,
+              1.000472
+            ],
+            "observations": 3,
+            "candidate": 1292.2518768310547
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 60003.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 60003,
+        "measurement_seconds": 16.563842,
+        "resources_complete": true
+      },
+      "riscv_gcd_euclid": {
+        "r": 0.991859,
+        "ci": [
+          0.989754,
+          0.993369
+        ],
+        "rounds": 3,
+        "a_median_ms": 1196.242875,
+        "b_median_ms": 1187.493125,
+        "request_ratio": 0.991489,
+        "rss_ratio": 1.00062,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.997796,
+            "ci": [
+              0.997133,
+              0.99968
+            ],
+            "observations": 3,
+            "candidate": 41.109316636
+          },
+          "peak_rss_mib": {
+            "ratio": 1.00062,
+            "ci": [
+              1.000464,
+              1.000746
+            ],
+            "observations": 3,
+            "candidate": 1279.4237060546875
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 62582.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 62582,
+        "measurement_seconds": 15.73031,
+        "resources_complete": true
+      },
+      "riscv_multi_shard_addi": {
+        "r": 0.988523,
+        "ci": [
+          0.986324,
+          0.990569
+        ],
+        "rounds": 3,
+        "a_median_ms": 1228.362458,
+        "b_median_ms": 1211.563,
+        "request_ratio": 0.987735,
+        "rss_ratio": 1.000045,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.99509,
+            "ci": [
+              0.992028,
+              0.999165
+            ],
+            "observations": 3,
+            "candidate": 42.096012569
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000045,
+            "ci": [
+              0.999903,
+              1.000424
+            ],
+            "observations": 3,
+            "candidate": 1290.0956726074219
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 58117.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 58117,
+        "measurement_seconds": 15.921555,
+        "resources_complete": true
+      },
+      "riscv_sha2_512b": {
+        "r": 0.983945,
+        "ci": [
+          0.977925,
+          0.990886
+        ],
+        "rounds": 5,
+        "a_median_ms": 1022.433833,
+        "b_median_ms": 1010.565959,
+        "request_ratio": 0.997871,
+        "rss_ratio": 0.999625,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.997806,
+            "ci": [
+              0.995767,
+              0.998796
+            ],
+            "observations": 5,
+            "candidate": 48.646441824
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999625,
+            "ci": [
+              0.999296,
+              1.000324
+            ],
+            "observations": 5,
+            "candidate": 1374.939697265625
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 78496.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 78496,
+        "measurement_seconds": 31.190845,
+        "resources_complete": true
+      },
+      "riscv_sha2_1024b": {
+        "r": 0.99634,
+        "ci": [
+          0.993588,
+          1.004276
+        ],
+        "rounds": 3,
+        "a_median_ms": 1289.459041,
+        "b_median_ms": 1281.191041,
+        "request_ratio": 0.994318,
+        "rss_ratio": 1.002052,
+        "resources": {
+          "energy_j": {
+            "ratio": 1.000904,
+            "ci": [
+              0.999683,
+              1.003096
+            ],
+            "observations": 3,
+            "candidate": 55.193010505
+          },
+          "peak_rss_mib": {
+            "ratio": 1.002052,
+            "ci": [
+              1.000295,
+              1.005921
+            ],
+            "observations": 3,
+            "candidate": 1429.4710388183594
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 76677.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 76677,
+        "measurement_seconds": 21.737958,
+        "resources_complete": true
+      },
+      "riscv_sha2_2048b": {
+        "r": 0.987797,
+        "ci": [
+          0.97669,
+          1.000836
+        ],
+        "rounds": 5,
+        "a_median_ms": 1510.304959,
+        "b_median_ms": 1479.272291,
+        "request_ratio": 0.996967,
+        "rss_ratio": 0.999334,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.999563,
+            "ci": [
+              0.99877,
+              1.000147
+            ],
+            "observations": 5,
+            "candidate": 61.746822159
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999334,
+            "ci": [
+              0.997353,
+              1.001829
+            ],
+            "observations": 5,
+            "candidate": 1499.596176147461
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 81115.0
+          }
+        },
+        "mechanism_verified": true,
+        "proof_bytes": 81115,
+        "measurement_seconds": 43.012404,
+        "resources_complete": true
+      }
+    },
+    "R_geomean": 0.98928,
+    "portfolio": {
+      "ci_method": "independent_workload_round_bootstrap_percentile_v1",
+      "ci_level": 0.95,
+      "bootstrap_iterations": 4000,
+      "seed": 4042241451,
+      "ci": [
+        0.987233,
+        0.991605
+      ],
+      "prove_ms_method": "geometric_mean_candidate_workload_medians_ms_v1",
+      "b_median_ms_geomean": 1210.46201,
+      "proof_bytes_method": "rounded_geometric_mean_candidate_proof_bytes_v1",
+      "proof_bytes": 67692,
+      "measurement_seconds": 158.621853,
+      "measurement_rounds": 25
+    },
+    "theta": 0.012888,
+    "aa_dispersion": 0.006444,
+    "significant": false,
+    "neutral": true,
+    "promotion_significance": {
+      "eligible": true,
+      "method": "independent_workload_round_bootstrap_percentile_v1",
+      "reason": "prove-time objective uses the deterministic workload portfolio CI"
+    },
+    "resource_portfolio": {
+      "peak_rss_mib": {
+        "ratio_geomean": 1.0002055186097434,
+        "upper_ci_geomean": 1.0013631295891143,
+        "candidate_geomean": 1344.7789238703817
+      },
+      "energy_j": {
+        "ratio_geomean": 0.9980711064306672,
+        "upper_ci_geomean": 0.9998042388156367,
+        "candidate_geomean": 46.86603730316038
+      },
+      "proof_bytes": {
+        "ratio_geomean": 1.0,
+        "upper_ci_geomean": 1.0,
+        "candidate_geomean": 67691.6135391908
+      }
+    }
+  },
+  "tiebreakers": {
+    "rss_ratio": 1.000206,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": 46.86603730316038,
+    "proof_bytes": 67691.6135391908
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "riscv_xorshift_prng",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "42995ce16ccf52573bd339bb6581370e51bf2a0d76093d90916f02fcba044899",
+      "proof_sha256": "c32a74186749f640a1b5b2a558768e9f6e60bcd58bc30595411e1722d5ead0e9"
+    },
+    {
+      "workload": "riscv_fib_iter",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "294bfdcbcd6e7396fdaefa041663abc7a7a63ae2a284561e33877524bdb1fa3f",
+      "proof_sha256": "100f0251e29fa5bbd58dfca387f52b776c0fa387ca0c2250a2f5534235bedc02"
+    },
+    {
+      "workload": "riscv_gcd_euclid",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "1ab334faadda1cb5d155a076e343e8288cf538290a6ca17f5121445e28a7a263",
+      "proof_sha256": "7cfa5df8529186cc005ad38e86f5aae1fc0cb150a2d4c899a42bebac5f46778b"
+    },
+    {
+      "workload": "riscv_multi_shard_addi",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "8522bd9d308c45e33cfdf47d2622eb1b46ee76f551ec944026fffb3d069d0dca",
+      "proof_sha256": "4bf8ab22c5ebb506421203abfb2905b06d3f9cc39cd42fcd3899f288f98775a4"
+    },
+    {
+      "workload": "riscv_sha2_512b",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "18f98b8511f830b29ff4b9cd5d484a19ed45e5fbee449cb4d815f88627eba44e",
+      "proof_sha256": "a5c7b4e54d0ba913b0ae1f58c77ea823826e0ba776a4a2673be2ab6dc3bcb74a"
+    },
+    {
+      "workload": "riscv_sha2_1024b",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "7ed1de59e9d6e2e615c818893b0ce764b680af8d87086098f8aaf79e1de3dd8a",
+      "proof_sha256": "63bbad02c8806622b99eba191ca9d1333ba77abd2f1486e2838525542d36cc50"
+    },
+    {
+      "workload": "riscv_sha2_2048b",
+      "verified": true,
+      "oracle": "pinned-stark-v-release-anchor",
+      "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+      "anchor_candidate": "4c4049bdf878de450f172403a3ddac37eef0dca2",
+      "anchor_receipt_sha256": "92a901106ff3f3236cf03e2d29469e9a6901ec50ce82a5dc2d473d85155a768a",
+      "artifact_sha256": "01cae1059dd28abfc89cefe201be4def7f77e12665026483838b4028d88031dc",
+      "proof_sha256": "adaa94716e7010c04814b2b574b3b7cb788f76f31f8258ad2a737bae68f1b851"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "pr6_supremacy",
+      "reason": "PR6 Supremacy remains disabled until every exact workload port, log22 oracle vector, both timing boundaries, locked-M5 statistical gate, and authenticated judged verdict are complete."
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "riscv_xorshift_prng": {
+        "round_ratios": [
+          0.984553,
+          0.983366,
+          0.986986
+        ],
+        "proof_digest": "c32a74186749f640a1b5b2a558768e9f6e60bcd58bc30595411e1722d5ead0e9",
+        "request_ratio": 0.984865,
+        "rss_ratio": 0.999728,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.997751,
+            "ci": [
+              0.99766,
+              0.997782
+            ],
+            "observations": 3,
+            "candidate": 39.852861869
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999728,
+            "ci": [
+              0.999543,
+              0.99984
+            ],
+            "observations": 3,
+            "candidate": 1265.142478942871
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 61123.0
+          }
+        },
+        "report_sha256s": [
+          "11e609cbfdebf045ffd10791cf3c3a33ad29cd7edb7815c86d03bebca889c292",
+          "2e9d6902e0b6794558a37d73adb32bf5b176e5be969c972f27f453bbcd14b73e",
+          "6337ff73ec152a5fef6dcbb8d0d9d5909a4cfe7bba013c2be6127cd7016513c8",
+          "4fed45ebe11852aa328c0e059dda7c6ed572acd79e79927dc89a27779175bace",
+          "9f7662071295e8b4e7bb4e428aa1d45d93c9ab9721bb4759db576b7bdac78c24",
+          "6d4db612902c4e33abf708e83cee1fb8720b108a777c9aeaa58ada6bfee52cb9"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_fib_iter": {
+        "round_ratios": [
+          0.99256,
+          0.992295,
+          0.989606
+        ],
+        "proof_digest": "100f0251e29fa5bbd58dfca387f52b776c0fa387ca0c2250a2f5534235bedc02",
+        "request_ratio": 0.991112,
+        "rss_ratio": 1.000036,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.997598,
+            "ci": [
+              0.996391,
+              0.999971
+            ],
+            "observations": 3,
+            "candidate": 43.432730258
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000036,
+            "ci": [
+              0.99977,
+              1.000472
+            ],
+            "observations": 3,
+            "candidate": 1292.2518768310547
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 60003.0
+          }
+        },
+        "report_sha256s": [
+          "a58ff684d53e271bda58f5afa3de4e2d9b8e1c3b8c17ae5cd80f0cb4ac302389",
+          "860b7a1cfa374697b6ace0784cf02d64d2a1082d42181917a48f57e1d22adf8f",
+          "5cf0c51d5cc40a020021490a5edf992b6e0549cbce02d641629a51a939a81d35",
+          "02ee3fc3d2c0e76a6808c6ff58cc58b8a5e3048f785df9e80a08111731d09c02",
+          "38c9953c689db1f6b34e2816a1138408a565fd3adec8635944e5827d49bcc7b1",
+          "979d4e531282ec240ad9428af2c3fac65517e99066aa48ce8a7865d4b224febc"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_gcd_euclid": {
+        "round_ratios": [
+          0.989754,
+          0.992156,
+          0.993369
+        ],
+        "proof_digest": "7cfa5df8529186cc005ad38e86f5aae1fc0cb150a2d4c899a42bebac5f46778b",
+        "request_ratio": 0.991489,
+        "rss_ratio": 1.00062,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.997796,
+            "ci": [
+              0.997133,
+              0.99968
+            ],
+            "observations": 3,
+            "candidate": 41.109316636
+          },
+          "peak_rss_mib": {
+            "ratio": 1.00062,
+            "ci": [
+              1.000464,
+              1.000746
+            ],
+            "observations": 3,
+            "candidate": 1279.4237060546875
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 62582.0
+          }
+        },
+        "report_sha256s": [
+          "737ca643bdb6bee9d1c2f1eeed9e69a811f6515d25d3891d18f642acd480dd4e",
+          "52edc5615e571c73599f7228b6909863bc09378b2f9606a48d6251e6a9f4fa36",
+          "bf3808593f5f0b19b5ea0e89c070ab6a09273a4aa6507ce0763ac48e0eb71cae",
+          "d7c285356d58d441059e1faa23772ea181cd6c0df7267001a887eae9cda7974a",
+          "5296cb5ca2d5df6839f8d52d819f081b5c827465c2c3f3d09762bfade48f438e",
+          "93278e2730ff1682ce831cdfc82c1b1dc665d43178d09079a2cc8fd2ecb07d9e"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_multi_shard_addi": {
+        "round_ratios": [
+          0.988599,
+          0.990569,
+          0.986324
+        ],
+        "proof_digest": "4bf8ab22c5ebb506421203abfb2905b06d3f9cc39cd42fcd3899f288f98775a4",
+        "request_ratio": 0.987735,
+        "rss_ratio": 1.000045,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.99509,
+            "ci": [
+              0.992028,
+              0.999165
+            ],
+            "observations": 3,
+            "candidate": 42.096012569
+          },
+          "peak_rss_mib": {
+            "ratio": 1.000045,
+            "ci": [
+              0.999903,
+              1.000424
+            ],
+            "observations": 3,
+            "candidate": 1290.0956726074219
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 58117.0
+          }
+        },
+        "report_sha256s": [
+          "ceb10adf2452c9d4b6325d981b260c32812f6d0fd7add57d2b564bfced504086",
+          "25762b097f1776f1072e583a9fa8ac9f89ba619dc44218e3bbe3e899d5b0c3d9",
+          "95219e52580684f5d57bb62724ae1efa84214302054ad62379b2f3dcd5d2cc48",
+          "9b90be7b26d2ca1eeb968960d2ff2181a0c907d91b0ebf681618a4ea1a979c36",
+          "e1da27273ea101f2956bb54f06d157be074d1dc7d8c7eba5eabc0d82a1d3acaa",
+          "eb07b64bfda60ee0c5478e7a36c23b09639635933a6ba3ceb5e1e11c64acc7fc"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_sha2_512b": {
+        "round_ratios": [
+          0.983945,
+          0.993379,
+          0.978952,
+          0.976897,
+          0.988393
+        ],
+        "proof_digest": "a5c7b4e54d0ba913b0ae1f58c77ea823826e0ba776a4a2673be2ab6dc3bcb74a",
+        "request_ratio": 0.997871,
+        "rss_ratio": 0.999625,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.997806,
+            "ci": [
+              0.995767,
+              0.998796
+            ],
+            "observations": 5,
+            "candidate": 48.646441824
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999625,
+            "ci": [
+              0.999296,
+              1.000324
+            ],
+            "observations": 5,
+            "candidate": 1374.939697265625
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 78496.0
+          }
+        },
+        "report_sha256s": [
+          "6fba41d7e4205a4b36ca7c4c0917f55fa8226dffc454d186cec7f3d4fdc2fcde",
+          "6ea9c5bb4109f90616800e43e05645ea5a0cff73c174d9237341881400575f94",
+          "878e3313615df25ec51753df806cea06868cdb7e91729a3e263e377a6344e2ad",
+          "41baf8c397aa928bdee6eba76309d086fcca2af5162b79fa8cca686d9b518bca",
+          "474fd0a5f0a9424bb3860886bd93ebd3da8a56be30d6689e13f6367d19dcd2ca",
+          "cf319dad95fdbeafcdcc5ad56351e3e495bc6beab41e8b0e8d4891d077700b05",
+          "9be1359e75ca88426a7a61d6fe32926e80c4814c7b11abcff2b537ab32b7b02b",
+          "7a5fcf1358504e2b318e086a56a6028df4d997f290a9aeda818b9c8542964646",
+          "a4d33ca67f892bbc04d6b2bc19dbca4e081c59bff567de9552ac3e67355b9991",
+          "1b4c59e5a8470ec6f708a35c2110165bd0a9919481541ffd0b338399f10e826f"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_sha2_1024b": {
+        "round_ratios": [
+          0.993748,
+          0.993588,
+          1.004276
+        ],
+        "proof_digest": "63bbad02c8806622b99eba191ca9d1333ba77abd2f1486e2838525542d36cc50",
+        "request_ratio": 0.994318,
+        "rss_ratio": 1.002052,
+        "resources": {
+          "energy_j": {
+            "ratio": 1.000904,
+            "ci": [
+              0.999683,
+              1.003096
+            ],
+            "observations": 3,
+            "candidate": 55.193010505
+          },
+          "peak_rss_mib": {
+            "ratio": 1.002052,
+            "ci": [
+              1.000295,
+              1.005921
+            ],
+            "observations": 3,
+            "candidate": 1429.4710388183594
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 76677.0
+          }
+        },
+        "report_sha256s": [
+          "8ded66ab441a8553196d782f109d564ccedf93dc952c5701d76310287804a378",
+          "0e338d5130819b5d0063a862259d4e94354945bf3e22a15b8757175262258cf8",
+          "04391b05a9dcccb9356933bd8f6a9f2c727ae6c7c97ba943fa2aa0558ae4670a",
+          "df8581629b4cedc76e49cc2192c6312a6fbf0967909a615572c8d8e03c82b040",
+          "c95b67f97a3ef2bd5f7c9561c6f30e43298abc7b3f2e0731a66e20f07d7e86c9",
+          "143c5c7007940e71703eba6de48c9fe89931d125e4b4363ec5c3751f8a86b71e"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      },
+      "riscv_sha2_2048b": {
+        "round_ratios": [
+          1.001575,
+          1.000098,
+          0.983593,
+          0.974019,
+          0.979361
+        ],
+        "proof_digest": "adaa94716e7010c04814b2b574b3b7cb788f76f31f8258ad2a737bae68f1b851",
+        "request_ratio": 0.996967,
+        "rss_ratio": 0.999334,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.999563,
+            "ci": [
+              0.99877,
+              1.000147
+            ],
+            "observations": 5,
+            "candidate": 61.746822159
+          },
+          "peak_rss_mib": {
+            "ratio": 0.999334,
+            "ci": [
+              0.997353,
+              1.001829
+            ],
+            "observations": 5,
+            "candidate": 1499.596176147461
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 81115.0
+          }
+        },
+        "report_sha256s": [
+          "83d1b9b539fe991a16479e95569804c51a5553352b2a62d0986b9fc87788a269",
+          "037c582fa13eaa8344bdd67fce50539b5c4a273af582459356c43994cdfe4aaa",
+          "90ed16ac1211ba80d54254f46aad6c3da1852445c189bb94095a9fd2b6e69b7b",
+          "28a2ecc8f3e58f6e0c8f9184acb575b7fd8a5d9d8dc7ffc6660faca7dc5d4b69",
+          "9b5d4195f8ee029a2c6ad23dcb91241c29955cc05d96f8a10979a9032f5d153c",
+          "28567d918e20c79926d3175b27c3479968d0702615aa597c6505fe77865cdcd8",
+          "7336cae37ab9404153e5cd26cca27233fe20850495a05667265fafd540dc380d",
+          "f37494c24bb848a8fae64d3eea87d91ebf7a7964ec2aaedc637d95d8146b1771",
+          "083ccf660a8b9fdbd29b71f322c0b843c1008706042416e494b6c8bd850f32a5",
+          "dea736c0468c041d144162a2b19dff57099f2c7a3386bd3853a84548ddd958ad"
+        ],
+        "mechanism_verified": true,
+        "resources_complete": true
+      }
+    },
+    "reports": [
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_xorshift_prng.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_xorshift_prng.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_xorshift_prng.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_xorshift_prng.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_xorshift_prng.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_xorshift_prng.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_fib_iter.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_fib_iter.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_fib_iter.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_fib_iter.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_fib_iter.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_fib_iter.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_gcd_euclid.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_gcd_euclid.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_gcd_euclid.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_gcd_euclid.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_gcd_euclid.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_gcd_euclid.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_multi_shard_addi.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_multi_shard_addi.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_multi_shard_addi.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_multi_shard_addi.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_multi_shard_addi.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_multi_shard_addi.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_512b.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_512b.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_512b.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_512b.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_512b.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_512b.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_512b.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_512b.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_512b.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_512b.b5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_1024b.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_1024b.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_1024b.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_1024b.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_1024b.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_1024b.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_2048b.a1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_2048b.b1.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_2048b.a2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_2048b.b2.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_2048b.a3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_2048b.b3.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_2048b.a4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_2048b.b4.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_2048b.a5.json",
+      "/Users/theodorepender/code/auto-researching/ws-riscv-system2x-epoch2/autoresearch/.runs/latest/riscv_sha2_2048b.b5.json"
+    ]
+  }
+}

--- a/src/core/crypto/blake2s_backend.zig
+++ b/src/core/crypto/blake2s_backend.zig
@@ -294,6 +294,39 @@ pub const Blake2sHasher = struct {
         return parallelStatesToDigests(&states);
     }
 
+    /// Finishes eight independent 128-byte messages that share their first
+    /// block. A 256-bit logical vector lets LLVM issue the two native AArch64
+    /// halves at each BLAKE dependency level instead of completing one
+    /// four-message compression before starting the next.
+    pub fn hashFinal64FromSeed8(
+        seed: Fixed64Seed,
+        data: *const [8][64]u8,
+    ) [8]Blake2sHash {
+        return hashFinal64FromSeed8WithMode(getDefaultBackendMode(), seed, data);
+    }
+
+    pub fn hashFinal64FromSeed8WithMode(
+        mode: BackendMode,
+        seed: Fixed64Seed,
+        data: *const [8][64]u8,
+    ) [8]Blake2sHash {
+        if (selectBackend(mode).effective == .scalar) {
+            var out: [8]Blake2sHash = undefined;
+            for (&out, data) |*digest, *block| {
+                digest.* = hashFinal64FromSeedWithMode(.scalar, seed, block);
+            }
+            return out;
+        }
+
+        var messages: [16]V8 = undefined;
+        loadParallelBlock8(data, &messages);
+
+        var states: [8]V8 = undefined;
+        for (0..8) |word_index| states[word_index] = @splat(seed[word_index]);
+        compressParallel8(&states, &messages, 128, 0, 0xFFFF_FFFF);
+        return parallel8StatesToDigests(&states);
+    }
+
     pub fn hashEqualFromSeed4(
         seed: Fixed64Seed,
         data: *const [4][]const u8,
@@ -596,6 +629,17 @@ fn loadParallelBlock4(data: *const [4][64]u8, out: *[16]V4) void {
     }
 }
 
+fn loadParallelBlock8(data: *const [8][64]u8, out: *[16]V8) void {
+    const halves: [2][4][64]u8 = @bitCast(data.*);
+    var low_words: [16]V4 = undefined;
+    var high_words: [16]V4 = undefined;
+    loadParallelBlock4(&halves[0], &low_words);
+    loadParallelBlock4(&halves[1], &high_words);
+    inline for (0..16) |word| {
+        out[word] = @bitCast([2]V4{ low_words[word], high_words[word] });
+    }
+}
+
 fn parallelStatesToDigests(states: *const [8]V4) [4]Blake2sHash {
     if (comptime builtin.cpu.arch.endian() == .little) {
         const low = transpose4x4(.{ states[0], states[1], states[2], states[3] });
@@ -612,6 +656,24 @@ fn parallelStatesToDigests(states: *const [8]V4) [4]Blake2sHash {
         }
         return out;
     }
+}
+
+fn parallel8StatesToDigests(states: *const [8]V8) [8]Blake2sHash {
+    var low: [8]V4 = undefined;
+    var high: [8]V4 = undefined;
+    inline for (0..8) |word| {
+        const halves: [2]V4 = @bitCast(states[word]);
+        low[word] = halves[0];
+        high[word] = halves[1];
+    }
+    const low_digests = parallelStatesToDigests(&low);
+    const high_digests = parallelStatesToDigests(&high);
+    var out: [8]Blake2sHash = undefined;
+    inline for (0..4) |lane| {
+        out[lane] = low_digests[lane];
+        out[lane + 4] = high_digests[lane];
+    }
+    return out;
 }
 
 fn stateToDigest(h: [8]u32) Blake2sHash {
@@ -679,6 +741,7 @@ fn compressScalar(h: *[8]u32, m: *const [16]u32, t0: u32, t1: u32, f0: u32) void
 }
 
 const V4 = @Vector(4, u32);
+const V8 = @Vector(8, u32);
 const Shift4 = @Vector(4, u5);
 const V16u8 = @Vector(16, u8);
 
@@ -718,6 +781,14 @@ fn rotr32x4(x: V4, comptime bits: u5) V4 {
     const r: Shift4 = @splat(bits);
     const l: Shift4 = @splat(left_bits);
     return (x >> r) | (x << l);
+}
+
+fn rotr32x8(x: V8, comptime bits: u5) V8 {
+    const halves: [2]V4 = @bitCast(x);
+    return @bitCast([2]V4{
+        rotr32x4(halves[0], bits),
+        rotr32x4(halves[1], bits),
+    });
 }
 
 fn gather4(values: *const [16]u32, idx: [4]u8) V4 {
@@ -830,6 +901,44 @@ fn compressParallel4(h: *[8]V4, m: *const [16]V4, t0: u32, t1: u32, f0: u32) voi
         parallel4.g4Interleaved(
             V4,
             rotr32x4,
+            &v,
+            .{ 0, 1, 2, 3 },
+            .{ 5, 6, 7, 4 },
+            .{ 10, 11, 8, 9 },
+            .{ 15, 12, 13, 14 },
+            .{ m[s[8]], m[s[10]], m[s[12]], m[s[14]] },
+            .{ m[s[9]], m[s[11]], m[s[13]], m[s[15]] },
+        );
+    }
+
+    for (0..8) |i| h[i] ^= v[i] ^ v[i + 8];
+}
+
+fn compressParallel8(h: *[8]V8, m: *const [16]V8, t0: u32, t1: u32, f0: u32) void {
+    var v: [16]V8 = undefined;
+    for (0..8) |i| {
+        v[i] = h[i];
+        v[i + 8] = @splat(BLAKE2S_IV[i]);
+    }
+    v[12] ^= @as(V8, @splat(t0));
+    v[13] ^= @as(V8, @splat(t1));
+    v[14] ^= @as(V8, @splat(f0));
+
+    inline for (BLAKE2S_SIGMA) |s| {
+        parallel4.g4Interleaved(
+            V8,
+            rotr32x8,
+            &v,
+            .{ 0, 1, 2, 3 },
+            .{ 4, 5, 6, 7 },
+            .{ 8, 9, 10, 11 },
+            .{ 12, 13, 14, 15 },
+            .{ m[s[0]], m[s[2]], m[s[4]], m[s[6]] },
+            .{ m[s[1]], m[s[3]], m[s[5]], m[s[7]] },
+        );
+        parallel4.g4Interleaved(
+            V8,
+            rotr32x8,
             &v,
             .{ 0, 1, 2, 3 },
             .{ 5, 6, 7, 4 },

--- a/src/core/crypto/tests/blake2s_backend.zig
+++ b/src/core/crypto/tests/blake2s_backend.zig
@@ -76,6 +76,21 @@ test "blake2s backend: four-way terminal compression matches scalar messages" {
     }
 }
 
+test "blake2s backend: eight-way terminal compression matches scalar messages" {
+    var prng = std.Random.DefaultPrng.init(0x3863_6f6d_7072_6573);
+    var prefix: [64]u8 = undefined;
+    var blocks: [8][64]u8 = undefined;
+    prng.random().bytes(prefix[0..]);
+    for (&blocks) |*block| prng.random().bytes(block[0..]);
+
+    const seed = Blake2sHasher.seedAfterFixed64(&prefix);
+    const batched = Blake2sHasher.hashFinal64FromSeed8(seed, &blocks);
+    for (blocks, 0..) |block, lane| {
+        const expected = Blake2sHasher.hashFinal64FromSeed(seed, &block);
+        try std.testing.expectEqualSlices(u8, expected[0..], batched[lane][0..]);
+    }
+}
+
 test "blake2s backend: four-way equal messages match seeded scalar stream" {
     var prng = std.Random.DefaultPrng.init(0x6c65_6166_345f_7369);
     var prefix: [64]u8 = undefined;

--- a/src/prover/vcs_lifted/blake2_stream4.zig
+++ b/src/prover/vcs_lifted/blake2_stream4.zig
@@ -12,6 +12,18 @@ pub fn supports(comptime H: type) bool {
     return H == CoreHasher;
 }
 
+pub fn hashChildren8(
+    seed: CoreHasher.NodeSeed,
+    children: *const [16]CoreHasher.Hash,
+) [8]CoreHasher.Hash {
+    var payloads: [8][64]u8 = undefined;
+    for (&payloads, 0..) |*payload, lane| {
+        @memcpy(payload[0..32], children[2 * lane][0..]);
+        @memcpy(payload[32..64], children[2 * lane + 1][0..]);
+    }
+    return BackendHasher.hashFinal64FromSeed8(seed, &payloads);
+}
+
 fn loadStates(hashers: *const [4]CoreHasher) [4]BackendHasher {
     var states: [4]BackendHasher = undefined;
     for (0..4) |lane| states[lane] = hashers[lane].inner.ctx;

--- a/src/prover/vcs_lifted/layers.zig
+++ b/src/prover/vcs_lifted/layers.zig
@@ -3,6 +3,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const work_pool_mod = @import("../work_pool.zig");
+const blake2_stream4 = @import("blake2_stream4.zig");
 const parameters = @import("parameters.zig");
 
 pub fn Operations(comptime H: type) type {
@@ -122,6 +123,13 @@ pub fn Operations(comptime H: type) type {
             if (comptime @hasDecl(H, "nodeSeed") and @hasDecl(H, "hashChildrenWithSeed")) {
                 const seed = H.nodeSeed();
                 var i_seeded: usize = 0;
+                if (comptime blake2_stream4.supports(H)) {
+                    while (i_seeded + 8 <= out.len) : (i_seeded += 8) {
+                        const children: *const [16]H.Hash = @ptrCast(&prev_layer[2 * i_seeded]);
+                        const hashes = blake2_stream4.hashChildren8(seed, children);
+                        inline for (0..8) |lane| out[i_seeded + lane] = hashes[lane];
+                    }
+                }
                 if (comptime @hasDecl(H, "hashChildrenWithSeed4")) {
                     while (i_seeded + 4 <= out.len) : (i_seeded += 4) {
                         const children: *const [8]H.Hash = @ptrCast(&prev_layer[2 * i_seeded]);
@@ -342,6 +350,13 @@ pub fn Operations(comptime H: type) type {
 
         fn hashSeededRange(ctx: *const SeededRangeCtx) void {
             var i = ctx.start;
+            if (comptime blake2_stream4.supports(H)) {
+                while (i + 8 <= ctx.end) : (i += 8) {
+                    const children: *const [16]H.Hash = @ptrCast(&ctx.prev_layer[2 * i]);
+                    const hashes = blake2_stream4.hashChildren8(ctx.seed, children);
+                    inline for (0..8) |lane| ctx.out[i + lane] = hashes[lane];
+                }
+            }
             if (comptime @hasDecl(H, "hashChildrenWithSeed4")) {
                 while (i + 4 <= ctx.end) : (i += 4) {
                     const children: *const [8]H.Hash = @ptrCast(&ctx.prev_layer[2 * i]);


### PR DESCRIPTION
Adds an exact eight-message terminal BLAKE2s path for lifted Merkle internal nodes while retaining V4 for residual and multi-block work. All deep RISC-V proofs are byte-identical and oracle-valid; all seven deep medians improve (portfolio ratio 0.9893), with complete notes and rejection transcript in the submission package. This is honestly classified as an architecture checkpoint because its incremental result is below the local 1.29% significance floor.