### PR TITLE
perf(riscv): reuse retained LDEs for previous-row masks

### DIFF
--- a/src/frontends/riscv/air/clock_update_component.zig
+++ b/src/frontends/riscv/air/clock_update_component.zig
@@ -12,9 +12,6 @@ const canonic = @import("stwo_core").poly.circle.canonic;
 const utils = @import("stwo_core").utils;
 const prover_air_accumulation = @import("stwo_prover_impl").air.accumulation;
 const prover_component = @import("stwo_prover_impl").air.component_prover;
-const prover_eval = @import("stwo_prover_impl").poly.circle.evaluation;
-const prover_poly = @import("stwo_prover_impl").poly.circle.poly;
-const prover_twiddles = @import("stwo_prover_impl").poly.twiddles;
 const interaction = @import("clock_update_interaction.zig");
 const logup = @import("logup.zig");
 const relations_mod = @import("relation_challenges.zig");
@@ -245,7 +242,7 @@ pub const ClockUpdateComponent = struct {
         const eval_domain = canonic.CanonicCoset.new(eval_log_size).circleDomain();
         const eval_size = eval_domain.size();
         const n_committed = 2 + interaction.N_MAIN_COLUMNS + interaction.N_INTERACTION_COLUMNS;
-        const n_sources = n_committed + interaction.N_INTERACTION_COLUMNS;
+        const n_sources = n_committed;
         const evaluations = try allocator.alloc([]const M31, n_sources);
         defer allocator.free(evaluations);
         var source: usize = 0;
@@ -262,34 +259,7 @@ pub const ClockUpdateComponent = struct {
             source += 1;
         }
 
-        var extension_buffers = std.ArrayList([]M31).empty;
-        defer {
-            for (extension_buffers.items) |values| allocator.free(values);
-            extension_buffers.deinit(allocator);
-        }
-        try appendPrevious(
-            allocator,
-            self.previous,
-            self.log_size,
-            eval_size,
-            evaluations,
-            &source,
-            &extension_buffers,
-        );
         std.debug.assert(source == n_sources);
-        if (extension_buffers.items.len != 0) {
-            var twiddles = try prover_twiddles.precomputeM31(allocator, eval_domain.half_coset);
-            defer prover_twiddles.deinitM31(allocator, &twiddles);
-            try prover_poly.evaluateBuffersWithTwiddles(
-                extension_buffers.items,
-                eval_domain,
-                prover_twiddles.TwiddleTree([]const M31).init(
-                    twiddles.root_coset,
-                    twiddles.twiddles,
-                    twiddles.itwiddles,
-                ),
-            );
-        }
 
         const denominator_inv = try quotientDenominators(
             allocator,
@@ -306,9 +276,13 @@ pub const ClockUpdateComponent = struct {
         const column_accumulator = &accumulators[0];
         const main_start: usize = 2;
         const secure_start = main_start + interaction.N_MAIN_COLUMNS;
-        const previous_start = secure_start + interaction.N_INTERACTION_COLUMNS;
         const denominator_shift: std.math.Log2Int(usize) = @intCast(self.log_size);
         for (0..eval_size) |row| {
+            const previous_row = utils.previousBitReversedCircleDomainIndex(
+                row,
+                self.log_size,
+                eval_log_size,
+            );
             var sampled: [interaction.N_MAIN_COLUMNS]QM31 = undefined;
             for (&sampled, evaluations[main_start..][0..interaction.N_MAIN_COLUMNS]) |*value, column| {
                 value.* = QM31.fromBase(column[row]);
@@ -316,7 +290,10 @@ pub const ClockUpdateComponent = struct {
             const evaluation = try self.evaluateRow(
                 &sampled,
                 secureAt(evaluations[secure_start..][0..interaction.N_INTERACTION_COLUMNS], row),
-                secureAt(evaluations[previous_start..][0..interaction.N_INTERACTION_COLUMNS], row),
+                secureAt(
+                    evaluations[secure_start..][0..interaction.N_INTERACTION_COLUMNS],
+                    previous_row,
+                ),
                 QM31.fromBase(evaluations[0][row]),
                 QM31.fromBase(evaluations[1][row]),
             );
@@ -372,42 +349,6 @@ fn sampledSecure(columns: [][]QM31, offset: usize, point: usize) !QM31 {
 
 fn secureAt(columns: []const []const M31, row: usize) QM31 {
     return QM31.fromM31(columns[0][row], columns[1][row], columns[2][row], columns[3][row]);
-}
-
-fn appendPrevious(
-    allocator: std.mem.Allocator,
-    previous: [interaction.N_INTERACTION_COLUMNS][]const M31,
-    log_size: u32,
-    eval_size: usize,
-    evaluations: [][]const M31,
-    source: *usize,
-    buffers: *std.ArrayList([]M31),
-) !void {
-    const domain = canonic.CanonicCoset.new(log_size).circleDomain();
-    var twiddles = try prover_twiddles.precomputeM31(allocator, domain.half_coset);
-    defer prover_twiddles.deinitM31(allocator, &twiddles);
-    const view = prover_twiddles.TwiddleTree([]const M31).init(
-        twiddles.root_coset,
-        twiddles.twiddles,
-        twiddles.itwiddles,
-    );
-    for (previous) |values| {
-        if (values.len != domain.size()) return error.InvalidProofShape;
-        const evaluation = try prover_eval.CircleEvaluation.init(domain, values);
-        var coefficients = try prover_poly.interpolateFromEvaluationWithTwiddles(
-            allocator,
-            evaluation,
-            view,
-        );
-        defer coefficients.deinit(allocator);
-        const extended = try allocator.alloc(M31, eval_size);
-        errdefer allocator.free(extended);
-        @memcpy(extended[0..coefficients.coefficients().len], coefficients.coefficients());
-        @memset(extended[coefficients.coefficients().len..], M31.zero());
-        try buffers.append(allocator, extended);
-        evaluations[source.*] = extended;
-        source.* += 1;
-    }
 }
 
 fn quotientDenominators(

--- a/src/frontends/riscv/air/component.zig
+++ b/src/frontends/riscv/air/component.zig
@@ -25,9 +25,6 @@ const canonic = @import("stwo_core").poly.circle.canonic;
 const utils = @import("stwo_core").utils;
 const prover_air_accumulation = @import("stwo_prover_impl").air.accumulation;
 const prover_component = @import("stwo_prover_impl").air.component_prover;
-const prover_eval = @import("stwo_prover_impl").poly.circle.evaluation;
-const prover_poly = @import("stwo_prover_impl").poly.circle.poly;
-const prover_twiddles = @import("stwo_prover_impl").poly.twiddles;
 const interaction_gen = @import("interaction_gen.zig");
 const logup = @import("logup.zig");
 const memory_interaction = @import("memory_commitment/interaction.zig");
@@ -413,30 +410,12 @@ pub const RiscVTraceComponent = struct {
             semantic_eval.isTraceCompatible(self.desc.family);
         const opcode_main_sources: usize = if (self.kind == .opcode) self.desc.n_columns else 0;
         const n_sources: usize = switch (self.kind) {
-            .opcode => 2 + opcode_main_sources + n_inter + 8 + opcode_memory.N_COLUMNS,
-            .program => 2 + program_commitment.N_MAIN_COLUMNS + n_inter +
-                program_interaction.N_COLUMNS,
-            .memory => 2 + 8 + n_inter + memory_interaction.N_COLUMNS,
+            .opcode => 2 + opcode_main_sources + n_inter,
+            .program => 2 + program_commitment.N_MAIN_COLUMNS + n_inter,
+            .memory => 2 + 8 + n_inter,
         };
         const evaluations = try allocator.alloc([]const M31, n_sources);
         defer allocator.free(evaluations);
-
-        var extension_buffers = std.ArrayList([]M31).empty;
-        defer {
-            for (extension_buffers.items) |values| allocator.free(values);
-            extension_buffers.deinit(allocator);
-        }
-
-        var trace_twiddles = try prover_twiddles.precomputeM31(
-            allocator,
-            canonic.CanonicCoset.new(log_size).circleDomain().half_coset,
-        );
-        defer prover_twiddles.deinitM31(allocator, &trace_twiddles);
-        const trace_twiddle_view = prover_twiddles.TwiddleTree([]const M31).init(
-            trace_twiddles.root_coset,
-            trace_twiddles.twiddles,
-            trace_twiddles.itwiddles,
-        );
 
         var source_index: usize = 0;
         // Committed polynomials: deterministic selectors, relation inputs
@@ -477,57 +456,7 @@ pub const RiscVTraceComponent = struct {
                 source_index += 1;
             }
         }
-        // Uncommitted shifted S columns: interpolate committed-order values on
-        // the trace domain, then extend exactly like the committed columns.
-        {
-            const prev_sets: []const [4][]const M31 = switch (self.kind) {
-                .opcode => &.{
-                    self.s_state_prev,
-                    self.s_prog_prev,
-                    self.s_opcode_memory_prev[0],
-                    self.s_opcode_memory_prev[1],
-                    self.s_opcode_memory_prev[2],
-                },
-                .program => &self.s_program_prev,
-                .memory => &self.s_memory_prev,
-            };
-            const trace_domain = canonic.CanonicCoset.new(log_size).circleDomain();
-            for (prev_sets) |prev_set| {
-                for (prev_set) |values| {
-                    if (values.len != trace_domain.size()) return error.InvalidProofShape;
-                    const evaluation = try prover_eval.CircleEvaluation.init(trace_domain, values);
-                    var coeffs = try prover_poly.interpolateFromEvaluationWithTwiddles(
-                        allocator,
-                        evaluation,
-                        trace_twiddle_view,
-                    );
-                    defer coeffs.deinit(allocator);
-                    evaluations[source_index] = try appendExtensionBuffer(
-                        allocator,
-                        &extension_buffers,
-                        coeffs.coefficients(),
-                        eval_size,
-                    );
-                    source_index += 1;
-                }
-            }
-        }
         std.debug.assert(source_index == n_sources);
-
-        if (extension_buffers.items.len != 0) {
-            var eval_twiddles = try prover_twiddles.precomputeM31(allocator, eval_domain.half_coset);
-            defer prover_twiddles.deinitM31(allocator, &eval_twiddles);
-            const twiddle_view = prover_twiddles.TwiddleTree([]const M31).init(
-                eval_twiddles.root_coset,
-                eval_twiddles.twiddles,
-                eval_twiddles.itwiddles,
-            );
-            try prover_poly.evaluateBuffersWithTwiddles(
-                extension_buffers.items,
-                eval_domain,
-                twiddle_view,
-            );
-        }
 
         // The trace-coset vanishing polynomial is block-constant over the
         // extended domain in committed order: block b (of 2^log_size rows)
@@ -559,6 +488,11 @@ pub const RiscVTraceComponent = struct {
 
         const denominator_shift: std.math.Log2Int(usize) = @intCast(log_size);
         for (0..eval_size) |row| {
+            const previous_row = utils.previousBitReversedCircleDomainIndex(
+                row,
+                log_size,
+                eval_log_size,
+            );
             const is_first = QM31.fromBase(evaluations[0][row]);
             const is_active = QM31.fromBase(evaluations[1][row]);
             var row_evaluation: QM31 = undefined;
@@ -566,7 +500,6 @@ pub const RiscVTraceComponent = struct {
                 .opcode => {
                     const main_start: usize = 2;
                     const inter_start = main_start + opcode_main_sources;
-                    const prev_start = inter_start + n_inter;
                     const clk = QM31.fromBase(
                         evaluations[main_start + semantic_eval.clockColumn(self.desc.family)][row],
                     );
@@ -581,8 +514,14 @@ pub const RiscVTraceComponent = struct {
                     const value_3 = QM31.fromBase(evaluations[bus + 4][row]);
                     const s_state = secureAt(evaluations[inter_start .. inter_start + 4], row);
                     const s_prog = secureAt(evaluations[inter_start + 4 .. inter_start + 8], row);
-                    const s_state_prev = secureAt(evaluations[prev_start .. prev_start + 4], row);
-                    const s_prog_prev = secureAt(evaluations[prev_start + 4 .. prev_start + 8], row);
+                    const s_state_prev = secureAt(
+                        evaluations[inter_start .. inter_start + 4],
+                        previous_row,
+                    );
+                    const s_prog_prev = secureAt(
+                        evaluations[inter_start + 4 .. inter_start + 8],
+                        previous_row,
+                    );
 
                     const c_state = logup.pairConstraint(
                         s_state,
@@ -618,9 +557,11 @@ pub const RiscVTraceComponent = struct {
                     var memory_previous: [opcode_memory.N_ACCESSES]QM31 = undefined;
                     for (0..opcode_memory.N_ACCESSES) |slot| {
                         const memory_offset = inter_start + 8 + slot * 4;
-                        const previous_offset = prev_start + 8 + slot * 4;
                         memory_sums[slot] = secureAt(evaluations[memory_offset..][0..4], row);
-                        memory_previous[slot] = secureAt(evaluations[previous_offset..][0..4], row);
+                        memory_previous[slot] = secureAt(
+                            evaluations[memory_offset..][0..4],
+                            previous_row,
+                        );
                     }
                     const memory_constraints = try opcode_memory.constraints(
                         self.desc.family,
@@ -653,7 +594,6 @@ pub const RiscVTraceComponent = struct {
                 .program => {
                     const main_start: usize = 2;
                     const inter_start = main_start + program_commitment.N_MAIN_COLUMNS;
-                    const prev_start = inter_start + program_interaction.N_COLUMNS;
                     var sampled: [program_commitment.N_MAIN_COLUMNS]QM31 = undefined;
                     for (&sampled, 0..) |*value, column| {
                         value.* = QM31.fromBase(evaluations[main_start + column][row]);
@@ -662,7 +602,10 @@ pub const RiscVTraceComponent = struct {
                     var previous: [program_interaction.N_SUMS]QM31 = undefined;
                     for (0..program_interaction.N_SUMS) |index| {
                         sums[index] = secureAt(evaluations[inter_start + index * 4 ..][0..4], row);
-                        previous[index] = secureAt(evaluations[prev_start + index * 4 ..][0..4], row);
+                        previous[index] = secureAt(
+                            evaluations[inter_start + index * 4 ..][0..4],
+                            previous_row,
+                        );
                     }
                     const constraints = program_interaction.evaluate(
                         sampled,
@@ -684,7 +627,6 @@ pub const RiscVTraceComponent = struct {
                 .memory => {
                     const main_start: usize = 2;
                     const inter_start = main_start + 8;
-                    const prev_start = inter_start + memory_interaction.N_COLUMNS;
                     var sampled: [8]QM31 = undefined;
                     for (&sampled, 0..) |*value, column| {
                         value.* = QM31.fromBase(evaluations[main_start + column][row]);
@@ -693,7 +635,10 @@ pub const RiscVTraceComponent = struct {
                     var previous: [memory_interaction.N_SUMS]QM31 = undefined;
                     for (0..memory_interaction.N_SUMS) |index| {
                         sums[index] = secureAt(evaluations[inter_start + index * 4 ..][0..4], row);
-                        previous[index] = secureAt(evaluations[prev_start + index * 4 ..][0..4], row);
+                        previous[index] = secureAt(
+                            evaluations[inter_start + index * 4 ..][0..4],
+                            previous_row,
+                        );
                     }
                     const constraints = memory_interaction.evaluate(
                         sampled,
@@ -723,21 +668,6 @@ pub const RiscVTraceComponent = struct {
 
 fn secureAt(coords: []const []const M31, row: usize) QM31 {
     return QM31.fromM31(coords[0][row], coords[1][row], coords[2][row], coords[3][row]);
-}
-
-/// Zero-extend circle-FFT coefficients into an owned eval-domain buffer.
-fn appendExtensionBuffer(
-    allocator: std.mem.Allocator,
-    extension_buffers: *std.ArrayList([]M31),
-    coefficient_values: []const M31,
-    eval_size: usize,
-) ![]const M31 {
-    const values = try allocator.alloc(M31, eval_size);
-    errdefer allocator.free(values);
-    @memcpy(values[0..coefficient_values.len], coefficient_values);
-    @memset(values[coefficient_values.len..], M31.zero());
-    try extension_buffers.append(allocator, values);
-    return values;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/frontends/riscv/air/lookups/opcode_component.zig
+++ b/src/frontends/riscv/air/lookups/opcode_component.zig
@@ -19,9 +19,6 @@ const canonic = @import("stwo_core").poly.circle.canonic;
 const utils = @import("stwo_core").utils;
 const prover_air_accumulation = @import("stwo_prover_impl").air.accumulation;
 const prover_component = @import("stwo_prover_impl").air.component_prover;
-const prover_eval = @import("stwo_prover_impl").poly.circle.evaluation;
-const prover_poly = @import("stwo_prover_impl").poly.circle.poly;
-const prover_twiddles = @import("stwo_prover_impl").poly.twiddles;
 const infra = @import("../../infra_trace.zig");
 const logup = @import("../logup.zig");
 const relations_mod = @import("../relation_challenges.zig");
@@ -279,7 +276,7 @@ pub const OpcodeLookupComponent = struct {
             secure.len < self.interaction_col_offset + n_interaction)
             return error.InvalidProofShape;
 
-        const n_sources = 1 + n_main + 2 * n_interaction;
+        const n_sources = 1 + n_main + n_interaction;
         const evaluations = try allocator.alloc([]const M31, n_sources);
         defer allocator.free(evaluations);
         var source: usize = 0;
@@ -294,45 +291,7 @@ pub const OpcodeLookupComponent = struct {
             source += 1;
         }
 
-        var extension_buffers = std.ArrayList([]M31).empty;
-        defer {
-            for (extension_buffers.items) |values| allocator.free(values);
-            extension_buffers.deinit(allocator);
-        }
-        var trace_twiddles = try prover_twiddles.precomputeM31(
-            allocator,
-            canonic.CanonicCoset.new(self.log_size).circleDomain().half_coset,
-        );
-        defer prover_twiddles.deinitM31(allocator, &trace_twiddles);
-        const trace_twiddle_view = prover_twiddles.TwiddleTree([]const M31).init(
-            trace_twiddles.root_coset,
-            trace_twiddles.twiddles,
-            trace_twiddles.itwiddles,
-        );
-        try appendPrevious(
-            allocator,
-            self.previous[0..self.nConstraints()],
-            self.log_size,
-            eval_size,
-            trace_twiddle_view,
-            evaluations,
-            &source,
-            &extension_buffers,
-        );
         std.debug.assert(source == n_sources);
-
-        var eval_twiddles = try prover_twiddles.precomputeM31(allocator, eval_domain.half_coset);
-        defer prover_twiddles.deinitM31(allocator, &eval_twiddles);
-        const eval_twiddle_view = prover_twiddles.TwiddleTree([]const M31).init(
-            eval_twiddles.root_coset,
-            eval_twiddles.twiddles,
-            eval_twiddles.itwiddles,
-        );
-        try prover_poly.evaluateBuffersWithTwiddles(
-            extension_buffers.items,
-            eval_domain,
-            eval_twiddle_view,
-        );
 
         const denominator_inv = try quotientDenominators(
             allocator,
@@ -349,8 +308,12 @@ pub const OpcodeLookupComponent = struct {
         const column_accumulator = &accumulators[0];
         const main_start: usize = 1;
         const interaction_start = main_start + n_main;
-        const previous_start = interaction_start + n_interaction;
         for (0..eval_size) |row| {
+            const previous_row = utils.previousBitReversedCircleDomainIndex(
+                row,
+                self.log_size,
+                eval_log_size,
+            );
             var sampled: [trace.MAX_FAMILY_COLUMNS]QM31 = undefined;
             for (sampled[0..n_main], evaluations[main_start..][0..n_main]) |*value, column| {
                 value.* = QM31.fromBase(column[row]);
@@ -359,7 +322,10 @@ pub const OpcodeLookupComponent = struct {
             var previous = [_]QM31{QM31.zero()} ** entry.MAX_BATCHES;
             for (0..self.nConstraints()) |batch| {
                 current[batch] = secureAt(evaluations[interaction_start + 4 * batch ..][0..4], row);
-                previous[batch] = secureAt(evaluations[previous_start + 4 * batch ..][0..4], row);
+                previous[batch] = secureAt(
+                    evaluations[interaction_start + 4 * batch ..][0..4],
+                    previous_row,
+                );
             }
             const evaluation = try self.evaluateRow(
                 sampled[0..n_main],
@@ -424,38 +390,6 @@ fn sampledSecure(columns: [][]QM31, offset: usize, point: usize) !QM31 {
 
 fn secureAt(columns: []const []const M31, row: usize) QM31 {
     return QM31.fromM31(columns[0][row], columns[1][row], columns[2][row], columns[3][row]);
-}
-
-fn appendPrevious(
-    allocator: std.mem.Allocator,
-    previous: []const [4][]const M31,
-    log_size: u32,
-    eval_size: usize,
-    twiddles: anytype,
-    evaluations: [][]const M31,
-    source: *usize,
-    buffers: *std.ArrayList([]M31),
-) !void {
-    const domain = canonic.CanonicCoset.new(log_size).circleDomain();
-    for (previous) |set| {
-        for (set) |values| {
-            if (values.len != domain.size()) return error.InvalidProofShape;
-            const evaluation = try prover_eval.CircleEvaluation.init(domain, values);
-            var coefficients = try prover_poly.interpolateFromEvaluationWithTwiddles(
-                allocator,
-                evaluation,
-                twiddles,
-            );
-            defer coefficients.deinit(allocator);
-            const extended = try allocator.alloc(M31, eval_size);
-            errdefer allocator.free(extended);
-            @memcpy(extended[0..coefficients.coefficients().len], coefficients.coefficients());
-            @memset(extended[coefficients.coefficients().len..], M31.zero());
-            try buffers.append(allocator, extended);
-            evaluations[source.*] = extended;
-            source.* += 1;
-        }
-    }
 }
 
 fn quotientDenominators(

--- a/src/frontends/riscv/air/lookups/tables/component.zig
+++ b/src/frontends/riscv/air/lookups/tables/component.zig
@@ -9,11 +9,9 @@ const circle = @import("stwo_core").circle;
 const M31 = @import("stwo_core").fields.m31.M31;
 const QM31 = @import("stwo_core").fields.qm31.QM31;
 const canonic = @import("stwo_core").poly.circle.canonic;
+const utils = @import("stwo_core").utils;
 const prover_air_accumulation = @import("stwo_prover_impl").air.accumulation;
 const prover_component = @import("stwo_prover_impl").air.component_prover;
-const prover_eval = @import("stwo_prover_impl").poly.circle.evaluation;
-const prover_poly = @import("stwo_prover_impl").poly.circle.poly;
-const prover_twiddles = @import("stwo_prover_impl").poly.twiddles;
 const logup = @import("../../logup.zig");
 const relations_mod = @import("../../relation_challenges.zig");
 const interaction = @import("interaction.zig");
@@ -286,7 +284,7 @@ pub const LookupTableComponent = struct {
         const eval_size = eval_domain.size();
         const n_tuple = schema.arity(self.kind);
         const n_committed = 1 + n_tuple + 1 + interaction.N_COLUMNS;
-        const n_sources = n_committed + interaction.N_COLUMNS;
+        const n_sources = n_committed;
         const preprocessed = trace.polys.items[0];
         const main = trace.polys.items[1];
         const secure = trace.polys.items[2];
@@ -323,45 +321,7 @@ pub const LookupTableComponent = struct {
             source += 1;
         }
 
-        var extension_buffers = std.ArrayList([]M31).empty;
-        defer {
-            for (extension_buffers.items) |values| allocator.free(values);
-            extension_buffers.deinit(allocator);
-        }
-        var trace_twiddles = try prover_twiddles.precomputeM31(
-            allocator,
-            canonic.CanonicCoset.new(log_size).circleDomain().half_coset,
-        );
-        defer prover_twiddles.deinitM31(allocator, &trace_twiddles);
-        const trace_twiddle_view = prover_twiddles.TwiddleTree([]const M31).init(
-            trace_twiddles.root_coset,
-            trace_twiddles.twiddles,
-            trace_twiddles.itwiddles,
-        );
-        try appendPrevious(
-            allocator,
-            self.previous,
-            log_size,
-            eval_size,
-            trace_twiddle_view,
-            evaluations,
-            &source,
-            &extension_buffers,
-        );
         std.debug.assert(source == n_sources);
-
-        var eval_twiddles = try prover_twiddles.precomputeM31(allocator, eval_domain.half_coset);
-        defer prover_twiddles.deinitM31(allocator, &eval_twiddles);
-        const eval_twiddle_view = prover_twiddles.TwiddleTree([]const M31).init(
-            eval_twiddles.root_coset,
-            eval_twiddles.twiddles,
-            eval_twiddles.itwiddles,
-        );
-        try prover_poly.evaluateBuffersWithTwiddles(
-            extension_buffers.items,
-            eval_domain,
-            eval_twiddle_view,
-        );
 
         const trace_coset = canonic.CanonicCoset.new(log_size).coset();
         var denominator_inv: [2]M31 = undefined;
@@ -381,8 +341,12 @@ pub const LookupTableComponent = struct {
         const tuple_start: usize = 1;
         const main_index = tuple_start + n_tuple;
         const interaction_start = main_index + 1;
-        const previous_start = interaction_start + interaction.N_COLUMNS;
         for (0..eval_size) |row| {
+            const previous_row = utils.previousBitReversedCircleDomainIndex(
+                row,
+                log_size,
+                eval_log_size,
+            );
             var tuple: [schema.MAX_ARITY]QM31 = undefined;
             for (tuple[0..n_tuple], evaluations[tuple_start..][0..n_tuple]) |*value, column| {
                 value.* = QM31.fromBase(column[row]);
@@ -391,7 +355,10 @@ pub const LookupTableComponent = struct {
                 tuple[0..n_tuple],
                 QM31.fromBase(evaluations[main_index][row]),
                 secureAt(evaluations[interaction_start..][0..interaction.N_COLUMNS], row),
-                secureAt(evaluations[previous_start..][0..interaction.N_COLUMNS], row),
+                secureAt(
+                    evaluations[interaction_start..][0..interaction.N_COLUMNS],
+                    previous_row,
+                ),
                 QM31.fromBase(evaluations[0][row]),
             );
             column_accumulator.accumulate(
@@ -455,36 +422,6 @@ fn sampledSecure(columns: [][]QM31, offset: usize, point: usize) !QM31 {
         value.* = columns[offset + index][point];
     }
     return QM31.fromPartialEvals(coordinates);
-}
-
-fn appendPrevious(
-    allocator: std.mem.Allocator,
-    previous: [interaction.N_COLUMNS][]const M31,
-    log_size: u32,
-    eval_size: usize,
-    twiddles: anytype,
-    evaluations: [][]const M31,
-    source: *usize,
-    buffers: *std.ArrayList([]M31),
-) !void {
-    const domain = canonic.CanonicCoset.new(log_size).circleDomain();
-    for (previous) |values| {
-        if (values.len != domain.size()) return error.InvalidProofShape;
-        const evaluation = try prover_eval.CircleEvaluation.init(domain, values);
-        var coefficients = try prover_poly.interpolateFromEvaluationWithTwiddles(
-            allocator,
-            evaluation,
-            twiddles,
-        );
-        defer coefficients.deinit(allocator);
-        const extended = try allocator.alloc(M31, eval_size);
-        errdefer allocator.free(extended);
-        @memcpy(extended[0..coefficients.coefficients().len], coefficients.coefficients());
-        @memset(extended[coefficients.coefficients().len..], M31.zero());
-        try buffers.append(allocator, extended);
-        evaluations[source.*] = extended;
-        source.* += 1;
-    }
 }
 
 fn secureAt(columns: []const []const M31, row: usize) QM31 {

--- a/src/frontends/riscv/air/memory_commitment/hash_component.zig
+++ b/src/frontends/riscv/air/memory_commitment/hash_component.zig
@@ -12,7 +12,6 @@ const canonic = @import("stwo_core").poly.circle.canonic;
 const utils = @import("stwo_core").utils;
 const prover_air_accumulation = @import("stwo_prover_impl").air.accumulation;
 const prover_component = @import("stwo_prover_impl").air.component_prover;
-const prover_eval = @import("stwo_prover_impl").poly.circle.evaluation;
 const prover_poly = @import("stwo_prover_impl").poly.circle.poly;
 const prover_twiddles = @import("stwo_prover_impl").poly.twiddles;
 const logup = @import("../logup.zig");
@@ -219,9 +218,8 @@ pub const HashComponent = struct {
         const eval_size = eval_domain.size();
         const n_main = nMainColumns(self.kind);
         const n_interaction = nInteractionColumns(self.kind);
-        const n_previous = n_interaction;
         const n_committed = 2 + n_main + n_interaction;
-        const n_sources = n_committed + n_previous;
+        const n_sources = n_committed;
         const preprocessed = trace.polys.items[0];
         const main_polys = trace.polys.items[1];
         const interaction_polys = trace.polys.items[2];
@@ -263,40 +261,6 @@ pub const HashComponent = struct {
             }
             source += 1;
         }
-        var trace_twiddles = try prover_twiddles.precomputeM31(
-            allocator,
-            canonic.CanonicCoset.new(self.log_size).circleDomain().half_coset,
-        );
-        defer prover_twiddles.deinitM31(allocator, &trace_twiddles);
-        const trace_twiddle_view = prover_twiddles.TwiddleTree([]const M31).init(
-            trace_twiddles.root_coset,
-            trace_twiddles.twiddles,
-            trace_twiddles.itwiddles,
-        );
-        switch (self.kind) {
-            .merkle => try appendPrevious(
-                merkle_node.N_SUMS,
-                allocator,
-                self.s_merkle_prev,
-                self.log_size,
-                eval_size,
-                trace_twiddle_view,
-                evaluations,
-                &source,
-                &extension_buffers,
-            ),
-            .poseidon2 => try appendPrevious(
-                poseidon2_air.N_SUMS,
-                allocator,
-                self.s_poseidon_prev,
-                self.log_size,
-                eval_size,
-                trace_twiddle_view,
-                evaluations,
-                &source,
-                &extension_buffers,
-            ),
-        }
         std.debug.assert(source == n_sources);
         var eval_twiddles = try prover_twiddles.precomputeM31(allocator, eval_domain.half_coset);
         defer prover_twiddles.deinitM31(allocator, &eval_twiddles);
@@ -330,8 +294,12 @@ pub const HashComponent = struct {
         const column_accumulator = &accumulators[0];
         const main_start: usize = 2;
         const interaction_start = main_start + n_main;
-        const previous_start = interaction_start + n_interaction;
         for (0..eval_size) |row| {
+            const previous_row = utils.previousBitReversedCircleDomainIndex(
+                row,
+                self.log_size,
+                eval_log_size,
+            );
             const is_first = QM31.fromBase(evaluations[0][row]);
             const is_active = QM31.fromBase(evaluations[1][row]);
             var row_evaluation = QM31.zero();
@@ -348,8 +316,8 @@ pub const HashComponent = struct {
                         merkle_node.N_SUMS,
                         evaluations,
                         interaction_start,
-                        previous_start,
                         row,
+                        previous_row,
                         &sums,
                         &previous,
                     );
@@ -376,8 +344,8 @@ pub const HashComponent = struct {
                         poseidon2_air.N_SUMS,
                         evaluations,
                         interaction_start,
-                        previous_start,
                         row,
+                        previous_row,
                         &sums,
                         &previous,
                     );
@@ -529,39 +497,6 @@ fn sampledSecure(columns: [][]QM31, offset: usize, point: usize) !QM31 {
     return QM31.fromPartialEvals(coordinates);
 }
 
-fn appendPrevious(
-    comptime n: usize,
-    allocator: std.mem.Allocator,
-    previous: [n][4][]const M31,
-    log_size: u32,
-    eval_size: usize,
-    twiddles: anytype,
-    evaluations: [][]const M31,
-    source: *usize,
-    buffers: *std.ArrayList([]M31),
-) !void {
-    const domain = canonic.CanonicCoset.new(log_size).circleDomain();
-    for (previous) |set| {
-        for (set) |values| {
-            if (values.len != domain.size()) return error.InvalidProofShape;
-            const evaluation = try prover_eval.CircleEvaluation.init(domain, values);
-            var coefficients = try prover_poly.interpolateFromEvaluationWithTwiddles(
-                allocator,
-                evaluation,
-                twiddles,
-            );
-            defer coefficients.deinit(allocator);
-            const extended = try allocator.alloc(M31, eval_size);
-            errdefer allocator.free(extended);
-            @memcpy(extended[0..coefficients.coefficients().len], coefficients.coefficients());
-            @memset(extended[coefficients.coefficients().len..], M31.zero());
-            try buffers.append(allocator, extended);
-            evaluations[source.*] = extended;
-            source.* += 1;
-        }
-    }
-}
-
 fn readMain(comptime n: usize, columns: []const []const M31, row: usize) [n]QM31 {
     var result: [n]QM31 = undefined;
     for (&result, columns) |*value, column| value.* = QM31.fromBase(column[row]);
@@ -572,14 +507,17 @@ fn readInteraction(
     comptime n: usize,
     evaluations: []const []const M31,
     interaction_start: usize,
-    previous_start: usize,
     row: usize,
+    previous_row: usize,
     sums: *[n]QM31,
     previous: *[n]QM31,
 ) void {
     for (0..n) |index| {
         sums[index] = secureAt(evaluations[interaction_start + 4 * index ..][0..4], row);
-        previous[index] = secureAt(evaluations[previous_start + 4 * index ..][0..4], row);
+        previous[index] = secureAt(
+            evaluations[interaction_start + 4 * index ..][0..4],
+            previous_row,
+        );
     }
 }
 


### PR DESCRIPTION
## Outcome

Removes duplicate previous-row interaction-column LDE construction from five RISC-V AIR component families. Instead, composition samples the already-retained current interaction LDE at the exact trace-predecessor index.

This is a regular performance PR, not an autoresearch submission: current `MANIFEST.json` does not admit `src/frontends/riscv/air/**` in scored submission diffs. The measurements below are qualification evidence, not a judged or promoted record.

## Mechanism

The interaction generators define each `previous` column as a one-row rotation of the current trace-order column. On the quotient domain, `previousBitReversedCircleDomainIndex` maps each evaluation row to that same polynomial one trace step earlier. The verifier already opens the current interaction polynomial at `prevRowPoint`.

The patch therefore reuses the retained current LDE and deletes the redundant allocation, interpolation, zero extension, and FFT of shifted copies.

Diff: 392 deletions, 72 additions across five RISC-V AIR component files.

## Current-main evidence

Exact predecessor: `3470b078e90529190625ad586cfc9a762c511a2d`
Candidate: `4510c8a54d3fa296428b9cccf8c1bc1cae650ab9`

Apple M4 Max, 16 workers, AC power, no thermal/performance warning, load1 <= 4 before every arm, 10 verified warmups + 5 verified samples per arm.

First A-B-B-A battery:
- pooled median wall ratio: `0.982506`
- temporal pairs: `0.981703`, `0.982050`
- instruction ratio: `0.982688`
- cycle ratio: `0.990219`
- energy ratio: `0.987471`

Independent reverse-order B-A-A-B replicate:
- pooled median wall ratio: `0.975850`
- temporal pairs: `0.979688`, `0.966019`
- instruction ratio: `0.984195`
- cycle ratio: `0.992520`
- energy ratio: `0.987263`

All arms produced the same statement SHA-256 `081253a76b31e19defd3714975ec64ac4543afe444587ee7267e3054db58444d` and transcript state `2a5f539b864e04352106562accf4d0686dd20296ca8f49e84a7b02dc019c2ff1`.

## Validation

- exact functional SHA2-128 proof and verification
- `zig build test-riscv-prover -Doptimize=ReleaseFast`
- RISC-V CPU product-marker check
- transitive Zig source closure check
- `git diff --check origin/main...HEAD`
- current repository PR validator

If this frontend surface should become promotion-eligible, the manifest policy needs a separate reviewed expansion; this PR does not alter that policy.