### PR TITLE
Reuse the prover worker pool for proof of work

### DIFF
--- a/autoresearch/submissions/2026-07-23-pow-global-pool/delta.json
+++ b/autoresearch/submissions/2026-07-23-pow-global-pool/delta.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "0c030ee1c1ae",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/prover/pcs/proof_of_work.zig": "sha256:66df1b4f5adf2ae37b509035b01493a5c7621aa4e2b7474949c3cfbb8a4dd54b"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "751cb31465a3ce178d9f450caa00395b16505a6e940937c4a1ed0abce7f40371",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-23-pow-global-pool/note.md
+++ b/autoresearch/submissions/2026-07-23-pow-global-pool/note.md
@@ -1,0 +1,72 @@
+# Reuse the prover work pool for proof of work
+
+## Model and harness
+
+Model: OpenAI GPT-5 (Codex). The candidate was built from canonical main
+`0c030ee1c1ae` and measured with the repository-resident `stwo-perf` harness
+at commit `8d20dbf7f600`, Zig 0.15.2, ReleaseFast. The final paired S3 ran on
+an idle 16-core Apple Silicon host from a clean canonical-origin clone.
+
+## Hypothesis
+
+The functional protocol's Blake2s proof-of-work search creates and joins a
+fresh set of OS threads for every proof. Earlier proving phases already use a
+persistent global worker pool, and the pool's own module says it replaces
+separate FFT, Merkle, and PoW pools, but the PoW call site never routes work
+through it.
+
+For the small proof, PoW was about 0.25 ms, roughly 23% of prove time. Reusing
+the live pool should remove fixed thread lifecycle overhead without changing
+the nonce search, transcript, hash, or proof. Elicit literature on task
+granularity supported the direction but supplied no transferable magnitude;
+the paired full-proof run was the deciding evidence.
+
+## Changes
+
+`src/prover/pcs/proof_of_work.zig` now recognizes the raw Blake2s channel and,
+when the global prover pool is available, assigns one strided nonce residue
+class per worker. The caller executes residue zero while the existing pool
+executes the remaining residues. All workers atomically lower a shared bound
+and join before return, preserving the globally lowest valid nonce independent
+of scheduling.
+
+The nonce-invariant prefix is computed once, and each candidate hashes the
+same 40-byte prefix-plus-nonce message as current main. The explicit
+`STWO_ZIG_POW_WORKERS` override, generic channels, single-threaded builds, and
+pool-unavailable execution retain the original channel path. Focused tests
+compare the result with the original grinder across difficulties and worker
+counts and bind it to changed transcripts.
+
+There is no cross-request nonce cache, SIMD-width threshold, protocol change,
+or core-channel edit.
+
+## Results
+
+The exact-main local S1 reported a prove ratio of **0.8650**, 95% CI
+**[0.8343, 0.9061]**, with medians of 1.048 and 0.905 ms. Request time fell
+to 0.8823, energy to 0.7966, and peak RSS to 0.9583. Proof bytes and digest
+were identical.
+
+The final Studio S3 with automatic guards reported a prove ratio of
+**0.9358**, 95% CI **[0.9175, 0.9518]**, with medians of 0.965 and 0.903 ms
+across 20 balanced rounds. Request time fell to 0.9473, energy to 0.8760, and
+peak RSS to 0.9645. All 13 impact-mapped regression guards passed their 1.05
+upper-CI budgets. Every timed proof verified, cross-arm proof digests were
+byte-identical, the pinned Rust oracle passed, and G1-G5 were green.
+
+Core, prover, Native CPU product, and source-conformance closures passed. A
+post-run fetch confirmed both the predecessor and canonical `origin/main`
+remained `0c030ee1c1ae`; candidate `92b18a7a1f51` was a clean descendant.
+
+## Caveats
+
+This is a local claimed verdict; the project judge's rerun is authoritative.
+The win is concentrated in the small class because fixed thread lifecycle
+cost is a larger fraction there. Wider guard rows were neutral or modestly
+faster and are not claimed as separate class records.
+
+The optimized path applies only to the raw Blake2s channel and the default
+worker policy. An explicit PoW worker override deliberately selects the
+original implementation. The prover-side prefix helper mirrors the locked
+core-channel construction; equality tests and whole-proof byte identity guard
+against drift, but a future protocol change must update both paths together.

--- a/autoresearch/submissions/2026-07-23-pow-global-pool/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-23-pow-global-pool/transcripts/session-01.md
@@ -1,0 +1,122 @@
+# Session 01: replacing per-proof PoW threads with the prover pool
+
+## Objective and freshness rule
+
+The user required every experiment to start from the latest canonical main.
+Before each build, evidence run, and seal, the campaign freshness gate fetched
+canonical main and required the candidate to descend from it. Main advanced
+during an earlier PoW experiment, so that evidence was discarded and the
+candidate was rebased before any further claim. This submission started from
+and finished against `0c030ee1c1ae`.
+
+## Blocker audit
+
+Exact-main stage profiles showed proof of work consuming about 0.25 ms of the
+small proof, close to 23% of prove time. The current raw Blake2s channel
+already computes the nonce-invariant prefix once, then creates and joins up to
+64 OS threads for each proof. That made thread lifecycle overhead the largest
+plausible remaining small-class lever.
+
+Two alternatives were rejected first:
+
+1. A transcript-keyed nonce cache made repeated benchmark requests fast but
+   did not accelerate fresh production transcripts. It was NACKED without
+   submission because performance depended on process history.
+2. Four-lane Blake2s nonce batches preserved the lowest nonce and proof bytes,
+   but an exact-main small S1 was neutral-to-worse at
+   `1.0140 [0.9952, 1.0382]`. Its apparent isolated gains depended on where a
+   fixed transcript's first valid nonce occurred. It was NACKED with no reroll.
+
+The next audit found a source-level contradiction: the global prover worker
+pool says it replaces separate FFT, Merkle, and PoW pools, while the actual PoW
+call still invokes the channel's thread-spawning grinder. This isolated a
+different mechanism: retain scalar hashing and the exact nonce order, but
+replace fresh OS threads with persistent pool jobs.
+
+## Research input
+
+Targeted Elicit searches covered persistent pools versus thread creation for
+sub-millisecond tasks, task-granularity crossover, deterministic
+lowest-valid-nonce search, and combined thread/SIMD hashing. The useful
+sources were general task-granularity studies, including DOI
+`10.1145/3338497`, DOI `10.1007/978-3-031-06156-1_36`, and the thread
+management study DOI `10.1145/75108.75378`. They support the qualitative
+prediction that creation and scheduling overhead can dominate fine tasks.
+None measured STWO, Blake2s nonce search, or Apple Silicon, so no paper result
+was transferred as a quantitative claim.
+
+## Implementation reasoning
+
+The candidate changes only `src/prover/pcs/proof_of_work.zig`.
+
+For the concrete raw Blake2s channel, the default path requests the existing
+global pool. It computes the same prefix once, creates one work descriptor per
+pool worker, spawns residues 1 through N-1 into the pool, and processes residue
+zero on the caller. Each worker checks nonces congruent to its worker index
+modulo N. A shared atomic `fetchMin` bound means a worker finding a high nonce
+cannot hide a lower valid nonce in another residue class; all jobs join before
+the bound is returned.
+
+The core channel implementation was not edited because it is outside the
+submission's editable surface. The prover path therefore contains a compact
+copy of the locked prefix and 40-byte nonce hash construction. Focused tests
+compare the resulting lowest nonce with the original channel grinder for
+several difficulties and worker counts, verify every returned nonce, and
+repeat the comparison after changing the transcript.
+
+The explicit `STWO_ZIG_POW_WORKERS` override remains authoritative by selecting
+the original channel grinder. Pool failure, tests, generic channels, and
+single-threaded execution also retain the original path. SIMD4 was not combined
+with pool reuse because its transcript sensitivity had already been falsified;
+isolating one mechanism makes the evidence interpretable.
+
+## Correctness and product closure
+
+Before timing, formatting and diff checks passed. ReleaseFast closures passed
+for 75 transitive core sources, 174 prover sources, and 214 Native CPU product
+sources. Source conformance reported only five explained legacy findings and
+no new violations. The candidate was committed as `92b18a7a1f51` and the
+freshness gate proved it was a clean descendant of `0c030ee1c1ae`.
+
+## Measurement path and surprises
+
+The first exact-main local S1 cleared decisively:
+
+- prove ratio `0.864994`, CI `[0.834305, 0.906102]`;
+- 1.048458 ms predecessor versus 0.905250 ms candidate;
+- request ratio `0.882266`;
+- energy ratio `0.796593`;
+- peak RSS ratio `0.958274`;
+- byte-identical proof digest.
+
+The first local S3 attempt took no samples because the quiet-host gate rejected
+load above its threshold. A short Studio slot was claimed well before another
+agent's reserved window. The shared Studio clone was discovered to use a stale
+fork `origin/main`; it was rejected before timing. An isolated clone with the
+canonical repository as `origin` established exact predecessor/main
+`0c030ee1c1ae` and candidate `92b18a7a1f51`.
+
+The isolated clone's first S3 attempt also took zero samples: clone/build
+activity briefly raised load above the fail-closed threshold. After the cache
+was warm and load dropped, one cooldown retry was admitted. It produced:
+
+- prove ratio `0.935815`, CI `[0.917518, 0.951777]`;
+- 0.964500 ms predecessor versus 0.902667 ms candidate;
+- request ratio `0.947329`;
+- energy ratio `0.875988`;
+- peak RSS ratio `0.964453`;
+- 13 of 13 automatic regression guards within budget;
+- exact proof digest and pinned Rust-oracle success;
+- G1-G5 pass.
+
+The lower S3 effect than S1 was retained, not optimized away. Both independent
+hosts still clear the significance floor, and the S3 is the claim artifact.
+A post-run fetch confirmed main had not advanced. Studio was released
+immediately.
+
+## Decision
+
+Package the immutable candidate for the small CPU class only. Wider guard rows
+were neutral or modestly faster but do not clear their class significance
+floors, so claiming them would overstate the result. The submission remains a
+local claimed result until the project judge reruns it.

--- a/autoresearch/submissions/2026-07-23-pow-global-pool/verdict.json
+++ b/autoresearch/submissions/2026-07-23-pow-global-pool/verdict.json
@@ -1,0 +1,489 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "8d20dbf7f600",
+  "repo_commit": "92b18a7a1f51",
+  "predecessor_commit": "0c030ee1c1ae",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "da0daaba4b15",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 7.49
+    }
+  },
+  "search_health": {
+    "schema_version": 1,
+    "decision": {
+      "schema_version": 1,
+      "board": "core_cpu",
+      "workload_class": "small",
+      "trailing_window": 8,
+      "trailing_evidence_count": 1,
+      "trailing_median_gradient_snr": 0.0,
+      "gradient_snr_threshold": 2.0,
+      "configured_rounds": 15,
+      "auto_boost_rounds": 5,
+      "maximum_rounds": 25,
+      "target_rounds": 20,
+      "workload_count": 1,
+      "class_wall_deadline_seconds": 240.0,
+      "estimated_seconds_per_round": 4.047260127732685,
+      "deadline_round_limit": 59,
+      "auto_boost_applied": true,
+      "auto_boost_reason": "trailing_median_below_threshold",
+      "recorded_before_measurement": true
+    },
+    "decision_sha256": "sha256:9db7f740061d3ef93711d44da55d5ee24cfe4fa0e2efd35e759d868425be2a53",
+    "actual_rounds": 20,
+    "actual_rounds_per_workload": {
+      "wf_log10x8": 20
+    },
+    "objective_wall_seconds": 2.994912417,
+    "measurement_wall_seconds": 30.38894825,
+    "measurement_wall_hours": 0.008441374513888888,
+    "gradient_snr": null,
+    "credited_ln_improvement": null,
+    "credited_ln_improvement_per_measurement_hour": null,
+    "credit_status": "pending_ledger_adjudication",
+    "decision_record": "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/search-health-decision.json"
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned correctness oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "native mechanism telemetry policy unchanged"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.3237 vs targeted budget x1.02; matrix row upper CIs 1/1 within budget x1.05; regression guards 13/13 within budget; request ratios 1/1 present rows within budget x1.05; resource vectors 1/1 within named budgets"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log10x8": {
+        "r": 0.935815,
+        "ci": [
+          0.917518,
+          0.951777
+        ],
+        "rounds": 20,
+        "a_median_ms": 0.9645,
+        "b_median_ms": 0.902667,
+        "request_ratio": 0.947329,
+        "rss_ratio": 0.964453,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.875988,
+            "ci": [
+              0.859524,
+              0.884543
+            ],
+            "observations": 20,
+            "candidate": 0.101692065
+          },
+          "peak_rss_mib": {
+            "ratio": 0.964453,
+            "ci": [
+              0.963085,
+              0.964481
+            ],
+            "observations": 20,
+            "candidate": 5.516151428222656
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 24965.0
+          }
+        },
+        "mechanism_verified": null,
+        "proof_bytes": 24965,
+        "measurement_seconds": 2.660794,
+        "resources_complete": null
+      }
+    },
+    "R_geomean": 0.935815,
+    "portfolio": {
+      "ci_method": "independent_workload_round_bootstrap_percentile_v1",
+      "ci_level": 0.95,
+      "bootstrap_iterations": 4000,
+      "seed": 2000059846,
+      "ci": [
+        0.917518,
+        0.951777
+      ],
+      "prove_ms_method": "geometric_mean_candidate_workload_medians_ms_v1",
+      "b_median_ms_geomean": 0.902667,
+      "proof_bytes_method": "rounded_geometric_mean_candidate_proof_bytes_v1",
+      "proof_bytes": 24965,
+      "measurement_seconds": 2.660794,
+      "measurement_rounds": 20
+    },
+    "theta": 0.037308,
+    "aa_dispersion": 0.018654,
+    "significant": true,
+    "neutral": false,
+    "promotion_significance": {
+      "eligible": true,
+      "method": "independent_workload_round_bootstrap_percentile_v1",
+      "reason": "prove-time objective uses the deterministic workload portfolio CI"
+    },
+    "resource_portfolio": {
+      "peak_rss_mib": {
+        "ratio_geomean": 0.9644532662096601,
+        "upper_ci_geomean": 0.9644810766322263,
+        "candidate_geomean": 5.516151428222656
+      },
+      "energy_j": {
+        "ratio_geomean": 0.8759877130040079,
+        "upper_ci_geomean": 0.8845430975413482,
+        "candidate_geomean": 0.10169206500000001
+      },
+      "proof_bytes": {
+        "ratio_geomean": 1.0,
+        "upper_ci_geomean": 1.0,
+        "candidate_geomean": 24965.0
+      }
+    }
+  },
+  "tiebreakers": {
+    "rss_ratio": 0.964453,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": 0.10169206500000001,
+    "proof_bytes": 24965.0
+  },
+  "holdout": null,
+  "guards": {
+    "guard_blake_10x10": {
+      "r": 0.994323,
+      "ci": [
+        0.989955,
+        0.996105
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "4153acd6e32a98b9d240730062f7fa35e2e31eca915f01c179337f04d409cbd2"
+    },
+    "guard_blake_12x16": {
+      "r": 0.983921,
+      "ci": [
+        0.963735,
+        0.998458
+      ],
+      "rounds": 5,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "70e516957d2d38ed78214bfda5b0b2bdfe41f1c93439fb68e124bfef096fbc9f"
+    },
+    "guard_plonk_14": {
+      "r": 0.974157,
+      "ci": [
+        0.965523,
+        0.999884
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "d63a2c92846148edc075fbb46fe63f5cf0fc6fe05ae1d5d54d09bda33b69dbaf"
+    },
+    "guard_plonk_16": {
+      "r": 0.995053,
+      "ci": [
+        0.98184,
+        1.013455
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "cfb36bf17fb3526bf1bdd9401fb885fd91ca46b9982fee1ca5fad33a1d574b72"
+    },
+    "guard_poseidon_10": {
+      "r": 0.980781,
+      "ci": [
+        0.97104,
+        0.989237
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "af33240da8e7947362fdf7e78d306f2e11cb2e3df7e1b6f498a6e86ac3ae7b1b"
+    },
+    "guard_poseidon_13": {
+      "r": 0.992819,
+      "ci": [
+        0.984846,
+        0.997118
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "f196835da5d4a155c6311bafb44335c2863cc028879d69a7ae53b802321200f1"
+    },
+    "guard_sm_14": {
+      "r": 0.990396,
+      "ci": [
+        0.95551,
+        1.023113
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "488fadeeb4e5d76b6fc0a9c10ab258bab6673de8e912ae5de927561650920b37"
+    },
+    "guard_sm_16": {
+      "r": 0.997851,
+      "ci": [
+        0.992697,
+        1.00119
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "88ec35ee88a05ce0a5db4b6cb063f4cf7824ee65284db0908a62a9362879af73"
+    },
+    "guard_wf_10x8": {
+      "r": 0.917639,
+      "ci": [
+        0.897531,
+        0.940746
+      ],
+      "rounds": 8,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700"
+    },
+    "guard_wf_14x32": {
+      "r": 0.981296,
+      "ci": [
+        0.971873,
+        0.989253
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "57a7d291eb8a103d0e4395c23fd7dc9ab7e9ed2d0f95558835cc6482630f3374"
+    },
+    "guard_wf_16x64": {
+      "r": 1.001363,
+      "ci": [
+        0.994934,
+        1.004565
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "42086545b7a170c5868afcc390f83d964e06d528e2d1039420fc6bfd7a6aac74"
+    },
+    "guard_xor_14": {
+      "r": 0.978186,
+      "ci": [
+        0.960048,
+        1.00136
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "35bb35714e10888c786a71ccdfe31d2b9b4651c567fac5ba4c9543bc247cad80"
+    },
+    "guard_xor_16": {
+      "r": 0.99788,
+      "ci": [
+        0.992687,
+        1.010559
+      ],
+      "rounds": 3,
+      "budget_upper": 1.05,
+      "pass": true,
+      "proof_digest": "56163b8ea3d877b3b9bf15753b7c0175d4a6ead493640eef8210c59ba7e5215c"
+    }
+  },
+  "rust_oracle": [
+    {
+      "workload": "wf_log10x8",
+      "verified": true,
+      "oracle": "pinned-rust-stwo",
+      "artifact_sha256": "6a2250b56d5e10b6385e3a0f617ef4cee001b5279fd3bbef404a5ccb58ccd7ce"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "pr6_supremacy",
+      "reason": "PR6 Supremacy remains disabled until every exact workload port, log22 oracle vector, both timing boundaries, locked-M5 statistical gate, and authenticated judged verdict are complete."
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "wf_log10x8": {
+        "round_ratios": [
+          0.900177,
+          0.898557,
+          0.939807,
+          0.946318,
+          0.945365,
+          0.936086,
+          0.963748,
+          0.994841,
+          0.983978,
+          0.986122,
+          0.890728,
+          0.953982,
+          0.891265,
+          0.925894,
+          0.976049,
+          0.90236,
+          0.889671,
+          0.962898,
+          0.873308,
+          0.932195
+        ],
+        "proof_digest": "91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700",
+        "request_ratio": 0.947329,
+        "rss_ratio": 0.964453,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.875988,
+            "ci": [
+              0.859524,
+              0.884543
+            ],
+            "observations": 20,
+            "candidate": 0.101692065
+          },
+          "peak_rss_mib": {
+            "ratio": 0.964453,
+            "ci": [
+              0.963085,
+              0.964481
+            ],
+            "observations": 20,
+            "candidate": 5.516151428222656
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 24965.0
+          }
+        },
+        "report_sha256s": [
+          "1d18fc966c79a4a9e40f9ab7dbe568ffa7573b3553682c714c3323edae2948d6",
+          "ffd5dcf0f8bf1e8a7547dd7b9254fa08e9dfb796dc456689f049914cd3fed324",
+          "3b7daeab1fec7ee08d9509477fe73f4a06866f374d6f8cf610fce1bed4eaeeb4",
+          "db3d6fd21c437bc2138e9c70a13f2503fb12ee4f805a433310b84c570300e12e",
+          "741d3b27731567d2dee332d315d4a6a0333902a289317253597aafc434334406",
+          "26f664bc504880e1a65ae5e01b37c58821337db4a92a39be203294cdaa37d82c",
+          "98c9c38cbdf672ac84e66a28920259689d01b192280f876509ef73f6924fa797",
+          "58ceb2cbe0f6022e48a061f77862fba57207610e0f6e0f6a35822154a95006d0",
+          "4c00086849be2587f18099bfa7f1a185f728c7dfd80e68f914bcb269c382708c",
+          "873b0c7912d12d18f14e6e3723bdb64c07bda7af9689e5f1ee1c4bf00d25e4be",
+          "10d5687c92e4d98761635c4ac42e0eb0e5b70510bb6c701f6990c7c125fa269e",
+          "f8619a569ceba7bf444403db2d16e1160653e692f6fc0b7ec50c52a249fca539",
+          "1547d110234e4ad5ac110b6a716db6e45f4af7c39905e22ac3962a297f4b20dd",
+          "33d60a837ced3a185ad9540ce1840802ee22a5d0da6072281f38b62ee34a58fa",
+          "fd3c92b79f2d96738cc1b963ca5757d067e9028ac5bf190cd54724fbad19ea34",
+          "239c8f0a78e715ee5ba4fc8e6481be6539d0b071287e8869d6d809e7554b653d",
+          "520251762e2c40e20655a80c79feb09f68103a3ef65ba7c63f3af278ab86965b",
+          "0b63ee5ff4b49d7abe10059244c1d377cdfecee6c9708ed3994eebe69364039a",
+          "53373641081623a69e71822454cbedb3c7e5cd27f1a05f068ad828d5208e4257",
+          "8ca561da583c6aa265d7c41a803a068d8548e039c497fafc7662b71fca22a4b5",
+          "bca2c36531a4e14735a3079e3c3ef9d84226f730c5dccd47f239d332f73d875a",
+          "1a21d1eb90d040d4b6d4ca23f93e6c6f4a743a073ef0fe40a76fac21ba644837",
+          "c1fd42eb15d8665244b01ad55e47dc21f1570b305c45c357c69f562477c943e6",
+          "9cbe8a32f39d91a621ecbd1cd1293c7040d2e8fe89c61a6251c3cff015c4bd21",
+          "3db7b4f047f98b980fd8780eaefd3c36bac77b4e68d7aa076e162e72f96a6250",
+          "ab3c19aec103654cafb630c19634b6ed908c51dad66d627518ee631c1ebcb379",
+          "a95c2e9aa42f813596cea1e9e998bb6bf082a4e34654bc46758fbd926c1cd338",
+          "7c0fc940cd02eb1eb709dd1c6d2738d0620ac41e09d25881a9ee448877acd50d",
+          "bcb28e9d0cf55788266b18f021c8ef2da696b48c24f04798a545ae1457949cc7",
+          "06a9bab285d1fa122e1499cb23179c7f6c11be12e458d36e225fcc265f756708",
+          "813b7330b81fbd306b6d80a19e04f2db6fffdb16c20c5a2364cf436b508bb430",
+          "9c7a9da344b3106812c9543e6ea6d692e63236a7d662e2d5879cb46148b6970b",
+          "eacdfca5d41b1c2ebe87ddebfb2f16d490f28da9bfc112b981275f0ae1f377f9",
+          "2f2342bdaf50cf42174ce857a42fbefb47590c5d6f8c48716dd0bed9fbd92608",
+          "f8ecb890a6e7e009942d347c01418e75da600cd2e38c86bab450ca7d6436e079",
+          "b1a1af3b5247192a29f9f22d6c40a07de6c513e0b316c297cca6f4609dd2ad48",
+          "c59df3140569e033f74200a2e5f9de53ad5e16abd5b873baa11baf89e983820f",
+          "120a2acda57d0656293f9548215fb6b00af0f8a5e15e1f11bdcd6a66e7b0a0d2",
+          "f1a1b48f281516fd517c1c02df5848227a94e1844d9958fdc7344c5866e56f27",
+          "fcf25a54e1ba9286a890e639a3c5cccb869cb9aeb2bcdf43f9509cdd65afed3a"
+        ],
+        "mechanism_verified": null,
+        "resources_complete": null
+      }
+    },
+    "reports": [
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.a1.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.b1.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.a2.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.b2.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.a3.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.b3.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.a4.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.b4.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.a5.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.b5.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.a6.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.b6.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.a7.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.b7.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.a8.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.b8.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.a9.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.b9.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.a10.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.b10.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.a11.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.b11.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.a12.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.b12.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.a13.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.b13.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.a14.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.b14.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.a15.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.b15.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.a16.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.b16.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.a17.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.b17.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.a18.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.b18.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.a19.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.b19.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.a20.json",
+      "/Users/odin/studio-runs/anvil-pow-global-pool-0c030ee/candidate-exact/autoresearch/.runs/latest/wf_log10x8.b20.json"
+    ]
+  }
+}

--- a/src/prover/pcs/proof_of_work.zig
+++ b/src/prover/pcs/proof_of_work.zig
@@ -1,6 +1,25 @@
 //! Prover-side proof-of-work nonce search policy.
 
+const std = @import("std");
+const stwo_core = @import("stwo_core");
+const work_pool_mod = @import("../work_pool.zig");
+
+const Blake2sChannel = stwo_core.channel.blake2s.Blake2sChannel;
+const Blake2sHasher = stwo_core.crypto.blake2s_backend.Blake2sHasher;
+
 pub fn grind(channel: anytype, pow_bits: u32) u64 {
+    if (pow_bits == 0) return 0;
+
+    if (comptime @TypeOf(channel.*) == Blake2sChannel) {
+        // Preserve the dedicated PoW worker override. The default path reuses
+        // the prover pool instead of creating and joining OS threads here.
+        if (!std.process.hasEnvVarConstant("STWO_ZIG_POW_WORKERS")) {
+            if (work_pool_mod.getGlobalPool()) |pool| {
+                return grindBlake2sInPool(channel.*, pow_bits, pool);
+            }
+        }
+    }
+
     // Prefer a channel's cached or parallel implementation when it provides one.
     if (@hasDecl(@TypeOf(channel.*), "grind")) {
         return channel.grind(pow_bits);
@@ -10,4 +29,133 @@ pub fn grind(channel: anytype, pow_bits: u32) u64 {
     while (true) : (nonce += 1) {
         if (channel.verifyPowNonce(pow_bits, nonce)) return nonce;
     }
+}
+
+const PowWork = struct {
+    prefix: [32]u8,
+    pow_bits: u32,
+    start: u64,
+    stride: u64,
+    found: *std.atomic.Value(u64),
+
+    fn run(self: *const PowWork) void {
+        var nonce = self.start;
+        while (nonce < self.found.load(.monotonic)) {
+            if (verifyNonceWithPrefix(self.prefix, nonce, self.pow_bits)) {
+                _ = self.found.fetchMin(nonce, .release);
+                return;
+            }
+            nonce = std.math.add(u64, nonce, self.stride) catch return;
+        }
+    }
+};
+
+fn grindBlake2sInPool(
+    channel: Blake2sChannel,
+    pow_bits: u32,
+    pool: *work_pool_mod.WorkPool,
+) u64 {
+    const worker_count = pool.workerCount();
+    std.debug.assert(worker_count >= 2);
+    std.debug.assert(worker_count <= work_pool_mod.MAX_WORKERS);
+
+    const prefix = computePowPrefix(channel, pow_bits);
+    var found = std.atomic.Value(u64).init(std.math.maxInt(u64));
+    var jobs: [work_pool_mod.MAX_WORKERS]PowWork = undefined;
+    for (jobs[0..worker_count], 0..) |*job, worker_index| {
+        job.* = .{
+            .prefix = prefix,
+            .pow_bits = pow_bits,
+            .start = @intCast(worker_index),
+            .stride = @intCast(worker_count),
+            .found = &found,
+        };
+    }
+
+    var wait_group: std.Thread.WaitGroup = .{};
+    for (jobs[1..worker_count]) |*job| {
+        pool.spawnWg(&wait_group, PowWork.run, .{@as(*const PowWork, job)});
+    }
+    PowWork.run(&jobs[0]);
+    wait_group.wait();
+    return found.load(.acquire);
+}
+
+fn computePowPrefix(channel: Blake2sChannel, pow_bits: u32) [32]u8 {
+    var input: [52]u8 = [_]u8{0} ** 52;
+    std.mem.writeInt(u32, input[0..4], Blake2sChannel.POW_PREFIX, .little);
+    @memcpy(input[16..48], channel.digestBytes()[0..]);
+    std.mem.writeInt(u32, input[48..52], pow_bits, .little);
+    return Blake2sHasher.hashFixedSingleBlock(input.len, &input);
+}
+
+fn verifyNonceWithPrefix(prefix: [32]u8, nonce: u64, pow_bits: u32) bool {
+    var input: [40]u8 = undefined;
+    @memcpy(input[0..32], prefix[0..]);
+    std.mem.writeInt(u64, input[32..40], nonce, .little);
+    const digest = Blake2sHasher.hashFixedSingleBlock(input.len, &input);
+    return trailingZeroBits(digest[0..16]) >= pow_bits;
+}
+
+fn trailingZeroBits(bytes: []const u8) u32 {
+    var total: u32 = 0;
+    for (bytes) |byte| {
+        if (byte == 0) {
+            total += 8;
+        } else {
+            total += @ctz(byte);
+            break;
+        }
+    }
+    return total;
+}
+
+fn grindBlake2sResiduesForTest(
+    channel: Blake2sChannel,
+    pow_bits: u32,
+    worker_count: usize,
+) u64 {
+    const prefix = computePowPrefix(channel, pow_bits);
+    var found = std.atomic.Value(u64).init(std.math.maxInt(u64));
+    for (0..worker_count) |worker_index| {
+        const job = PowWork{
+            .prefix = prefix,
+            .pow_bits = pow_bits,
+            .start = @intCast(worker_index),
+            .stride = @intCast(worker_count),
+            .found = &found,
+        };
+        job.run();
+    }
+    return found.load(.acquire);
+}
+
+test "proof of work: pooled residue search preserves the lowest nonce" {
+    var channel = Blake2sChannel{};
+    channel.mixU32s(&.{ 0x1234_5678, 0x9abc_def0 });
+
+    for ([_]u32{ 1, 4, 8, 10 }) |pow_bits| {
+        const expected = channel.grind(pow_bits);
+        for ([_]usize{ 1, 2, 5, 16 }) |worker_count| {
+            const actual = grindBlake2sResiduesForTest(
+                channel,
+                pow_bits,
+                worker_count,
+            );
+            try std.testing.expectEqual(expected, actual);
+            try std.testing.expect(channel.verifyPowNonce(pow_bits, actual));
+        }
+    }
+}
+
+test "proof of work: pooled residue search binds the transcript" {
+    var first = Blake2sChannel{};
+    first.mixU32s(&.{1});
+    var second = Blake2sChannel{};
+    second.mixU32s(&.{2});
+
+    const first_nonce = grindBlake2sResiduesForTest(first, 8, 7);
+    const second_nonce = grindBlake2sResiduesForTest(second, 8, 7);
+    try std.testing.expectEqual(first.grind(8), first_nonce);
+    try std.testing.expectEqual(second.grind(8), second_nonce);
 }


### PR DESCRIPTION
## Summary

- route raw Blake2s PoW residue classes through the existing persistent prover pool
- preserve the globally lowest nonce, explicit PoW worker overrides, and all fallback paths
- add focused lowest-nonce and transcript-binding tests

## Evidence

Exact predecessor `0c030ee1c1ae`, candidate source commit `92b18a7a1f51`.

Studio S3 `core_cpu/small/time`: ratio **0.9358**, 95% CI **[0.9175, 0.9518]**, 0.965 ms to 0.903 ms across 20 balanced rounds. Request ratio 0.9473, energy ratio 0.8760, peak RSS ratio 0.9645. All 13 automatic regression guards passed. Every proof verified, cross-arm proof digests were byte-identical, the pinned Rust oracle passed, and G1-G5 were green.

Core, prover, Native CPU product, source conformance, and local submission validation pass.

This is a claimed result; the project judge remains authoritative.