### PR TITLE
Scope fork qualification setup to its board

### DIFF
--- a/autoresearch/cli/stwo_perf/__main__.py
+++ b/autoresearch/cli/stwo_perf/__main__.py
@@ -57,10 +57,10 @@ def cmd_clone(args) -> int:
     return 0
 
 
-def cmd_setup(_args) -> int:
+def cmd_setup(args) -> int:
     from . import workspace
     m = manifest_mod.load()
-    built = workspace.setup(m.root, m)
+    built = workspace.setup(m.root, m, board=args.board)
     print(f"{ansi.OK} toolchain verified; bench targets built for group(s): "
           + ", ".join(built))
     return 0
@@ -595,7 +595,14 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("clone", help="create a searcher workspace (git worktree)")
     p.add_argument("dest")
 
-    sub.add_parser("setup", help="verify toolchain and build the bench target")
+    p = sub.add_parser("setup", help="verify toolchain and build bench targets")
+    p.add_argument(
+        "--board",
+        default=None,
+        choices=["core_cpu", "core_hybrid", "core_metal", "core_cuda",
+                 "heavy_native", "heavy_cairo", "stream", "riscv"],
+        help="build only the workload group owned by this board",
+    )
 
     sub.add_parser(
         "update",

--- a/autoresearch/cli/stwo_perf/workspace.py
+++ b/autoresearch/cli/stwo_perf/workspace.py
@@ -7,10 +7,11 @@ else at the default-branch tip, and both refuse a dirty worktree without
 
 from __future__ import annotations
 
+import platform
 import subprocess
 from pathlib import Path
 
-from .manifest import Manifest
+from .manifest import Manifest, ManifestError
 
 
 class WorkspaceError(RuntimeError):
@@ -42,20 +43,41 @@ def clone(repo_root: Path, dest: Path, ref: str = "HEAD") -> Path:
     return dest
 
 
-def setup(root: Path, manifest: Manifest) -> list[str]:
-    """Verify toolchain and build every enabled group's bench target once.
+def setup(root: Path, manifest: Manifest, board: str | None = None) -> list[str]:
+    """Verify toolchain and build the selected board's bench target.
 
+    With no board, preserve the interactive setup behavior and build every
+    enabled group. Fork qualification supplies its dispatched board so a
+    Linux runner never tries to build unrelated host-specific backends.
     Disabled groups are announced loudly (never silently dropped); returns
     the group ids that were built.
     """
     zig = subprocess.run(["zig", "version"], capture_output=True, text=True)
     if zig.returncode != 0:
         raise WorkspaceError("zig not found on PATH")
+    groups = manifest.groups()
+    if board is not None:
+        try:
+            group = manifest.group_for_board(board)
+        except ManifestError as exc:
+            raise WorkspaceError(str(exc)) from exc
+        if not group.enabled:
+            raise WorkspaceError(
+                f"workload group {group.group_id} for board {board} is disabled: "
+                f"{group.disabled_reason or 'no reason recorded'}"
+            )
+        groups = [group]
     built: list[str] = []
-    for group in manifest.groups():
+    for group in groups:
         if not group.enabled:
             print(f"skipped group {group.group_id}: "
                   f"{group.disabled_reason or 'no reason recorded'}")
+            continue
+        if board is None and group.board == "core_metal" and platform.system() != "Darwin":
+            print(
+                f"skipped group {group.group_id}: core_metal requires a Darwin "
+                "host with the Apple Metal SDK"
+            )
             continue
         proc = subprocess.run(
             group.build_step.split(), cwd=root, capture_output=True, text=True

--- a/autoresearch/tests/test_workspace.py
+++ b/autoresearch/tests/test_workspace.py
@@ -2,7 +2,9 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from copy import deepcopy
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "cli"))
 from stwo_perf import workspace
@@ -84,6 +86,61 @@ class RestoreTest(unittest.TestCase):
         m = Manifest(root=self.root, raw=raw)
         restored = workspace.restore_editable_from(self.root, m, self.c1)
         self.assertTrue(any("absent in source" in r for r in restored))
+
+
+class SetupTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        raw = deepcopy(MANIFEST_RAW)
+        raw["workload_registry"]["groups"]["metal"] = {
+            "enabled": True,
+            "promotion_eligible": True,
+            "board": "core_metal",
+            "build_step": "false",
+            "binary": "true",
+            "report_schema": "native_proof_v7",
+            "workloads": {},
+        }
+        self.manifest = Manifest(root=self.root, raw=raw)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    @mock.patch("stwo_perf.workspace.subprocess.run")
+    def test_board_scoped_setup_builds_only_selected_group(self, run):
+        run.return_value = subprocess.CompletedProcess([], 0, stdout="0.15.2\n")
+
+        built = workspace.setup(self.root, self.manifest, board="core_cpu")
+
+        self.assertEqual(built, ["native"])
+        self.assertEqual(
+            [call.args[0] for call in run.call_args_list],
+            [["zig", "version"], ["true"]],
+        )
+
+    @mock.patch("stwo_perf.workspace.platform.system", return_value="Linux")
+    @mock.patch("stwo_perf.workspace.subprocess.run")
+    def test_default_setup_skips_apple_metal_on_linux(self, run, _system):
+        run.return_value = subprocess.CompletedProcess([], 0, stdout="0.15.2\n")
+
+        built = workspace.setup(self.root, self.manifest)
+
+        self.assertEqual(built, ["native"])
+        self.assertEqual(
+            [call.args[0] for call in run.call_args_list],
+            [["zig", "version"], ["true"]],
+        )
+
+    def test_unknown_board_is_rejected(self):
+        with mock.patch(
+            "stwo_perf.workspace.subprocess.run",
+            return_value=subprocess.CompletedProcess([], 0, stdout="0.15.2\n"),
+        ):
+            with self.assertRaisesRegex(
+                workspace.WorkspaceError, "board has no workload group"
+            ):
+                workspace.setup(self.root, self.manifest, board="unknown")
 
 
 if __name__ == "__main__":

--- a/autoresearch/workflows/qualify-fork.yml
+++ b/autoresearch/workflows/qualify-fork.yml
@@ -64,8 +64,14 @@ jobs:
           --frontier '${{ inputs.frontier_commit }}' --preflight
       - name: Validate the locked harness
         run: python3 -m unittest discover -s autoresearch/tests -v
+      - name: Install pinned Zig toolchain
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        with:
+          version: 0.15.2
       - name: Build release benchmark targets
-        run: python3 autoresearch/cli/stwo-perf setup
+        run: >-
+          python3 autoresearch/cli/stwo-perf setup
+          --board '${{ inputs.board }}'
       - name: Materialize the declared frontier
         run: git worktree add --detach "$RUNNER_TEMP/frontier" '${{ inputs.frontier_commit }}'
       - name: Run the public paired qualification benchmark


### PR DESCRIPTION
## What changed

- add `stwo-perf setup --board <board>` to build only the workload group owned by the selected board;
- loudly skip the Apple-only Metal group during default setup on non-Darwin hosts, which repairs the already-installed fork workflow without modifying it;
- pass the dispatched board from the reusable `qualify-fork.yml` template;
- restore the pinned Zig setup step in the reusable workflow template;
- add workspace regression tests for board-scoped selection and unknown-board rejection.

## Why

Fork qualification currently runs on `ubuntu-latest`, but bare `stwo-perf setup`
builds every enabled group. A `core_cpu` qualification therefore reaches the
unrelated Metal build and fails because Linux has no Apple Metal SDK. That makes
the attested remote-submission path unusable for outside contributors even when
their candidate touches only the CPU board.

The failure is reproduced in
[fork run 30344584862](https://github.com/welttowelt/stwo-zig/actions/runs/30344584862):
source policy and the locked harness passed, then Ubuntu setup failed while
building `native-proof-bench-metal`, before the paired benchmark or receipt.

Darwin interactive setup is unchanged. On non-Darwin hosts, default setup now
explicitly skips the Apple-only Metal group; callers that pass `--board` build
only the selected board's group.

## Validation

- `python3 -m unittest autoresearch.tests.test_workspace -v`
- `python3 -m unittest discover -s autoresearch/tests -v` — 373 tests passed
- `git diff --check`
