### PR TITLE
Reuse the prover work pool for proof of work

### DIFF
--- a/autoresearch/submissions/2026-07-28-pow-pool/delta.json
+++ b/autoresearch/submissions/2026-07-28-pow-pool/delta.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "cfd47be98a10",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/prover/pcs/proof_of_work.zig": "sha256:66df1b4f5adf2ae37b509035b01493a5c7621aa4e2b7474949c3cfbb8a4dd54b"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "cf01c9f18c7150adf3d2a65038789481fff62bab68039629fc1eaa1b4e6b7de7",
+      "captured_by": "submitter"
+    },
+    "transcripts/session-02.md": {
+      "sha256": "4771a763812304b4e0db653df2f16300a3274127a631a42eb906c2798cd4e5c9",
+      "captured_by": "submitter"
+    },
+    "transcripts/session-03.md": {
+      "sha256": "14fb137ce84e5b56f72245506542b18f6fefc4aba15d4e8727977ef7e2e2d533",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-28-pow-pool/note.md
+++ b/autoresearch/submissions/2026-07-28-pow-pool/note.md
@@ -1,0 +1,59 @@
+# Reuse the prover work pool for proof of work
+
+## Model and harness
+
+Model: OpenAI Codex. Candidate `6efb93d539498178fe2fb67ead0788bb884a6bcb`
+is a source-only descendant of canonical frontier
+`cfd47be98a10598b90a898e787e5cd1c674b09e7`. It is intended for the
+`core_cpu/small/time` fork-qualification path with Zig 0.15.2 and ReleaseFast.
+The current hosted result is pending. The canonical Ubuntu workflow first
+failed while building the unrelated Metal target. A non-canonical repair
+canary subsequently passed setup and reached benchmarking, then exhausted the
+generic runner's fixed guard wall budget before producing a receipt.
+
+## Hypothesis
+
+The raw Blake2s proof-of-work search creates and joins OS threads for each
+proof even though earlier prover stages already keep a global worker pool
+alive. On the small class, fixed thread lifecycle cost is a material fraction
+of proof time. Routing the same strided nonce search through the persistent
+pool should remove that fixed cost without changing transcript inputs, nonce
+selection, hashes, or proof bytes.
+
+## Changes
+
+The candidate changes only `src/prover/pcs/proof_of_work.zig`. It assigns one
+nonce residue class per existing pool worker, executes residue zero on the
+caller, and atomically lowers a shared best-nonce bound. All jobs join before
+return, preserving the globally lowest valid nonce. Generic channels, explicit
+worker overrides, pool-unavailable execution, tests, and single-threaded builds
+retain the original path.
+
+## Results
+
+Hosted fork qualification is pending. Diagnostic run `30346576852` proved that
+the board-scoped setup repair reaches the paired S3 path on Ubuntu, but the
+unchanged predecessor consumed almost the entire 300-second first-guard wall
+budget and left only 6.44856008 seconds for the candidate arm. The run emitted
+no verdict, receipt, or attestation.
+
+A fresh local advisory S3 screen against the exact canonical frontier completed
+20 paired rounds with `R = 0.956784` and portfolio CI
+`[0.921421, 0.980501]`. All five local gates passed, the pinned Rust oracle
+verified the scored workload, proof bytes were identical, peak RSS ratio was
+`0.962034`, and energy ratio was `0.928132`. The point estimate exceeds the
+configured `theta = 0.037308` improvement, but the CI does not lie entirely
+below `1 - theta`, so the harness correctly labels it not significant. The
+screen used `--guards none` to avoid the known generic-runner guard-budget
+defect; it is evidence for prioritization, not a qualification receipt,
+attestation, judged result, or promotable claim.
+
+## Caveats
+
+The optimized path is deliberately limited to the raw Blake2s channel and
+default worker policy. A prior transcript-keyed nonce cache was rejected
+because it accelerated repeated benchmark history rather than fresh work, and
+a four-lane nonce batch was rejected after a neutral-to-worse exact-main run.
+Branch publication, the original Metal setup failure, and the diagnostic guard
+timeout are not performance evidence. Central qualification must still
+re-run the complete guard portfolio and independently reproduce significance.

--- a/autoresearch/submissions/2026-07-28-pow-pool/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-28-pow-pool/transcripts/session-01.md
@@ -1,0 +1,47 @@
+# Session 01: persistent proof-of-work workers
+
+## Objective and evidence boundary
+
+The objective is one net-new `core_cpu/small/time` remote record from immutable
+candidate `6efb93d539498178fe2fb67ead0788bb884a6bcb`. A local build, published
+branch, or green source-policy check does not count. Completion requires an
+attested fork receipt, a new remote submission ID, central intake, and the
+service's terminal state.
+
+## Why this candidate survived screening
+
+Earlier profiles placed proof of work near the fixed-cost end of the small
+proof. Source inspection found that the prover's global pool advertises PoW as
+one of its intended consumers, but the raw Blake2s call path still creates and
+joins fresh OS threads. Elicit searches on task granularity and thread
+management supported only the qualitative expectation that creation overhead
+can dominate fine tasks; they did not provide a transferable STWO magnitude.
+The code-path contradiction and prior paired measurements, not a paper result,
+were the decision evidence.
+
+Two alternatives were kept as negative evidence. A transcript-keyed nonce
+cache was rejected because its gain depended on process history and would not
+accelerate fresh production transcripts. A four-lane Blake2s nonce batch
+preserved correctness but measured neutral-to-worse on exact main, so it was
+not combined with pool reuse.
+
+## Implementation reasoning
+
+Each persistent worker scans a fixed residue class modulo the worker count.
+The caller owns residue zero. An atomic minimum shares the best discovered
+nonce, and joining every job before return ensures scheduling cannot hide a
+lower valid nonce. The candidate mirrors the existing prefix-plus-nonce
+construction and retains the original implementation for explicit worker
+overrides, generic channels, unavailable pools, and single-threaded builds.
+Focused tests compare returned nonces with the original grinder across
+difficulties, worker counts, and changed transcripts.
+
+## Current qualification state
+
+The branch was rebased onto frontier `cfd47be98a10598b90a898e787e5cd1c674b09e7`,
+passed editable-path and ancestry preflight, and passed the full local tests.
+Fork run `30344584862` reproduced a workflow defect: policy and harness tests
+passed, then Ubuntu setup tried to build `native-proof-bench-metal` and failed
+before the paired benchmark or receipt. The candidate therefore remains
+unmeasured at the current frontier. Upstream PR 118 carries the board-scoped
+setup repair. No performance claim is made from that failed run.

--- a/autoresearch/submissions/2026-07-28-pow-pool/transcripts/session-02.md
+++ b/autoresearch/submissions/2026-07-28-pow-pool/transcripts/session-02.md
@@ -1,0 +1,60 @@
+# Session 02: non-canonical qualification repair canary
+
+## Purpose and evidence boundary
+
+PR 118 was green but still a draft, so its commit
+`e973ff8b3061b5ebc0eaf2d13566037b1ad993a2` was not a canonical frontier.
+To test the repair without misrepresenting it as submission evidence, a
+diagnostic branch placed the unchanged PoW source delta on top of that repair.
+The resulting fork commit was
+`52c96d89990a0546f5f5890cf35f5a51d169c4d8`, with
+`e973ff8b3061b5ebc0eaf2d13566037b1ad993a2` declared as its diagnostic
+predecessor. Any receipt would have remained non-submit-eligible.
+
+## Local qualification
+
+The diagnostic tree changed only
+`src/prover/pcs/proof_of_work.zig` relative to the repair commit. Source-policy
+preflight accepted the ancestry, locked-tree identity, file mode, patch size,
+and one editable path. The complete repository suite passed 373 tests, and the
+six board-scoped setup regression tests passed separately.
+
+## Hosted result
+
+Fork run `30346576852` was bound to the expected diagnostic branch and exact
+commit. It passed:
+
+- checkout of the immutable diagnostic source;
+- source-policy preflight against the repair commit;
+- all 373 locked harness tests;
+- installation of Zig 0.15.2;
+- release-target setup on Ubuntu; and
+- materialization of the repair commit as predecessor.
+
+This proves that PR 118 repairs the original Linux setup failure: the default
+setup explicitly skipped the Apple-only Metal group and reached the paired S3
+benchmark.
+
+The benchmark then failed on the first unchanged Blake regression guard before
+receipt generation. Guard round one orders predecessor before candidate. The
+predecessor arm consumed almost all of the hard 300-second per-guard wall
+budget; only 6.44856008 seconds remained for the candidate arm, which timed
+out. No guard ratio, verdict, receipt, artifact attestation, or remote
+submission was produced.
+
+## Classification and rejected interpretations
+
+The result is `qualification-infrastructure-failed`, not a PoW candidate
+failure. The timeout was created by the generic hosted runner and the
+whole-guard wall budget after the unchanged predecessor ran first. It is not
+evidence that the candidate regressed Blake, and it cannot be used as a
+performance claim.
+
+Blindly rerunning the same workflow was rejected: the first arm takes nearly
+the full fixed budget, so cache luck cannot make the required predecessor and
+candidate ABBA pair fit honestly. Raising the guard cap alone was also rejected
+as an unreviewed workaround because the workflow has a 90-minute job limit and
+twelve mandatory guards. The focused follow-up is to make the fork
+qualification contract explicitly objective-only while preserving full guard
+execution on the central judge, but that workflow-policy change requires
+review before implementation.

--- a/autoresearch/submissions/2026-07-28-pow-pool/transcripts/session-03.md
+++ b/autoresearch/submissions/2026-07-28-pow-pool/transcripts/session-03.md
@@ -1,0 +1,39 @@
+# Session 03: exact-frontier local objective screen
+
+## Why this run was performed
+
+The hosted diagnostic proved that the setup repair reaches benchmarking, then
+failed because the unchanged predecessor consumed almost all of the shared
+300-second guard wall budget. That failure left the PoW mechanism without a
+fresh current-frontier measurement. A same-host objective screen could not
+replace fork qualification, but it could test whether the candidate still
+deserved priority while the workflow policy remained under review.
+
+The run therefore used the exact canonical predecessor
+`cfd47be98a10598b90a898e787e5cd1c674b09e7`, immutable candidate
+`6efb93d539498178fe2fb67ead0788bb884a6bcb`, pinned Zig 0.15.2,
+`core_cpu/small/time`, S3, and 20 preregistered paired rounds. Automatic
+regression guards were disabled explicitly because their generic-runner budget
+is the diagnosed infrastructure defect; the scored objective, correctness
+checks, proof-byte comparison, resource vectors, and pinned Rust oracle
+remained active.
+
+## Result and interpretation
+
+The screen completed with `R = 0.956784`, workload CI
+`[0.922230, 0.979032]`, and portfolio CI `[0.921421, 0.980501]`.
+All five local gates passed. The Rust oracle verified the workload, every
+cross-arm proof digest was identical, peak RSS ratio was `0.962034`, and
+energy ratio was `0.928132`.
+
+The configured threshold was `theta = 0.037308`. Although the point estimate
+is faster than `1 - theta`, the full CI is not below that boundary. The
+harness therefore reports `significant: false`. The correct status is a
+promising but non-promotable advisory result, not a claimed win.
+
+## Evidence boundary
+
+The verdict is hash-bound to the exact source commits and retained as local
+screening evidence. It contains no GitHub artifact attestation and ran without
+the complete guard portfolio. It is not a fork qualification receipt, remote
+submission ID, central judgment, or research-record promotion.

--- a/autoresearch/submissions/2026-07-28-pow-pool/verdict.json
+++ b/autoresearch/submissions/2026-07-28-pow-pool/verdict.json
@@ -1,0 +1,349 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "596f2ddfb88b",
+  "repo_commit": "6efb93d53949",
+  "predecessor_commit": "cfd47be98a10",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "d00bf0abb109",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 4.12
+    }
+  },
+  "search_health": {
+    "schema_version": 1,
+    "decision": {
+      "schema_version": 1,
+      "board": "core_cpu",
+      "workload_class": "small",
+      "trailing_window": 8,
+      "trailing_evidence_count": 1,
+      "trailing_median_gradient_snr": 0.0,
+      "gradient_snr_threshold": 2.0,
+      "configured_rounds": 15,
+      "auto_boost_rounds": 5,
+      "maximum_rounds": 25,
+      "target_rounds": 20,
+      "workload_count": 1,
+      "class_wall_deadline_seconds": 240.0,
+      "estimated_seconds_per_round": 4.047260127732685,
+      "deadline_round_limit": 59,
+      "auto_boost_applied": true,
+      "auto_boost_reason": "trailing_median_below_threshold",
+      "recorded_before_measurement": true
+    },
+    "decision_sha256": "sha256:9db7f740061d3ef93711d44da55d5ee24cfe4fa0e2efd35e759d868425be2a53",
+    "actual_rounds": 20,
+    "actual_rounds_per_workload": {
+      "wf_log10x8": 20
+    },
+    "objective_wall_seconds": 3.1846513749915175,
+    "measurement_wall_seconds": 31.529127333982615,
+    "measurement_wall_hours": 0.008758090926106282,
+    "gradient_snr": null,
+    "credited_ln_improvement": null,
+    "credited_ln_improvement_per_measurement_hour": null,
+    "credit_status": "pending_ledger_adjudication",
+    "decision_record": "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/search-health-decision.json"
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned correctness oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "native mechanism telemetry policy unchanged"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.4553 vs targeted budget x1.02; matrix row upper CIs 1/1 within budget x1.05; request ratios 1/1 present rows within budget x1.05; resource vectors 1/1 within named budgets"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log10x8": {
+        "r": 0.956784,
+        "ci": [
+          0.92223,
+          0.979032
+        ],
+        "rounds": 20,
+        "a_median_ms": 1.307792,
+        "b_median_ms": 1.269708,
+        "request_ratio": 0.97664,
+        "rss_ratio": 0.962034,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.928132,
+            "ci": [
+              0.906826,
+              0.95091
+            ],
+            "observations": 20,
+            "candidate": 0.096339194
+          },
+          "peak_rss_mib": {
+            "ratio": 0.962034,
+            "ci": [
+              0.960796,
+              0.964607
+            ],
+            "observations": 20,
+            "candidate": 5.953559875488281
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 24965.0
+          }
+        },
+        "mechanism_verified": null,
+        "proof_bytes": 24965,
+        "measurement_seconds": 2.829353,
+        "resources_complete": null
+      }
+    },
+    "R_geomean": 0.956784,
+    "portfolio": {
+      "ci_method": "independent_workload_round_bootstrap_percentile_v1",
+      "ci_level": 0.95,
+      "bootstrap_iterations": 4000,
+      "seed": 2000059846,
+      "ci": [
+        0.921421,
+        0.980501
+      ],
+      "prove_ms_method": "geometric_mean_candidate_workload_medians_ms_v1",
+      "b_median_ms_geomean": 1.269708,
+      "proof_bytes_method": "rounded_geometric_mean_candidate_proof_bytes_v1",
+      "proof_bytes": 24965,
+      "measurement_seconds": 2.829353,
+      "measurement_rounds": 20
+    },
+    "theta": 0.037308,
+    "aa_dispersion": 0.018654,
+    "significant": false,
+    "neutral": false,
+    "promotion_significance": {
+      "eligible": true,
+      "method": "independent_workload_round_bootstrap_percentile_v1",
+      "reason": "prove-time objective uses the deterministic workload portfolio CI"
+    },
+    "resource_portfolio": {
+      "peak_rss_mib": {
+        "ratio_geomean": 0.9620341367049017,
+        "upper_ci_geomean": 0.964606867754166,
+        "candidate_geomean": 5.953559875488281
+      },
+      "energy_j": {
+        "ratio_geomean": 0.9281315459079564,
+        "upper_ci_geomean": 0.9509103324433528,
+        "candidate_geomean": 0.096339194
+      },
+      "proof_bytes": {
+        "ratio_geomean": 1.0,
+        "upper_ci_geomean": 1.0,
+        "candidate_geomean": 24965.0
+      }
+    }
+  },
+  "tiebreakers": {
+    "rss_ratio": 0.962034,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": 0.096339194,
+    "proof_bytes": 24965.0
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "wf_log10x8",
+      "verified": true,
+      "oracle": "pinned-rust-stwo",
+      "artifact_sha256": "4cabcca685cb0c4168d136ce3fea0f742b0b6a87d6b98beb3e048301f4d7b4e2"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "cuda",
+      "reason": "core_cuda is staged only: all six Native AIR families are required, but only wide Fibonacci is exact and release-ready; exact family semantics, the stwo-perf CUDA report adapter, locked-host A/A calibration, pinned Rust verification, and complete structural coverage are not yet release-gated."
+    },
+    {
+      "group": "pr6_supremacy",
+      "reason": "PR6 Supremacy remains disabled until every exact workload port, log22 oracle vector, both timing boundaries, locked-M5 statistical gate, and authenticated judged verdict are complete."
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "wf_log10x8": {
+        "round_ratios": [
+          0.981616,
+          0.948067,
+          0.988194,
+          0.817496,
+          0.683544,
+          0.992149,
+          0.977006,
+          0.93514,
+          0.922441,
+          0.909984,
+          1.005444,
+          0.997192,
+          1.002389,
+          0.980501,
+          1.019036,
+          0.917441,
+          0.990883,
+          0.934476,
+          0.947918,
+          0.894774
+        ],
+        "proof_digest": "91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700",
+        "request_ratio": 0.97664,
+        "rss_ratio": 0.962034,
+        "resources": {
+          "energy_j": {
+            "ratio": 0.928132,
+            "ci": [
+              0.906826,
+              0.95091
+            ],
+            "observations": 20,
+            "candidate": 0.096339194
+          },
+          "peak_rss_mib": {
+            "ratio": 0.962034,
+            "ci": [
+              0.960796,
+              0.964607
+            ],
+            "observations": 20,
+            "candidate": 5.953559875488281
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 24965.0
+          }
+        },
+        "report_sha256s": [
+          "61f8689e80b680af9be087b40fdd989f72466a047dbacf228a59ba263656b9a7",
+          "707b0b9c1f6456491ef2a58defe86ee66bd14cd99d870af3cb641288692af865",
+          "b2aebdfabff85a22302b278791fadbe56fc487d5bfdb4df5296c9d85df23ee4a",
+          "a107e9d8cbb0ed829eeda568bbfbdc0c0921512a108e86b56df30a04618f4a27",
+          "6690f68e262e5f340656fa883b8da7353fce8e63ecde8473dee416fbaadaea57",
+          "ca10c3a9f4cef70ccc03e5aecaf9a61cc846fbabb60f42fb8e1e9fb3616d6885",
+          "43443e7e0423a93bf24a98ea9bc4ef95ed1d280a4b6255062f784a47d720f44e",
+          "a5603fcb8441acaae87bc53882bb162a17b7306985e26a336b44c27dc48d4e09",
+          "9fada6f4355e282d7ad95c5b48362c20277282cd7b9283bef020e84a38562558",
+          "e0a34252624535d9964e57e565c41bf18ab23c2e0c9f679d5602c9fccb552fd1",
+          "c626732b1e0c9c76df59ec9791a376af5842dc07709c729bca69d86569af339a",
+          "f80944685a2906357603ca8a46228551d8fc02807bb6704ebd0a07e37c3a6043",
+          "7d3fb314438c169fbed057a057b67819972f0ee3467a1475693f16114b711ae8",
+          "fa8d91f84acea5cc141c3efedee994884342c11f0398e29a72e8427da2a96b7c",
+          "814b61c68402674ee1951d884a6ab3fa7ec45e3123821e9603b2c35b0b643ab2",
+          "ae842910b23d9995ddc276a57d192ea97118ab730828d0b7e14d1bef4e624a1d",
+          "5faeb35cc24a0a05aff2fcfa6269e94914f5a60c3147cbc06af00225aa3cdc80",
+          "142a4d0135015dd1ade7b9651be79c2e790fe5c7ac3f029256badf91971593cd",
+          "e837f58662c3b1c424c36ce5395328e0e2f45445bb822d26b30f70b028c7538e",
+          "1aa40fbc86373b75fd2abba3b874e788cdf5df3bc55985e2a85e01548a45692b",
+          "875f779213f563ee55439f847c028cc1472924db51c8212aa76ecffeae3174d5",
+          "02f62727e44c9feb8710107e4cfe12539ba33599a53eefbdab2a94a901f442cd",
+          "00b2ef96237cef87d6ba5e50c1d853b4395303e201ff46005959a0b88c80b84b",
+          "450e79482894287238b8b81287d984f0c4361d4cc250710b270979214ce109fe",
+          "6f7d0f63bb10cb0565fc6947b8912038eb0a46bb7e1e7d52f7e9ff31ff96ac65",
+          "48628be43491b43dcd1467389d4b8c861e1f48e9c2baf140f3f8336293d48045",
+          "7ff6dbb068a12a77bd02806cb398acd45f8e70af6e7ceefc8b06a9f6e5453175",
+          "678f7e4c6c8322f7f284c898c19c6a60c30c2a6e3be71379cb61187ce172dbc0",
+          "21358e608993ece0c2a68591f07539c27fde0c0322336ea897e2014aca6d5960",
+          "4fbd799eac612ef3afddbdf14ca630b856e28b9bc4c3d90beca7138919ffd5b1",
+          "9a9279e09bdf7d21d978828420ce111471f653c9b68146eac004ac5b05e8ff8f",
+          "9958cd247de3c4d959190ddda7d8e62e280f7dd48915a2e35941c42f1a4ba9aa",
+          "035556b9bef2e7f3d398796cdf2b45925c15051548b6e4f4c75b59c48e1f1f86",
+          "db4dcba7c35857630c71efcdd0affacfb9d75bc8267395aded23d3ce16143b47",
+          "bde319b7d0e1d7746148ae2ba6a6eb4e009487020a18e792df6ebc60d19b2bc9",
+          "8f571ee7dead58a3d2072d07feb96a569181c4911b929a3f6fdc5f10ef5e7824",
+          "866230f06658b1f0716285ba8c619ee1e1e716c133cea032b70f3ec083ed7e34",
+          "e75f14d3135a7641bc570c5e4d1b1ff55506f8e161abda2bad03918999a3ce83",
+          "79d83cd182646485cf30b935a8f879d5640a7233c3b35823d263477a27d5a878",
+          "5bfc23f838164199f635e0e9f88f23c3f7b60832b9af6957a066f8286e10657b"
+        ],
+        "mechanism_verified": null,
+        "resources_complete": null
+      }
+    },
+    "reports": [
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.a1.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.b1.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.a2.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.b2.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.a3.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.b3.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.a4.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.b4.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.a5.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.b5.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.a6.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.b6.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.a7.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.b7.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.a8.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.b8.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.a9.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.b9.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.a10.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.b10.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.a11.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.b11.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.a12.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.b12.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.a13.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.b13.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.a14.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.b14.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.a15.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.b15.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.a16.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.b16.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.a17.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.b17.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.a18.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.b18.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.a19.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.b19.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.a20.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/pow/autoresearch/.runs/latest/wf_log10x8.b20.json"
+    ]
+  }
+}

--- a/src/prover/pcs/proof_of_work.zig
+++ b/src/prover/pcs/proof_of_work.zig
@@ -1,6 +1,25 @@
 //! Prover-side proof-of-work nonce search policy.
 
+const std = @import("std");
+const stwo_core = @import("stwo_core");
+const work_pool_mod = @import("../work_pool.zig");
+
+const Blake2sChannel = stwo_core.channel.blake2s.Blake2sChannel;
+const Blake2sHasher = stwo_core.crypto.blake2s_backend.Blake2sHasher;
+
 pub fn grind(channel: anytype, pow_bits: u32) u64 {
+    if (pow_bits == 0) return 0;
+
+    if (comptime @TypeOf(channel.*) == Blake2sChannel) {
+        // Preserve the dedicated PoW worker override. The default path reuses
+        // the prover pool instead of creating and joining OS threads here.
+        if (!std.process.hasEnvVarConstant("STWO_ZIG_POW_WORKERS")) {
+            if (work_pool_mod.getGlobalPool()) |pool| {
+                return grindBlake2sInPool(channel.*, pow_bits, pool);
+            }
+        }
+    }
+
     // Prefer a channel's cached or parallel implementation when it provides one.
     if (@hasDecl(@TypeOf(channel.*), "grind")) {
         return channel.grind(pow_bits);
@@ -10,4 +29,133 @@ pub fn grind(channel: anytype, pow_bits: u32) u64 {
     while (true) : (nonce += 1) {
         if (channel.verifyPowNonce(pow_bits, nonce)) return nonce;
     }
+}
+
+const PowWork = struct {
+    prefix: [32]u8,
+    pow_bits: u32,
+    start: u64,
+    stride: u64,
+    found: *std.atomic.Value(u64),
+
+    fn run(self: *const PowWork) void {
+        var nonce = self.start;
+        while (nonce < self.found.load(.monotonic)) {
+            if (verifyNonceWithPrefix(self.prefix, nonce, self.pow_bits)) {
+                _ = self.found.fetchMin(nonce, .release);
+                return;
+            }
+            nonce = std.math.add(u64, nonce, self.stride) catch return;
+        }
+    }
+};
+
+fn grindBlake2sInPool(
+    channel: Blake2sChannel,
+    pow_bits: u32,
+    pool: *work_pool_mod.WorkPool,
+) u64 {
+    const worker_count = pool.workerCount();
+    std.debug.assert(worker_count >= 2);
+    std.debug.assert(worker_count <= work_pool_mod.MAX_WORKERS);
+
+    const prefix = computePowPrefix(channel, pow_bits);
+    var found = std.atomic.Value(u64).init(std.math.maxInt(u64));
+    var jobs: [work_pool_mod.MAX_WORKERS]PowWork = undefined;
+    for (jobs[0..worker_count], 0..) |*job, worker_index| {
+        job.* = .{
+            .prefix = prefix,
+            .pow_bits = pow_bits,
+            .start = @intCast(worker_index),
+            .stride = @intCast(worker_count),
+            .found = &found,
+        };
+    }
+
+    var wait_group: std.Thread.WaitGroup = .{};
+    for (jobs[1..worker_count]) |*job| {
+        pool.spawnWg(&wait_group, PowWork.run, .{@as(*const PowWork, job)});
+    }
+    PowWork.run(&jobs[0]);
+    wait_group.wait();
+    return found.load(.acquire);
+}
+
+fn computePowPrefix(channel: Blake2sChannel, pow_bits: u32) [32]u8 {
+    var input: [52]u8 = [_]u8{0} ** 52;
+    std.mem.writeInt(u32, input[0..4], Blake2sChannel.POW_PREFIX, .little);
+    @memcpy(input[16..48], channel.digestBytes()[0..]);
+    std.mem.writeInt(u32, input[48..52], pow_bits, .little);
+    return Blake2sHasher.hashFixedSingleBlock(input.len, &input);
+}
+
+fn verifyNonceWithPrefix(prefix: [32]u8, nonce: u64, pow_bits: u32) bool {
+    var input: [40]u8 = undefined;
+    @memcpy(input[0..32], prefix[0..]);
+    std.mem.writeInt(u64, input[32..40], nonce, .little);
+    const digest = Blake2sHasher.hashFixedSingleBlock(input.len, &input);
+    return trailingZeroBits(digest[0..16]) >= pow_bits;
+}
+
+fn trailingZeroBits(bytes: []const u8) u32 {
+    var total: u32 = 0;
+    for (bytes) |byte| {
+        if (byte == 0) {
+            total += 8;
+        } else {
+            total += @ctz(byte);
+            break;
+        }
+    }
+    return total;
+}
+
+fn grindBlake2sResiduesForTest(
+    channel: Blake2sChannel,
+    pow_bits: u32,
+    worker_count: usize,
+) u64 {
+    const prefix = computePowPrefix(channel, pow_bits);
+    var found = std.atomic.Value(u64).init(std.math.maxInt(u64));
+    for (0..worker_count) |worker_index| {
+        const job = PowWork{
+            .prefix = prefix,
+            .pow_bits = pow_bits,
+            .start = @intCast(worker_index),
+            .stride = @intCast(worker_count),
+            .found = &found,
+        };
+        job.run();
+    }
+    return found.load(.acquire);
+}
+
+test "proof of work: pooled residue search preserves the lowest nonce" {
+    var channel = Blake2sChannel{};
+    channel.mixU32s(&.{ 0x1234_5678, 0x9abc_def0 });
+
+    for ([_]u32{ 1, 4, 8, 10 }) |pow_bits| {
+        const expected = channel.grind(pow_bits);
+        for ([_]usize{ 1, 2, 5, 16 }) |worker_count| {
+            const actual = grindBlake2sResiduesForTest(
+                channel,
+                pow_bits,
+                worker_count,
+            );
+            try std.testing.expectEqual(expected, actual);
+            try std.testing.expect(channel.verifyPowNonce(pow_bits, actual));
+        }
+    }
+}
+
+test "proof of work: pooled residue search binds the transcript" {
+    var first = Blake2sChannel{};
+    first.mixU32s(&.{1});
+    var second = Blake2sChannel{};
+    second.mixU32s(&.{2});
+
+    const first_nonce = grindBlake2sResiduesForTest(first, 8, 7);
+    const second_nonce = grindBlake2sResiduesForTest(second, 8, 7);
+    try std.testing.expectEqual(first.grind(8), first_nonce);
+    try std.testing.expectEqual(second.grind(8), second_nonce);
 }


### PR DESCRIPTION
## What changed

Routes raw Blake2s proof-of-work search through the existing prover worker pool and attaches the 2026-07-28 research record with claimed verdict and sanitized transcripts.

## Why

Fresh thread creation is fixed overhead in the small proof. The candidate preserves the globally lowest valid nonce and retains the original path for unsupported policies.

## Evidence

Exact-frontier local S3 screen: R 0.956784, 95% portfolio CI [0.921421, 0.980501], 20 paired rounds, proof bytes identical, Rust oracle passed. This does not clear the configured significance CI threshold and is presented as advisory, not promotable. The repository submission validator passes.