### PR TITLE
Share radix-8 twiddles across forward FFT batches

### DIFF
--- a/autoresearch/submissions/2026-07-28-radix8-twiddle-reuse/delta.json
+++ b/autoresearch/submissions/2026-07-28-radix8-twiddle-reuse/delta.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "cfd47be98a10",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/prover/poly/circle/fft_kernels.zig": "sha256:97173d2e0185dfca01aafd46c17df0d03b745243e6ac91d9c7b40be4568ef6b5",
+    "src/prover/poly/circle/fft_radix8.zig": "sha256:26ca6ee86379ff68bd92dfa89b4f843a25a2b46974928860b338d00798cf5231",
+    "src/prover/poly/circle/transforms.zig": "sha256:0e727d59dd74b4f058e765806fbe28b973d16638e026999a067262512f548480"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "a89ce169a4ba6ee8b27c4e586c0252804538de4f1db5b4dc70240e266b311675",
+      "captured_by": "submitter"
+    },
+    "transcripts/session-02.md": {
+      "sha256": "3735af8d264a544246e1225bb4ba3e14373c827359d189e706e8297215565998",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-28-radix8-twiddle-reuse/delta.json
+++ b/autoresearch/submissions/2026-07-28-radix8-twiddle-reuse/delta.json
@@ -9,7 +9,7 @@
   "declared_scope": "s3",
   "files": {
     "src/prover/poly/circle/fft_kernels.zig": "sha256:97173d2e0185dfca01aafd46c17df0d03b745243e6ac91d9c7b40be4568ef6b5",
-    "src/prover/poly/circle/fft_radix8.zig": "sha256:26ca6ee86379ff68bd92dfa89b4f843a25a2b46974928860b338d00798cf5231",
+    "src/prover/poly/circle/fft_radix8.zig": "sha256:90f78995063a9bf90e072ff14e3db231e256d49d9c8791f198646e91cd171576",
     "src/prover/poly/circle/transforms.zig": "sha256:0e727d59dd74b4f058e765806fbe28b973d16638e026999a067262512f548480"
   },
   "transcripts": {
@@ -19,6 +19,10 @@
     },
     "transcripts/session-02.md": {
       "sha256": "3735af8d264a544246e1225bb4ba3e14373c827359d189e706e8297215565998",
+      "captured_by": "submitter"
+    },
+    "transcripts/session-03.md": {
+      "sha256": "998062e4984e5d5a1826129a55cbc2eabe2450d7c73092437a0e9fa8d614feb9",
       "captured_by": "submitter"
     }
   },

--- a/autoresearch/submissions/2026-07-28-radix8-twiddle-reuse/note.md
+++ b/autoresearch/submissions/2026-07-28-radix8-twiddle-reuse/note.md
@@ -2,9 +2,11 @@
 
 ## Model and harness
 
-Model: OpenAI Codex. Candidate `2a74f0a152c6b43fc6873ccc45ee185195cc50ae`
-is a source-only descendant of frontier
-`cfd47be98a10598b90a898e787e5cd1c674b09e7`. Qualification target:
+Model: OpenAI Codex. The measured candidate
+`2a74f0a152c6b43fc6873ccc45ee185195cc50ae` is a source-only descendant
+of frontier `cfd47be98a10598b90a898e787e5cd1c674b09e7`. The publication branch
+adds a post-screen correctness repair for empty batches; the local performance
+numbers below remain bound to the measured candidate. Qualification target:
 `core_cpu/small/time`, Zig 0.15.2, ReleaseFast, paired S3.
 
 ## Hypothesis
@@ -23,7 +25,9 @@ The candidate adds forward-only batch kernels in
 `fft_kernels.zig`, and uses them from the batched transform scheduler.
 Single-buffer and inverse paths are unchanged. Both ordinary transforms and
 duplicated-half expansion are covered by randomized differential tests against
-independent packed radix-8 calls.
+independent packed radix-8 calls. The publication repair also makes an empty
+forward batch an explicit no-op before geometry or twiddle work and locks the
+observed RISC-V quotient geometry into a regression test.
 
 ## Results
 
@@ -36,6 +40,16 @@ confirmed-neutral. The screen used `--guards none` to avoid the known
 generic-runner guard-budget defect; it is not a qualification receipt,
 attestation, judged result, or improvement claim.
 
+The first publication CI run exposed a separate correctness defect in the
+unmeasured RISC-V product path: the transaction-engine proof test invoked the
+batch helper with zero buffers at `log = 7`, `highest_stage = 6`, and 64
+twiddles. The original helper asserted a non-empty batch in checked builds and
+continued into batch setup in ReleaseFast, where CI terminated with signal 11.
+After the explicit empty-batch return and regression test were added, the full
+RISC-V CPU product suite passed in both Debug and the CI-equivalent ReleaseFast
+configuration. This is correctness evidence for the publication repair, not a
+new performance measurement.
+
 ## Caveats
 
 The mechanism helps only when multiple buffers share a forward transform.
@@ -43,4 +57,6 @@ Its extra loop structure may be neutral for very small batches or pressure
 instruction cache on some hosts. It is therefore isolated from larger FFT
 fusion ideas. The measured small-class result falsifies a material whole-proof
 gain on this host; any central record must retain that neutral status unless an
-independent judged run establishes otherwise.
+independent judged run establishes otherwise. Because the timing verdict is
+bound to the pre-repair measured commit, the repaired publication tree must be
+re-measured before anyone attributes a performance ratio to the repair itself.

--- a/autoresearch/submissions/2026-07-28-radix8-twiddle-reuse/note.md
+++ b/autoresearch/submissions/2026-07-28-radix8-twiddle-reuse/note.md
@@ -1,0 +1,46 @@
+# Share radix-8 twiddles across forward FFT batches
+
+## Model and harness
+
+Model: OpenAI Codex. Candidate `2a74f0a152c6b43fc6873ccc45ee185195cc50ae`
+is a source-only descendant of frontier
+`cfd47be98a10598b90a898e787e5cd1c674b09e7`. Qualification target:
+`core_cpu/small/time`, Zig 0.15.2, ReleaseFast, paired S3.
+
+## Hypothesis
+
+Independent coefficient buffers share transform geometry and the same twiddle
+tree. The existing scheduler invokes the packed radix-8 kernel separately for
+each buffer, reloading the same seven packed twiddles for every buffer and
+group. Hoisting those loads across the buffer batch should reduce repeated
+addressing and cache traffic while leaving butterfly order and proof bytes
+unchanged.
+
+## Changes
+
+The candidate adds forward-only batch kernels in
+`src/prover/poly/circle/fft_radix8.zig`, exports them through
+`fft_kernels.zig`, and uses them from the batched transform scheduler.
+Single-buffer and inverse paths are unchanged. Both ordinary transforms and
+duplicated-half expansion are covered by randomized differential tests against
+independent packed radix-8 calls.
+
+## Results
+
+Hosted qualification is pending the upstream workflow repair. A fresh local
+advisory S3 screen against the exact canonical frontier completed 20 paired
+rounds with `R = 1.001324` and portfolio CI `[0.980664, 1.022294]`. All five
+local gates passed, the pinned Rust oracle verified the scored workload, and
+proof bytes were identical. The harness classifies the result as
+confirmed-neutral. The screen used `--guards none` to avoid the known
+generic-runner guard-budget defect; it is not a qualification receipt,
+attestation, judged result, or improvement claim.
+
+## Caveats
+
+The mechanism helps only when multiple buffers share a forward transform.
+Its extra loop structure may be neutral for very small batches or pressure
+instruction cache on some hosts. It is therefore isolated from larger FFT
+fusion ideas. The measured small-class result falsifies a material whole-proof
+gain on this host; any central record must retain that neutral status unless an
+independent judged run establishes otherwise.

--- a/autoresearch/submissions/2026-07-28-radix8-twiddle-reuse/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-28-radix8-twiddle-reuse/transcripts/session-01.md
@@ -1,0 +1,43 @@
+# Session 01: batched radix-8 twiddle reuse
+
+## Search rationale
+
+Four Elicit searches were used as a discovery layer across FFT batching,
+fixed-tree scheduling, FRI folding, and fine-grained parallel work. Primary
+sources on FFT locality and fold-and-batch methods supported examining shared
+schedule data, but the broad mechanisms were mostly already present on
+canonical main. The surviving source-level gap was narrower: current
+`evaluateBuffersTailLayers` loops over buffers and calls the same packed
+three-layer forward kernel with identical domain geometry and twiddle slices.
+
+## Alternatives and falsifiers
+
+Changing radix, proof layout, inverse order, or transcript-visible data was
+rejected because it would enlarge the proof-equivalence surface. A more general
+multi-direction batch kernel was also rejected: inverse transforms have
+different normalization and are not the measured duplication. The candidate
+therefore hoists only the repeated forward twiddle loads and preserves each
+buffer's existing butterfly sequence.
+
+Falsifiers are any mismatch against independent transforms, changed proof
+bytes, a regression guard above budget, or a paired result whose confidence
+interval does not clear the significance rule.
+
+## Implementation reasoning
+
+For each fused three-layer group, the batch kernel loads the seven packed
+twiddles once: one for the first stage, two for the second, and four for the
+third. It then applies the unchanged tuple butterflies to every independent
+buffer. The duplicated-half variant retains reverse group traversal and reads
+the initialized lower half exactly as the prior per-buffer kernel did.
+Randomized tests compare two distinct buffers at multiple stages and separately
+check duplicated-half expansion.
+
+## Current state
+
+The immutable branch touches three allowed source files and passes ancestry,
+mode, locked-tree, patch-size, and local correctness gates. It is published on
+the participant fork. Hosted qualification has not run because the canonical
+Ubuntu workflow currently builds the unrelated Metal group. Upstream PR 118
+repairs that infrastructure. Until an attested paired S3 receipt exists, this
+is a candidate mechanism, not a record.

--- a/autoresearch/submissions/2026-07-28-radix8-twiddle-reuse/transcripts/session-02.md
+++ b/autoresearch/submissions/2026-07-28-radix8-twiddle-reuse/transcripts/session-02.md
@@ -1,0 +1,31 @@
+# Session 02: exact-frontier local objective screen
+
+## Run design
+
+The current-frontier candidate
+`2a74f0a152c6b43fc6873ccc45ee185195cc50ae` was paired against
+`cfd47be98a10598b90a898e787e5cd1c674b09e7` for 20 S3 rounds on
+`core_cpu/small/time` with pinned Zig 0.15.2. The scored objective,
+correctness checks, proof-byte comparison, resource vectors, and pinned Rust
+oracle remained active. Automatic guards were disabled only to avoid the
+separately diagnosed generic-runner wall-budget defect, so this run is
+advisory rather than qualification evidence.
+
+## Result and interpretation
+
+The screen completed with `R = 1.001324`, workload CI
+`[0.980883, 1.021910]`, and portfolio CI `[0.980664, 1.022294]`.
+All five local gates passed, the Rust oracle verified the workload, and every
+cross-arm proof digest was identical. The harness classified the candidate as
+confirmed-neutral.
+
+This falsifies the hypothesis that shared forward twiddle loads create a
+material whole-proof gain for the current small workload on this host. The
+kernel may still reduce repeated loads internally, but any effect is below
+whole-proof noise or offset by the extra batch-loop structure.
+
+## Evidence boundary
+
+No attestation or qualification receipt was generated, and no improvement is
+claimed. The neutral result is retained because rejected mechanisms are part
+of the research record and should not be silently recycled as winners.

--- a/autoresearch/submissions/2026-07-28-radix8-twiddle-reuse/transcripts/session-03.md
+++ b/autoresearch/submissions/2026-07-28-radix8-twiddle-reuse/transcripts/session-03.md
@@ -1,0 +1,56 @@
+# Session 03: empty-batch correctness repair
+
+## Failure and initial hypotheses
+
+The first publication CI run passed every focused Linux lane except
+`riscv_cpu`. Its transaction-engine proof test terminated with signal 11 under
+Zig 0.15.2 ReleaseFast after the test runner reported 392 tests passed. The
+same branch's native, aggregate, prover, static, package, oracle, CUDA-static,
+and macOS lanes passed, which localized the defect to a RISC-V proof geometry
+not exercised by the original local objective screen.
+
+Temporary checked-build assertions were placed at the batched radix-8 boundary
+to distinguish three possibilities: non-canonical input field values, a bad
+twiddle load, or corruption created by the reordered butterfly traversal. The
+checked product run stopped before arithmetic at the helper's existing
+non-empty-batch assertion. A temporary diagnostic panic then recorded the
+exact call as zero buffers, `log = 7`, `highest_stage = 6`, 64 twiddles, and
+ordinary rather than duplicated-half mode.
+
+That evidence corrected the initial suspicion of arithmetic corruption. The
+twiddle indices implied by the captured geometry are within the 64-element
+tree; the invalid assumption was that every batched transform contains at
+least one buffer. The higher-level transform contract already treats an empty
+collection as a no-op.
+
+## Repair and rejected alternatives
+
+The final change replaces the non-empty assertion with an immediate return.
+It occurs before length, geometry, group, or twiddle setup, so both checked and
+optimized builds implement the same empty-batch semantics.
+
+Two broader alternatives were rejected:
+
+- Special-casing only the RISC-V memory-commitment caller would leave the
+  reusable batch helper inconsistent with other collection transforms.
+- Merely deleting the assertion would make Debug continue but would retain
+  unnecessary setup in ReleaseFast and would not encode the no-op contract.
+
+All temporary canonical-value checks, index panics, and diagnostic helpers were
+removed. The permanent regression invokes both public forward-batch entry
+points with the observed `7/6/64` geometry and no buffers. Existing randomized
+two-buffer differential coverage remains unchanged.
+
+## Verification and evidence boundary
+
+The complete RISC-V CPU product target passed locally in Debug. The exact
+CI-equivalent command also passed with `test-riscv-cpu-product`,
+`stwo-zig-riscv-cpu`, `-Doptimize=ReleaseFast`, and `-j2`. Both runs passed the
+RISC-V product marker check and the 365-source transitive closure before
+completing the proof suite. `git diff --check` also passed.
+
+The published performance verdict remains the confirmed-neutral advisory
+screen measured at candidate `2a74f0a152c6b43fc6873ccc45ee185195cc50ae`.
+The correctness repair was not re-benchmarked and therefore does not inherit
+that timing ratio as a fresh measurement. No attestation, judged result,
+promotion, or performance improvement is claimed from this session.

--- a/autoresearch/submissions/2026-07-28-radix8-twiddle-reuse/verdict.json
+++ b/autoresearch/submissions/2026-07-28-radix8-twiddle-reuse/verdict.json
@@ -1,0 +1,349 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "596f2ddfb88b",
+  "repo_commit": "2a74f0a152c6",
+  "predecessor_commit": "cfd47be98a10",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "d00bf0abb109",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 6.86
+    }
+  },
+  "search_health": {
+    "schema_version": 1,
+    "decision": {
+      "schema_version": 1,
+      "board": "core_cpu",
+      "workload_class": "small",
+      "trailing_window": 8,
+      "trailing_evidence_count": 1,
+      "trailing_median_gradient_snr": 0.0,
+      "gradient_snr_threshold": 2.0,
+      "configured_rounds": 15,
+      "auto_boost_rounds": 5,
+      "maximum_rounds": 25,
+      "target_rounds": 20,
+      "workload_count": 1,
+      "class_wall_deadline_seconds": 240.0,
+      "estimated_seconds_per_round": 4.047260127732685,
+      "deadline_round_limit": 59,
+      "auto_boost_applied": true,
+      "auto_boost_reason": "trailing_median_below_threshold",
+      "recorded_before_measurement": true
+    },
+    "decision_sha256": "sha256:9db7f740061d3ef93711d44da55d5ee24cfe4fa0e2efd35e759d868425be2a53",
+    "actual_rounds": 20,
+    "actual_rounds_per_workload": {
+      "wf_log10x8": 20
+    },
+    "objective_wall_seconds": 3.4539882079989184,
+    "measurement_wall_seconds": 32.019344458007254,
+    "measurement_wall_hours": 0.00889426234944646,
+    "gradient_snr": null,
+    "credited_ln_improvement": null,
+    "credited_ln_improvement_per_measurement_hour": null,
+    "credit_status": "pending_ledger_adjudication",
+    "decision_record": "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/search-health-decision.json"
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned correctness oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "native mechanism telemetry policy unchanged"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.4772 vs targeted budget x1.02; matrix row upper CIs 1/1 within budget x1.05; request ratios 1/1 present rows within budget x1.05; resource vectors 1/1 within named budgets"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log10x8": {
+        "r": 1.001324,
+        "ci": [
+          0.980883,
+          1.02191
+        ],
+        "rounds": 20,
+        "a_median_ms": 1.334208,
+        "b_median_ms": 1.330875,
+        "request_ratio": 1.007228,
+        "rss_ratio": 0.998741,
+        "resources": {
+          "energy_j": {
+            "ratio": 1.002502,
+            "ci": [
+              0.986006,
+              1.01845
+            ],
+            "observations": 20,
+            "candidate": 0.105832175
+          },
+          "peak_rss_mib": {
+            "ratio": 0.998741,
+            "ci": [
+              0.996216,
+              1.001263
+            ],
+            "observations": 20,
+            "candidate": 6.18804931640625
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 24965.0
+          }
+        },
+        "mechanism_verified": null,
+        "proof_bytes": 24965,
+        "measurement_seconds": 3.096256,
+        "resources_complete": null
+      }
+    },
+    "R_geomean": 1.001324,
+    "portfolio": {
+      "ci_method": "independent_workload_round_bootstrap_percentile_v1",
+      "ci_level": 0.95,
+      "bootstrap_iterations": 4000,
+      "seed": 2000059846,
+      "ci": [
+        0.980664,
+        1.022294
+      ],
+      "prove_ms_method": "geometric_mean_candidate_workload_medians_ms_v1",
+      "b_median_ms_geomean": 1.330875,
+      "proof_bytes_method": "rounded_geometric_mean_candidate_proof_bytes_v1",
+      "proof_bytes": 24965,
+      "measurement_seconds": 3.096256,
+      "measurement_rounds": 20
+    },
+    "theta": 0.037308,
+    "aa_dispersion": 0.018654,
+    "significant": false,
+    "neutral": true,
+    "promotion_significance": {
+      "eligible": true,
+      "method": "independent_workload_round_bootstrap_percentile_v1",
+      "reason": "prove-time objective uses the deterministic workload portfolio CI"
+    },
+    "resource_portfolio": {
+      "peak_rss_mib": {
+        "ratio_geomean": 0.9987406737258018,
+        "upper_ci_geomean": 1.001262514178626,
+        "candidate_geomean": 6.18804931640625
+      },
+      "energy_j": {
+        "ratio_geomean": 1.0025020244726401,
+        "upper_ci_geomean": 1.0184499036274963,
+        "candidate_geomean": 0.105832175
+      },
+      "proof_bytes": {
+        "ratio_geomean": 1.0,
+        "upper_ci_geomean": 1.0,
+        "candidate_geomean": 24965.0
+      }
+    }
+  },
+  "tiebreakers": {
+    "rss_ratio": 0.998741,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": 0.105832175,
+    "proof_bytes": 24965.0
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "wf_log10x8",
+      "verified": true,
+      "oracle": "pinned-rust-stwo",
+      "artifact_sha256": "4cabcca685cb0c4168d136ce3fea0f742b0b6a87d6b98beb3e048301f4d7b4e2"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "cuda",
+      "reason": "core_cuda is staged only: all six Native AIR families are required, but only wide Fibonacci is exact and release-ready; exact family semantics, the stwo-perf CUDA report adapter, locked-host A/A calibration, pinned Rust verification, and complete structural coverage are not yet release-gated."
+    },
+    {
+      "group": "pr6_supremacy",
+      "reason": "PR6 Supremacy remains disabled until every exact workload port, log22 oracle vector, both timing boundaries, locked-M5 statistical gate, and authenticated judged verdict are complete."
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "wf_log10x8": {
+        "round_ratios": [
+          1.047933,
+          1.046054,
+          0.914212,
+          1.013191,
+          0.922011,
+          1.082445,
+          1.056463,
+          0.948836,
+          1.056397,
+          0.964208,
+          0.997121,
+          0.981457,
+          0.996505,
+          1.038974,
+          0.980883,
+          0.992219,
+          1.049632,
+          0.993569,
+          0.956061,
+          0.988191
+        ],
+        "proof_digest": "91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700",
+        "request_ratio": 1.007228,
+        "rss_ratio": 0.998741,
+        "resources": {
+          "energy_j": {
+            "ratio": 1.002502,
+            "ci": [
+              0.986006,
+              1.01845
+            ],
+            "observations": 20,
+            "candidate": 0.105832175
+          },
+          "peak_rss_mib": {
+            "ratio": 0.998741,
+            "ci": [
+              0.996216,
+              1.001263
+            ],
+            "observations": 20,
+            "candidate": 6.18804931640625
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 24965.0
+          }
+        },
+        "report_sha256s": [
+          "336a02e960d552d4ae10a2f1baa23e72d6e5d0e3e381a86567a9d4af0599597f",
+          "7f613eebbf6173c979c5358748df89b360e264ca48319bd332a61e187dccf582",
+          "ce61b0c68ad63a0173ac65b03ba7b5e79ce50f85e84ab9216bba4f360fa2e7a1",
+          "a327068b6b54b32b96dac33602c992903a87f60002ee49a5422947f29fc5982c",
+          "e3bdf247237779d5010e2a35f2095b0cd9704b8d116cba413badffac6841b2bb",
+          "7ad2f7f236a5271b72954c848e49a55c4b83852f59a771f074dfd09bab7a6023",
+          "d3fef40e44e23f08008fe9d5b5aeb2e34f780e012bd78bc157d903db04e0829d",
+          "e8b63998fde1c07e2c2a0e976c664517b8f86984e87fa4328d137bd5509d6fa9",
+          "269cf1dac525ccbfb33ea9a0c5e0dff46777c7bb695ad8f6a3ebacb8cd33944b",
+          "b36e0531a7fbca92508d3f0eeb0de9b32afa5d82ac3efe0e71eaacc5dfd97590",
+          "8b405c779cf2e14a53c88d5b0d61ed0bb833043c889b57f74779b776896a9e09",
+          "33d6166f67c2736461aaeb29762fefe96c905fe8ae9a4a315acf6e6cad10c943",
+          "d042898af07d8779a58d0167761ea45e8a35ca001d15dd40ec75d4e87141efaf",
+          "d7be00b7ff6321c2c82387c377b635a29ae26b449a62d09cf23af860f3ac38fc",
+          "7c21151e9eeb181fa3b7e3e022bc204c18ccfdd1c5963106577c2d927a80304f",
+          "03926bf730b054fe1502acc10a46f32496118408da1adc6b59537d27ed293c07",
+          "9d924d51149b8b8ea2b67bcb2bcd624970793c3061ef5ff696f98a3384d5b606",
+          "9bbbeee0d15b2b1e5026d0265f41b8dfa116c4db046f457868cb0ade82390658",
+          "d93b2df4b99cf77933878521baf0e81ec6830276f54752e48ea04f6914fd6c16",
+          "daa01910082cd2eb9d4b529b5520c67064e8dc6c2486e9fe0e969aa1cc5fe4a1",
+          "0ec126b19e26b1492567c10eef4c6f4152a0a0893fbd57ae33377fa5f2819c2f",
+          "00412ea41061eeda411ebcfd424ff0c45bcaaeb4e96e7ac4419f007f43642c97",
+          "a79eda78da61cbcefa2879463d3a04ecc18f11f987d9e66e492ca2473314d121",
+          "cd9244e3790776df49369135de5f48ab47da13758462611c79210a0b0c47a7c5",
+          "bf58d62858b9f897a825d8da9aa564185dad416cba7c1a1f5eb90dd64105daf1",
+          "6798934633da7f7d196834ca84a3567717bd8a4d1b7d4c57dad5f7f220a07bdc",
+          "a0b45c83be6ab7a4f15c9e7c11d22790923464b669473c101833fc6803b9e6f6",
+          "d23cb50336e380434009e98db2db190e149c7c9a094d927d988b00e87fd0e12a",
+          "f593cfee58411382113bc907d83d4da083a851f75c22b4eaeacae79710c2d3aa",
+          "f3249291a8ab1dc730ef5a9ee76489793ffc82b21153bbff35f680c0a8cf6ad2",
+          "da65cf1d4b64fb0d3f38464653e80128f761fc6d6e36e495c08e9192ad6f7c71",
+          "ee0b7f87f2cd4e0797c5303b5aa696f38b1c0b8acbd5aa77537ef2fcf69e3f2c",
+          "404e87afa7f28d6b118b0dc1b90cfeb7248d14631222eb16d24fbfc020be858e",
+          "406913116ede0818ca51ab7932c5b3bf772b83f676fca370cd361403b34e796c",
+          "9cb5aa4551c35b0583de949b17ba763f687626896cb4246ebe6b0fa6a52f7a6b",
+          "a1135370d3287ab3f8505d48d120caf77356f0f8fbea174184983f7eec924dc2",
+          "1744365ecaaef8be4ed6a989767ba8094dbc58e7d5f4e0c96863a68c40b1ca12",
+          "bb8ab57a60edd9d3bb3c02d2d5dd4275900448f4f1382729ea8f0d4d7a45f6b2",
+          "91e028b9d704902cd490b1c4f9d39955a1ae5e5eb9bd213094dce8845df53d97",
+          "b8530a9d4b7b2ba39eef0297bb4aa05775938d81e04adf1dc2c2946ec285c7a0"
+        ],
+        "mechanism_verified": null,
+        "resources_complete": null
+      }
+    },
+    "reports": [
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.a1.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.b1.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.a2.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.b2.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.a3.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.b3.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.a4.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.b4.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.a5.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.b5.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.a6.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.b6.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.a7.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.b7.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.a8.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.b8.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.a9.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.b9.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.a10.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.b10.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.a11.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.b11.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.a12.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.b12.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.a13.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.b13.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.a14.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.b14.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.a15.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.b15.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.a16.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.b16.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.a17.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.b17.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.a18.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.b18.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.a19.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.b19.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.a20.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/radix8/autoresearch/.runs/latest/wf_log10x8.b20.json"
+    ]
+  }
+}

--- a/src/prover/poly/circle/fft_kernels.zig
+++ b/src/prover/poly/circle/fft_kernels.zig
@@ -130,7 +130,9 @@ pub inline fn fftLayerLoopForwardM31(
 
 pub const canFuseThreeLayersPacked = radix8.canFuseThreeLayersPacked;
 pub const fftThreeLayersForwardPackedM31 = radix8.forward;
+pub const fftThreeLayersForwardPackedM31Batch = radix8.forwardBatch;
 pub const fftThreeLayersForwardPackedM31FromDuplicatedHalf = radix8.forwardFromDuplicatedHalf;
+pub const fftThreeLayersForwardPackedM31BatchFromDuplicatedHalf = radix8.forwardBatchFromDuplicatedHalf;
 pub const fftThreeLayersInversePackedM31 = radix8.inverse;
 pub const fftThreeLayersInversePackedM31Normalized = radix8.inverseNormalized;
 

--- a/src/prover/poly/circle/fft_radix8.zig
+++ b/src/prover/poly/circle/fft_radix8.zig
@@ -103,6 +103,88 @@ fn run(
     }
 }
 
+fn runForwardBatch(
+    values_batch: []const []M31,
+    log_size: u32,
+    highest_stage: u32,
+    twiddles: []const M31,
+    comptime duplicate_upper_from_lower: bool,
+) void {
+    std.debug.assert(values_batch.len != 0);
+    std.debug.assert(log_size < @bitSizeOf(usize));
+    const values_len = @as(usize, 1) << @intCast(log_size);
+    for (values_batch) |values| std.debug.assert(values.len == values_len);
+    const pair_count = values_len / 2;
+    std.debug.assert(twiddles.len >= pair_count);
+
+    const lowest_stage = highest_stage - 2;
+    std.debug.assert(canFuseThreeLayersPacked(lowest_stage));
+    std.debug.assert(highest_stage >= 2 and highest_stage < log_size);
+
+    const distance = @as(usize, 1) << @intCast(lowest_stage);
+    const group_count = values_len >> @intCast(lowest_stage + 3);
+    std.debug.assert(!duplicate_upper_from_lower or group_count == 2);
+    const PW = m31.PACK_WIDTH;
+
+    var group_cursor: usize = if (duplicate_upper_from_lower) group_count else 0;
+    while (if (duplicate_upper_from_lower) group_cursor > 0 else group_cursor < group_count) {
+        if (duplicate_upper_from_lower) group_cursor -= 1;
+        const group = group_cursor;
+        const base = group << @intCast(lowest_stage + 3);
+        const load_base = if (duplicate_upper_from_lower and group == 1) 0 else base;
+
+        // Every buffer uses the same transform geometry and twiddle tree.
+        // Load each stage's 1+2+4 packed twiddles once for the whole group.
+        var group_twiddles: [7]m31.PackedM31 = undefined;
+        inline for (0..3) |step| {
+            const substage = highest_stage - @as(u32, @intCast(step));
+            const half_span: usize = @as(usize, 4) >> @intCast(step);
+            const block_count = 4 / half_span;
+            const packed_offset = (@as(usize, 1) << @intCast(step)) - 1;
+            const twiddle_offset = pair_count -
+                (@as(usize, 1) << @intCast(log_size - substage));
+            inline for (0..block_count) |block| {
+                group_twiddles[packed_offset + block] = @splat(
+                    twiddles[twiddle_offset + group * block_count + block].v,
+                );
+            }
+        }
+
+        for (values_batch) |values| {
+            var lane: usize = 0;
+            while (lane < distance) : (lane += PW) {
+                var tuple: [8]m31.PackedM31 = undefined;
+                inline for (0..8) |item| {
+                    tuple[item] = m31.loadPacked(values.ptr + load_base + lane + item * distance);
+                }
+
+                inline for (0..3) |step| {
+                    const half_span: usize = @as(usize, 4) >> @intCast(step);
+                    const block_count = 4 / half_span;
+                    const packed_offset = (@as(usize, 1) << @intCast(step)) - 1;
+                    inline for (0..block_count) |block| {
+                        const twiddle = group_twiddles[packed_offset + block];
+                        const block_start = block * (half_span * 2);
+                        inline for (0..half_span) |item| {
+                            const lo = block_start + item;
+                            const hi = lo + half_span;
+                            const lhs = tuple[lo];
+                            const product = m31.mulPacked(tuple[hi], twiddle);
+                            tuple[lo] = m31.addPacked(lhs, product);
+                            tuple[hi] = m31.subPacked(lhs, product);
+                        }
+                    }
+                }
+
+                inline for (0..8) |item| {
+                    m31.storePacked(values.ptr + base + lane + item * distance, tuple[item]);
+                }
+            }
+        }
+        if (!duplicate_upper_from_lower) group_cursor += 1;
+    }
+}
+
 pub fn forward(
     values: []M31,
     log_size: u32,
@@ -112,6 +194,15 @@ pub fn forward(
     run(values, log_size, highest_stage, twiddles, false, false, M31.one(), false);
 }
 
+pub fn forwardBatch(
+    values_batch: []const []M31,
+    log_size: u32,
+    highest_stage: u32,
+    twiddles: []const M31,
+) void {
+    runForwardBatch(values_batch, log_size, highest_stage, twiddles, false);
+}
+
 pub fn forwardFromDuplicatedHalf(
     values: []M31,
     log_size: u32,
@@ -119,6 +210,15 @@ pub fn forwardFromDuplicatedHalf(
     twiddles: []const M31,
 ) void {
     run(values, log_size, highest_stage, twiddles, false, false, M31.one(), true);
+}
+
+pub fn forwardBatchFromDuplicatedHalf(
+    values_batch: []const []M31,
+    log_size: u32,
+    highest_stage: u32,
+    twiddles: []const M31,
+) void {
+    runForwardBatch(values_batch, log_size, highest_stage, twiddles, true);
 }
 
 pub fn inverse(
@@ -138,4 +238,63 @@ pub fn inverseNormalized(
     normalization: M31,
 ) void {
     run(values, log_size, lowest_stage, itwiddles, true, true, normalization, false);
+}
+
+test "batched forward matches independent packed radix-8 transforms" {
+    const log_size: u32 = 10;
+    const value_count = @as(usize, 1) << @intCast(log_size);
+    const pair_count = value_count / 2;
+    var prng = std.Random.DefaultPrng.init(0xb7e1_5162_8aed_2a6b);
+    const random = prng.random();
+
+    const input = try std.testing.allocator.alloc(M31, value_count);
+    defer std.testing.allocator.free(input);
+    const input_b = try std.testing.allocator.alloc(M31, value_count);
+    defer std.testing.allocator.free(input_b);
+    const expected = try std.testing.allocator.alloc(M31, value_count);
+    defer std.testing.allocator.free(expected);
+    const expected_b = try std.testing.allocator.alloc(M31, value_count);
+    defer std.testing.allocator.free(expected_b);
+    const batch_a = try std.testing.allocator.alloc(M31, value_count);
+    defer std.testing.allocator.free(batch_a);
+    const batch_b = try std.testing.allocator.alloc(M31, value_count);
+    defer std.testing.allocator.free(batch_b);
+    const twiddles = try std.testing.allocator.alloc(M31, pair_count);
+    defer std.testing.allocator.free(twiddles);
+
+    for (input) |*value| value.* = M31.fromCanonical(
+        random.intRangeLessThan(u32, 0, m31.Modulus),
+    );
+    for (input_b) |*value| value.* = M31.fromCanonical(
+        random.intRangeLessThan(u32, 0, m31.Modulus),
+    );
+    for (twiddles) |*value| value.* = M31.fromCanonical(
+        random.intRangeLessThan(u32, 1, m31.Modulus),
+    );
+
+    for ([_]u32{ 9, 5 }) |highest_stage| {
+        @memcpy(expected, input);
+        @memcpy(expected_b, input_b);
+        forward(expected, log_size, highest_stage, twiddles);
+        forward(expected_b, log_size, highest_stage, twiddles);
+        @memcpy(batch_a, input);
+        @memcpy(batch_b, input_b);
+        const batch = [_][]M31{ batch_a, batch_b };
+        forwardBatch(&batch, log_size, highest_stage, twiddles);
+        try std.testing.expectEqualSlices(M31, expected, batch_a);
+        try std.testing.expectEqualSlices(M31, expected_b, batch_b);
+    }
+
+    @memcpy(expected, input);
+    @memcpy(expected_b, input_b);
+    @memcpy(expected[value_count / 2 ..], expected[0 .. value_count / 2]);
+    @memcpy(expected_b[value_count / 2 ..], expected_b[0 .. value_count / 2]);
+    forward(expected, log_size, 8, twiddles);
+    forward(expected_b, log_size, 8, twiddles);
+    @memcpy(batch_a, input);
+    @memcpy(batch_b, input_b);
+    const expansion_batch = [_][]M31{ batch_a, batch_b };
+    forwardBatchFromDuplicatedHalf(&expansion_batch, log_size, 8, twiddles);
+    try std.testing.expectEqualSlices(M31, expected, batch_a);
+    try std.testing.expectEqualSlices(M31, expected_b, batch_b);
 }

--- a/src/prover/poly/circle/fft_radix8.zig
+++ b/src/prover/poly/circle/fft_radix8.zig
@@ -110,7 +110,7 @@ fn runForwardBatch(
     twiddles: []const M31,
     comptime duplicate_upper_from_lower: bool,
 ) void {
-    std.debug.assert(values_batch.len != 0);
+    if (values_batch.len == 0) return;
     std.debug.assert(log_size < @bitSizeOf(usize));
     const values_len = @as(usize, 1) << @intCast(log_size);
     for (values_batch) |values| std.debug.assert(values.len == values_len);
@@ -297,4 +297,12 @@ test "batched forward matches independent packed radix-8 transforms" {
     forwardBatchFromDuplicatedHalf(&expansion_batch, log_size, 8, twiddles);
     try std.testing.expectEqualSlices(M31, expected, batch_a);
     try std.testing.expectEqualSlices(M31, expected_b, batch_b);
+}
+
+test "empty forward batch is a no-op for RISC-V quotient geometry" {
+    const empty_batch: [0][]M31 = .{};
+    const twiddles = [_]M31{M31.one()} ** 64;
+
+    forwardBatch(&empty_batch, 7, 6, &twiddles);
+    forwardBatchFromDuplicatedHalf(&empty_batch, 7, 6, &twiddles);
 }

--- a/src/prover/poly/circle/transforms.zig
+++ b/src/prover/poly/circle/transforms.zig
@@ -589,22 +589,20 @@ fn evaluateBuffersTailLayers(
         if (layer_idx >= 5 and
             fft_kernels.canFuseThreeLayersPacked(layer_idx - 2))
         {
-            for (values_batch) |values| {
-                if (expand_on_first_radix) {
-                    fft_kernels.fftThreeLayersForwardPackedM31FromDuplicatedHalf(
-                        values,
-                        domain.logSize(),
-                        layer_idx,
-                        twiddle_tree.twiddles,
-                    );
-                } else {
-                    fft_kernels.fftThreeLayersForwardPackedM31(
-                        values,
-                        domain.logSize(),
-                        layer_idx,
-                        twiddle_tree.twiddles,
-                    );
-                }
+            if (expand_on_first_radix) {
+                fft_kernels.fftThreeLayersForwardPackedM31BatchFromDuplicatedHalf(
+                    values_batch,
+                    domain.logSize(),
+                    layer_idx,
+                    twiddle_tree.twiddles,
+                );
+            } else {
+                fft_kernels.fftThreeLayersForwardPackedM31Batch(
+                    values_batch,
+                    domain.logSize(),
+                    layer_idx,
+                    twiddle_tree.twiddles,
+                );
             }
             expand_on_first_radix = false;
             layer_idx -= 3;


### PR DESCRIPTION
## What changed

Hoists repeated packed radix-8 twiddle loads across forward FFT buffers, makes empty forward batches an explicit no-op, and attaches the 2026-07-28 research record with claimed verdict and sanitized transcripts.

## Why

Buffers with the same transform geometry reuse the same seven packed twiddles. The candidate isolates forward batching and leaves inverse and single-buffer paths unchanged. The first publication CI run also showed that the RISC-V memory-commitment path can supply zero buffers; returning before geometry and twiddle setup preserves the collection transform's no-op semantics in both checked and optimized builds.

## Root cause and fix

`Focused Linux / riscv_cpu` terminated the transaction-engine proof test with signal 11 under Zig 0.15.2 ReleaseFast. A checked diagnostic captured an empty batch at `log = 7`, `highest_stage = 6`, with 64 twiddles and ordinary forward mode. The helper had asserted that batches were non-empty and still entered setup when assertions compiled out. The fix returns immediately for zero buffers and adds the exact geometry as a regression for both public forward-batch entry points.

## Evidence

The original exact-frontier local S3 screen at candidate `2a74f0a152c6b43fc6873ccc45ee185195cc50ae` measured R 1.001324 with 95% portfolio CI [0.980664, 1.022294] over 20 paired rounds; proof bytes were identical and the Rust oracle passed. The harness classifies that measured tree as confirmed-neutral. The correctness repair is not presented as a fresh performance result.

The repaired publication tree passes:

- full RISC-V CPU product suite in Debug;
- full `test-riscv-cpu-product stwo-zig-riscv-cpu -Doptimize=ReleaseFast -j2` CI-equivalent lane;
- submission schema, transcript hash, and secret-scan validation;
- all 370 autoresearch unit tests; and
- `git diff --check`.

## Current-main matrix boundary

The refreshed merge-ref matrix also reports two non-required failures that are independently reproducible or attributable to current `main`, not this PR's radix-8 diff:

- Unmodified `78556fe7` fails the identical Zig 0.15.2 ReleaseFast `test-cairo-cpu-proof` control at `official Cairo all-opcodes canonical-small CPU proof completes` with `ConstraintsNotSatisfied`.
- The macOS aggregate lane passes 73/73 tests and then fails the product-closure manifest because current `main` imports `src/backends/metal/source_contract.zig` without listing it in the aggregate product manifest.

Both protected submission checks (`autoresearch-validate` and `autoresearch-judge`) and the repaired RISC-V lane pass at exact head `b7b0ebc1813098a2c3368074b1d095c83811685d`. These upstream failures are recorded here rather than folded into the candidate or its historical performance claim.