### PR TITLE
Skip degenerate layers in fourfold circle extensions

### DIFF
--- a/autoresearch/submissions/2026-07-28-fourfold-extension/delta.json
+++ b/autoresearch/submissions/2026-07-28-fourfold-extension/delta.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "predecessor_commit": "cfd47be98a10",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "declared_scope": "s3",
+  "files": {
+    "src/prover/pcs/columns/circle_transforms.zig": "sha256:1eae5b244fa971e582031465595debe53b448bc3919961b2c312caae7d805894",
+    "src/prover/poly/circle/poly.zig": "sha256:38d1c273b1b7f047de4fbb35e93fd036f359e378f04639698c6a197e14cd9789",
+    "src/prover/poly/circle/transforms.zig": "sha256:d383de6322232ca81b65c8c74e5cd069281731219079c3b5319585f2de943adf"
+  },
+  "transcripts": {
+    "transcripts/session-01.md": {
+      "sha256": "25da559ac19496197bd7aad707f04abd68eb70a99fd48acb648f089e6cfb81d5",
+      "captured_by": "submitter"
+    },
+    "transcripts/session-02.md": {
+      "sha256": "cc91f78dbbaef81dac3f2d2036884c86da390a744746a6c010bbf7195e68651c",
+      "captured_by": "submitter"
+    }
+  },
+  "transcripts_declined": false
+}

--- a/autoresearch/submissions/2026-07-28-fourfold-extension/note.md
+++ b/autoresearch/submissions/2026-07-28-fourfold-extension/note.md
@@ -1,0 +1,47 @@
+# Skip both degenerate layers in fourfold circle extensions
+
+## Model and harness
+
+Model: OpenAI Codex. Candidate `f3d814b087abe7585930bc334f89cfb37bd6a7c9`
+is a source-only descendant of frontier
+`cfd47be98a10598b90a898e787e5cd1c674b09e7`. Qualification target:
+`core_cpu/small/time`, Zig 0.15.2, ReleaseFast, paired S3.
+
+## Hypothesis
+
+For a fourfold extension, the upper three quarters of the coefficient buffer
+are mathematically zero. The first two largest-block FFT layers therefore pair
+populated quarters with zeros and reduce to deterministic duplication,
+independent of twiddles. Materializing four equal quarters once and starting
+the normal tail two layers later should remove zero initialization and two
+degenerate passes.
+
+## Changes
+
+The candidate adds scalar and batched fourfold-extension entry points, tracks
+one or two implicit extension layers in grouped column work, and materializes
+zeros only when a backend requires explicit buffers. Mixed or unsupported
+shapes fall back to the ordinary zero-padded transform. Differential tests
+compare the fast path with explicit zero padding for multiple domain sizes and
+multiple buffers.
+
+## Results
+
+Hosted qualification is pending the upstream workflow repair. A fresh local
+advisory S3 screen against the exact canonical frontier completed 20 paired
+rounds with `R = 0.975219` and portfolio CI `[0.962243, 0.989400]`. All five
+local gates passed, the pinned Rust oracle verified the scored workload, and
+proof bytes were identical. The interval is below parity but does not lie
+entirely below the configured `1 - theta` threshold, so the harness marks the
+result neither significant nor confirmed-neutral. The screen used
+`--guards none` to avoid the known generic-runner guard-budget defect; it is
+not a qualification receipt, attestation, judged result, or promotable claim.
+
+## Caveats
+
+The fast path applies only to exact power-of-two fourfold geometry. Small
+domains and mixed batches retain safe fallbacks. The proof-equivalence gate
+must confirm that skipping the degenerate layers is byte-identical in the full
+prover, not merely algebraically equal in an isolated transform. The local
+directional gain is insufficient for promotion without independent judged
+confirmation.

--- a/autoresearch/submissions/2026-07-28-fourfold-extension/transcripts/session-01.md
+++ b/autoresearch/submissions/2026-07-28-fourfold-extension/transcripts/session-01.md
@@ -1,0 +1,43 @@
+# Session 01: fourfold extension layer skipping
+
+## Mechanism selection
+
+The broad FFT literature search surfaced batching and locality ideas, but most
+general fusion was already represented in main. A narrower algebraic case
+remained in coefficient extension: the code recognizes a twofold extension and
+skips its one degenerate largest-block layer, but a fourfold extension still
+materializes three zero quarters and executes two layers whose outputs are
+known duplications.
+
+This candidate replays the previously isolated fourfold mechanism onto the
+current frontier. It was kept separate from batched radix-8 twiddle reuse so
+each remote record has one interpretable cause and can be rejected
+independently.
+
+## Correctness reasoning
+
+With only the first quarter populated, the largest-block butterfly sees a
+nonzero lower half and zero upper half; the next layer repeats that structure
+within both halves. Neither result depends on the skipped twiddles. Copying the
+first quarter into the other three therefore produces the exact state that the
+ordinary transform would have after two layers.
+
+The implementation records `extension_layers` rather than a Boolean, selecting
+the existing twofold path for one layer and the new fourfold path for two.
+Grouped batches use the fast path only when every member has the same exact
+geometry. Otherwise they explicitly zero the unwritten tail and run the
+ordinary transform. Backends that require materialized extension zeros receive
+the correct initialized length derived from the layer count.
+
+## Falsifiers and current state
+
+Randomized differential tests compare explicit zero padding with the new
+scalar and batched paths across domain log sizes 5 through 12. Remaining
+falsifiers are proof-byte drift, a failed Rust oracle, a resource regression,
+or an insignificant whole-proof ratio.
+
+The immutable branch touches three allowed source files, passes local preflight
+and correctness tests, and is published on the participant fork. Hosted
+qualification awaits upstream PR 118 because the canonical Ubuntu workflow
+currently builds Metal before measurement. No benchmark or record is inferred
+from the successful algebraic tests.

--- a/autoresearch/submissions/2026-07-28-fourfold-extension/transcripts/session-02.md
+++ b/autoresearch/submissions/2026-07-28-fourfold-extension/transcripts/session-02.md
@@ -1,0 +1,31 @@
+# Session 02: exact-frontier local objective screen
+
+## Run design
+
+The current-frontier candidate
+`f3d814b087abe7585930bc334f89cfb37bd6a7c9` was paired against
+`cfd47be98a10598b90a898e787e5cd1c674b09e7` for 20 S3 rounds on
+`core_cpu/small/time` with pinned Zig 0.15.2. The scored objective,
+correctness checks, proof-byte comparison, resource vectors, and pinned Rust
+oracle remained active. Automatic guards were disabled only to avoid the
+separately diagnosed generic-runner wall-budget defect, so this run is
+advisory rather than qualification evidence.
+
+## Result and interpretation
+
+The screen completed with `R = 0.975219`, workload CI
+`[0.962150, 0.989141]`, and portfolio CI `[0.962243, 0.989400]`.
+All five local gates passed, the Rust oracle verified the workload, and every
+cross-arm proof digest was identical.
+
+The interval lies below parity, which supports the mechanism's direction, but
+the promotion rule requires the full objective CI below
+`1 - theta = 0.962692`. The observed upper bound is well above that bar. The
+harness therefore correctly reports neither significant nor neutral. This is
+a directional, non-promotable result.
+
+## Evidence boundary
+
+No attestation or qualification receipt was generated, and no improvement is
+claimed. A central judged run could record the result, but it must independently
+execute the full guard portfolio and apply the same significance rule.

--- a/autoresearch/submissions/2026-07-28-fourfold-extension/verdict.json
+++ b/autoresearch/submissions/2026-07-28-fourfold-extension/verdict.json
@@ -1,0 +1,349 @@
+{
+  "schema_version": 1,
+  "kind": "claimed",
+  "harness_commit": "596f2ddfb88b",
+  "repo_commit": "f3d814b087ab",
+  "predecessor_commit": "cfd47be98a10",
+  "scope": "s3",
+  "declared_objective": {
+    "board": "core_cpu",
+    "workload_class": "small",
+    "dimension": "time"
+  },
+  "environment": {
+    "host": "d00bf0abb109",
+    "os": "Darwin 25.5.0",
+    "zig_version": "0.15.2",
+    "release_fast": true,
+    "clean_tree": true,
+    "judge_lock_held": false,
+    "preflight": {
+      "load_ok": true,
+      "load1": 5.55
+    }
+  },
+  "search_health": {
+    "schema_version": 1,
+    "decision": {
+      "schema_version": 1,
+      "board": "core_cpu",
+      "workload_class": "small",
+      "trailing_window": 8,
+      "trailing_evidence_count": 1,
+      "trailing_median_gradient_snr": 0.0,
+      "gradient_snr_threshold": 2.0,
+      "configured_rounds": 15,
+      "auto_boost_rounds": 5,
+      "maximum_rounds": 25,
+      "target_rounds": 20,
+      "workload_count": 1,
+      "class_wall_deadline_seconds": 240.0,
+      "estimated_seconds_per_round": 4.047260127732685,
+      "deadline_round_limit": 59,
+      "auto_boost_applied": true,
+      "auto_boost_reason": "trailing_median_below_threshold",
+      "recorded_before_measurement": true
+    },
+    "decision_sha256": "sha256:9db7f740061d3ef93711d44da55d5ee24cfe4fa0e2efd35e759d868425be2a53",
+    "actual_rounds": 20,
+    "actual_rounds_per_workload": {
+      "wf_log10x8": 20
+    },
+    "objective_wall_seconds": 3.4310602500045206,
+    "measurement_wall_seconds": 32.19895183300832,
+    "measurement_wall_hours": 0.008944153286946756,
+    "gradient_snr": null,
+    "credited_ln_improvement": null,
+    "credited_ln_improvement_per_measurement_hour": null,
+    "credit_status": "pending_ledger_adjudication",
+    "decision_record": "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/search-health-decision.json"
+  },
+  "gates": {
+    "G1": {
+      "pass": true,
+      "detail": "every timed sample verified; cross-arm proof digests byte-identical per round; pinned correctness oracle verified 1/1 workloads"
+    },
+    "G2": {
+      "pass": true,
+      "detail": "no locked or out-of-scope path touched"
+    },
+    "G3": {
+      "pass": true,
+      "detail": "native mechanism telemetry policy unchanged"
+    },
+    "G4": {
+      "pass": true,
+      "detail": "candidate/anchor 0.4643 vs targeted budget x1.02; matrix row upper CIs 1/1 within budget x1.05; request ratios 1/1 present rows within budget x1.05; resource vectors 1/1 within named budgets"
+    },
+    "G5": {
+      "pass": true,
+      "detail": "local advisory run"
+    }
+  },
+  "score": {
+    "per_workload": {
+      "wf_log10x8": {
+        "r": 0.975219,
+        "ci": [
+          0.96215,
+          0.989141
+        ],
+        "rounds": 20,
+        "a_median_ms": 1.329375,
+        "b_median_ms": 1.295042,
+        "request_ratio": 0.987116,
+        "rss_ratio": 1.0,
+        "resources": {
+          "energy_j": {
+            "ratio": 1.00404,
+            "ci": [
+              0.98516,
+              1.026743
+            ],
+            "observations": 20,
+            "candidate": 0.105745065
+          },
+          "peak_rss_mib": {
+            "ratio": 1.0,
+            "ci": [
+              0.997481,
+              1.001275
+            ],
+            "observations": 20,
+            "candidate": 6.18804931640625
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 24965.0
+          }
+        },
+        "mechanism_verified": null,
+        "proof_bytes": 24965,
+        "measurement_seconds": 3.075885,
+        "resources_complete": null
+      }
+    },
+    "R_geomean": 0.975219,
+    "portfolio": {
+      "ci_method": "independent_workload_round_bootstrap_percentile_v1",
+      "ci_level": 0.95,
+      "bootstrap_iterations": 4000,
+      "seed": 2000059846,
+      "ci": [
+        0.962243,
+        0.9894
+      ],
+      "prove_ms_method": "geometric_mean_candidate_workload_medians_ms_v1",
+      "b_median_ms_geomean": 1.295042,
+      "proof_bytes_method": "rounded_geometric_mean_candidate_proof_bytes_v1",
+      "proof_bytes": 24965,
+      "measurement_seconds": 3.075885,
+      "measurement_rounds": 20
+    },
+    "theta": 0.037308,
+    "aa_dispersion": 0.018654,
+    "significant": false,
+    "neutral": false,
+    "promotion_significance": {
+      "eligible": true,
+      "method": "independent_workload_round_bootstrap_percentile_v1",
+      "reason": "prove-time objective uses the deterministic workload portfolio CI"
+    },
+    "resource_portfolio": {
+      "peak_rss_mib": {
+        "ratio_geomean": 1.0,
+        "upper_ci_geomean": 1.0012753304378719,
+        "candidate_geomean": 6.18804931640625
+      },
+      "energy_j": {
+        "ratio_geomean": 1.0040399739355368,
+        "upper_ci_geomean": 1.026742885164835,
+        "candidate_geomean": 0.10574506499999999
+      },
+      "proof_bytes": {
+        "ratio_geomean": 1.0,
+        "upper_ci_geomean": 1.0,
+        "candidate_geomean": 24965.0
+      }
+    }
+  },
+  "tiebreakers": {
+    "rss_ratio": 1.0,
+    "waits": null,
+    "dispatches": null,
+    "energy_j": 0.10574506499999999,
+    "proof_bytes": 24965.0
+  },
+  "holdout": null,
+  "guards": {},
+  "rust_oracle": [
+    {
+      "workload": "wf_log10x8",
+      "verified": true,
+      "oracle": "pinned-rust-stwo",
+      "artifact_sha256": "4cabcca685cb0c4168d136ce3fea0f742b0b6a87d6b98beb3e048301f4d7b4e2"
+    }
+  ],
+  "skipped_groups": [
+    {
+      "group": "cuda",
+      "reason": "core_cuda is staged only: all six Native AIR families are required, but only wide Fibonacci is exact and release-ready; exact family semantics, the stwo-perf CUDA report adapter, locked-host A/A calibration, pinned Rust verification, and complete structural coverage are not yet release-gated."
+    },
+    {
+      "group": "pr6_supremacy",
+      "reason": "PR6 Supremacy remains disabled until every exact workload port, log22 oracle vector, both timing boundaries, locked-M5 statistical gate, and authenticated judged verdict are complete."
+    }
+  ],
+  "evidence": {
+    "pairing": "round-level ABBA (bench reports expose medians, not raw samples)",
+    "per_workload": {
+      "wf_log10x8": {
+        "round_ratios": [
+          0.979144,
+          0.962243,
+          0.963466,
+          0.950542,
+          0.962277,
+          0.985978,
+          0.914838,
+          1.012086,
+          0.975881,
+          1.017471,
+          0.944723,
+          0.907856,
+          1.009277,
+          0.952412,
+          1.001324,
+          1.015334,
+          1.010861,
+          0.962949,
+          0.972288,
+          0.982225
+        ],
+        "proof_digest": "91741aec956846d52e50f7b8fef3ac93195dbcd76cdb89e25ed33a148bea5700",
+        "request_ratio": 0.987116,
+        "rss_ratio": 1.0,
+        "resources": {
+          "energy_j": {
+            "ratio": 1.00404,
+            "ci": [
+              0.98516,
+              1.026743
+            ],
+            "observations": 20,
+            "candidate": 0.105745065
+          },
+          "peak_rss_mib": {
+            "ratio": 1.0,
+            "ci": [
+              0.997481,
+              1.001275
+            ],
+            "observations": 20,
+            "candidate": 6.18804931640625
+          },
+          "proof_bytes": {
+            "ratio": 1.0,
+            "ci": [
+              1.0,
+              1.0
+            ],
+            "observations": 1,
+            "candidate": 24965.0
+          }
+        },
+        "report_sha256s": [
+          "dad59522723e80717f030cf628564136e4ec2b31caa1830a78183ebfc40d89ba",
+          "ea7687e6f4c74208bd1aeec186637d785ac1d9c551e2f137ac50af09ee087759",
+          "c39a155af9c425e656792b4f0c80e3824c05c8c5edf436bc18d04d654ee39b54",
+          "465d4d59ef29b1d5b04a37a1f88d3d44f3480284cdc0d14eb90913f0e881f037",
+          "8acd447bc755a1076205ec09c1c82f74f4f80a7c2a7d14a2fb519bf9bcd0ae9e",
+          "9f1d3c1aeb884f4dee2ef1e77d2ec6623ca2aa81d9b12c74c98a4a73a7f80c0a",
+          "df560e958589cdcd38f4d0155b4143ee67f7fa55f00bd539e680f328692f1e29",
+          "9a725f475624b761e93811db61c264589d6959370a0c2f1b0b6d455e9e311703",
+          "9b1f80634efe009ad5ee05903744bb12974116a21f09d92a41442b2bf3a2d5b1",
+          "6d256254c42c7898e164eb967741b219f5c8474609c95d1a625a20047bcde329",
+          "31a22acda7a9a48b5f6033b9ae2e1f2610a49e8424db8d8bbe87e72ab2f9fb2e",
+          "9fbacb90000641ff54e60ab358d1ec7436f869907ba5c7d3beb0348e3c192328",
+          "f965e99e3f56a3ce4c1ceee1d46158f613e9bccf392ff579b7e7dfd081f207d9",
+          "de0aa5fb959468d55c0fa0674eec5e7c41ccce5b5337514ccee70e3e5a891303",
+          "4d246cca658db3155d6ee23094797bc9a355ca5dc1c0554a5c82361bcb40e40b",
+          "ee0e8d73bb9e6375cfa81a3d530f83cf39c1d8175b4cb34a9a2dedf0165cdd8e",
+          "92dd0e00b55a6978bc47ce26b670af589d077b3131ed7f5d512b418e69be1bf6",
+          "f712ab799ad14bf4cdc81f61c9c28edf757c3f3901ff9c6e2b0277a11542a06d",
+          "6e6d2ddbcb6eb3179bc7888cbeb6142ff7a37b9ef0466c91260815ce94e872e5",
+          "5b9718d3f5645d5abc2ca8bfff15f9c331fe05efa2a9e0a9ffc8312599ded25b",
+          "b2716e64ee840e78f9cad7b141da031f4d07675a8b6e2141300cccb210353519",
+          "9c96768156a782fd6f7e1db0bf3ad8951da45ac985177e7687c1086528ea90e4",
+          "ff2b82369ef6222fd95af165ccda186a347e08b277c1cee65edd2417e5bb7218",
+          "1fda5b31a434e7901358303ed129504d3536c69b8b3b6b620bcb3bfc064db11c",
+          "42af40b9c9c9b54b784204691cfa2a37a2945c1ca6d535c3c43cdac9a28cf088",
+          "d753563f3c320427598b58eabaae9c29e42ec884fa9d772c25fd8e237a68d69c",
+          "275ea619c86b851859c43c508357abe289e940706024ed40d9cdfac0d22441e5",
+          "477903c4629fb206b5a4354fa0ffd9add18353999b83e3e88d1978fc8b3b5252",
+          "3df0e392d1476ae4e914cfd8439b2c7210957669bcc40c62ab7823855cb4e82e",
+          "340b8b41660eb1ee9f09f1b77f89d96bff7246359dc9aacdceb88d35ac43b3fe",
+          "d367a7dc23459c59779f6ad3b2c5613a8b85d7e4f70af13bf6a047e40f48e3b7",
+          "d66aafa0606abb17517d0e9dffc008e0f34d0827f3b084ee8a5c03950df3f5b1",
+          "8b0fbb34dad7bffa83604661531ad802cfe9db7bf9816c43073aca9115c1bc0d",
+          "3dc0ea2cce48019a02713ba2c33cc02cb5456c5b9bc4af7598ca3cb9b80eb769",
+          "9fb4583c516d88c10895440dc29c4b404e2c0340dfeab65be562a369ed2ea4ec",
+          "cdbb0e1da78ccf6243eff4f23bc51c112807a32f3ab03cdfd90725e83c7fc3f9",
+          "d4fb753b039451f6b48a71cbb9ea45f2ca577f50f7e435556d5b201e4b4c95ba",
+          "6d76794efa34ec44038a18f7d19e91242d8c79a0e518e1199bbacf46af1e9ed2",
+          "f23088505c86884c546d923bb9886c4b650e848f5413985e984b0b4b31251803",
+          "b5abf9e9d37b17d195713fece0fb969e2d60be5749f41f76efd1d7420399c4ad"
+        ],
+        "mechanism_verified": null,
+        "resources_complete": null
+      }
+    },
+    "reports": [
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.a1.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.b1.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.a2.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.b2.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.a3.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.b3.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.a4.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.b4.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.a5.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.b5.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.a6.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.b6.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.a7.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.b7.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.a8.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.b8.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.a9.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.b9.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.a10.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.b10.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.a11.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.b11.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.a12.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.b12.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.a13.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.b13.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.a14.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.b14.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.a15.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.b15.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.a16.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.b16.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.a17.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.b17.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.a18.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.b18.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.a19.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.b19.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.a20.json",
+      "/Users/m1/Documents/Codex/2026-07-28/p/work/autoresearch/stwo-zig/work/records/fourfold/autoresearch/.runs/latest/wf_log10x8.b20.json"
+    ]
+  }
+}

--- a/src/prover/pcs/columns/circle_transforms.zig
+++ b/src/prover/pcs/columns/circle_transforms.zig
@@ -302,19 +302,30 @@ const FftEvalWorkItem = struct {
     values: [][]M31,
     domain: prover_circle.CircleDomain,
     twiddle_tree: twiddles_mod.TwiddleTree([]const M31),
-    /// Upper halves are unwritten and mathematically zero (2x extension);
-    /// the worker uses the degenerate-first-layer path.
-    extension: bool = false,
+    /// Number of unwritten, degenerate largest-block layers in the power-of-two
+    /// extension. Supported fast paths are 1 (2x) and 2 (4x).
+    extension_layers: u32 = 0,
 };
 
 fn fftEvalWorker(item: *const FftEvalWorkItem) void {
-    if (item.extension) {
-        prover_circle.poly.evaluateExtensionBuffersWithTwiddles(
-            item.values,
-            item.domain,
-            item.twiddle_tree,
-        ) catch {};
-        return;
+    switch (item.extension_layers) {
+        1 => {
+            prover_circle.poly.evaluateExtensionBuffersWithTwiddles(
+                item.values,
+                item.domain,
+                item.twiddle_tree,
+            ) catch {};
+            return;
+        },
+        2 => {
+            prover_circle.poly.evaluateFourfoldExtensionBuffersWithTwiddles(
+                item.values,
+                item.domain,
+                item.twiddle_tree,
+            ) catch {};
+            return;
+        },
+        else => {},
     }
     prover_circle.poly.evaluateBuffersWithTwiddles(
         item.values,
@@ -401,13 +412,23 @@ pub fn extendCoefficientColumnsByGroupForBackend(
             const batch_values = try allocator.alloc([]M31, chunk_len);
             errdefer allocator.free(batch_values);
 
-            var batch_extension = chunk_len > 0;
+            var batch_extension_layers: u32 = 0;
             for (group.indices.items[batch_start .. batch_start + chunk_len], 0..) |idx, bi| {
                 const values = try allocator.alloc(M31, domain_size);
                 const coeff_slice = coeffs[idx].coefficients();
                 @memcpy(values[0..coeff_slice.len], coeff_slice);
-                if (coeff_slice.len * 2 != values.len) {
-                    batch_extension = false;
+                const extension_layers: u32 = if (coeff_slice.len * 4 == values.len)
+                    2
+                else if (coeff_slice.len * 2 == values.len)
+                    1
+                else
+                    0;
+                if (bi == 0) {
+                    batch_extension_layers = extension_layers;
+                } else if (batch_extension_layers != extension_layers) {
+                    batch_extension_layers = 0;
+                }
+                if (extension_layers == 0) {
                     if (coeff_slice.len < values.len) @memset(values[coeff_slice.len..], M31.zero());
                 }
                 batch_values[bi] = values;
@@ -416,10 +437,10 @@ pub fn extendCoefficientColumnsByGroupForBackend(
                     .values = values,
                 };
             }
-            if (!batch_extension) {
+            if (batch_extension_layers == 0) {
                 for (batch_values, group.indices.items[batch_start .. batch_start + chunk_len]) |values, idx| {
                     const coeff_slice = coeffs[idx].coefficients();
-                    if (coeff_slice.len * 2 == values.len) @memset(values[coeff_slice.len..], M31.zero());
+                    if (coeff_slice.len < values.len) @memset(values[coeff_slice.len..], M31.zero());
                 }
             }
 
@@ -430,7 +451,7 @@ pub fn extendCoefficientColumnsByGroupForBackend(
                 .values = batch_values,
                 .domain = domain,
                 .twiddle_tree = twiddle_tree,
-                .extension = batch_extension,
+                .extension_layers = batch_extension_layers,
             });
         }
     }
@@ -473,9 +494,10 @@ pub fn extendCoefficientColumnsByGroupForBackend(
 
 fn materializeBackendExtensionZeros(work_items: []const FftEvalWorkItem) void {
     for (work_items) |item| {
-        if (!item.extension) continue;
+        if (item.extension_layers == 0) continue;
         for (item.values) |values| {
-            @memset(values[values.len / 2 ..], M31.zero());
+            const initialized_len = values.len >> @intCast(item.extension_layers);
+            @memset(values[initialized_len..], M31.zero());
         }
     }
 }
@@ -619,19 +641,89 @@ test "circle transforms: CPU FFT batch exposes one task per worker" {
 
 test "circle transforms: backend extension buffers materialize implicit zeros" {
     const allocator = std.testing.allocator;
-    const values = try allocator.alloc(M31, 16);
-    defer allocator.free(values);
-    @memset(values, M31.fromCanonical(0x5a5a));
+    const twofold_values = try allocator.alloc(M31, 16);
+    defer allocator.free(twofold_values);
+    const fourfold_values = try allocator.alloc(M31, 16);
+    defer allocator.free(fourfold_values);
+    @memset(twofold_values, M31.fromCanonical(0x5a5a));
+    @memset(fourfold_values, M31.fromCanonical(0x5a5a));
 
-    var slices = [_][]M31{values};
-    const items = [_]FftEvalWorkItem{.{
-        .values = slices[0..],
-        .domain = canonic.CanonicCoset.new(4).circleDomain(),
-        .twiddle_tree = undefined,
-        .extension = true,
-    }};
+    var twofold_slices = [_][]M31{twofold_values};
+    var fourfold_slices = [_][]M31{fourfold_values};
+    const items = [_]FftEvalWorkItem{
+        .{
+            .values = twofold_slices[0..],
+            .domain = canonic.CanonicCoset.new(4).circleDomain(),
+            .twiddle_tree = undefined,
+            .extension_layers = 1,
+        },
+        .{
+            .values = fourfold_slices[0..],
+            .domain = canonic.CanonicCoset.new(4).circleDomain(),
+            .twiddle_tree = undefined,
+            .extension_layers = 2,
+        },
+    };
     materializeBackendExtensionZeros(items[0..]);
 
-    for (values[0..8]) |value| try std.testing.expectEqual(M31.fromCanonical(0x5a5a), value);
-    for (values[8..]) |value| try std.testing.expectEqual(M31.zero(), value);
+    for (twofold_values[0..8]) |value| try std.testing.expectEqual(M31.fromCanonical(0x5a5a), value);
+    for (twofold_values[8..]) |value| try std.testing.expectEqual(M31.zero(), value);
+    for (fourfold_values[0..4]) |value| try std.testing.expectEqual(M31.fromCanonical(0x5a5a), value);
+    for (fourfold_values[4..]) |value| try std.testing.expectEqual(M31.zero(), value);
+}
+
+test "circle transforms: batched fourfold extension matches explicit zero padding" {
+    const allocator = std.testing.allocator;
+    var domain_log_size: u32 = 5;
+    while (domain_log_size <= 12) : (domain_log_size += 1) {
+        const domain = canonic.CanonicCoset.new(domain_log_size).circleDomain();
+        const domain_size = domain.size();
+        const coefficient_len = domain_size / 4;
+        const sentinel = M31.fromCanonical(0x5a5a);
+
+        const explicit_a = try allocator.alloc(M31, domain_size);
+        defer allocator.free(explicit_a);
+        const explicit_b = try allocator.alloc(M31, domain_size);
+        defer allocator.free(explicit_b);
+        const candidate_a = try allocator.alloc(M31, domain_size);
+        defer allocator.free(candidate_a);
+        const candidate_b = try allocator.alloc(M31, domain_size);
+        defer allocator.free(candidate_b);
+
+        for (0..coefficient_len) |index| {
+            const value_a = M31.fromCanonical(@intCast((index * 29 + 17) % m31.Modulus));
+            const value_b = M31.fromCanonical(@intCast((index * 43 + 11) % m31.Modulus));
+            explicit_a[index] = value_a;
+            candidate_a[index] = value_a;
+            explicit_b[index] = value_b;
+            candidate_b[index] = value_b;
+        }
+        @memset(explicit_a[coefficient_len..], M31.zero());
+        @memset(explicit_b[coefficient_len..], M31.zero());
+        @memset(candidate_a[coefficient_len..], sentinel);
+        @memset(candidate_b[coefficient_len..], sentinel);
+
+        var twiddle_tree = try twiddles_mod.precomputeM31(allocator, domain.half_coset);
+        defer twiddles_mod.deinitM31(allocator, &twiddle_tree);
+        const twiddles: twiddles_mod.TwiddleTree([]const M31) = .{
+            .root_coset = twiddle_tree.root_coset,
+            .twiddles = twiddle_tree.twiddles,
+            .itwiddles = twiddle_tree.itwiddles,
+        };
+        var explicit_batch = [_][]M31{ explicit_a, explicit_b };
+        var candidate_batch = [_][]M31{ candidate_a, candidate_b };
+        try prover_circle.poly.evaluateBuffersWithTwiddles(
+            explicit_batch[0..],
+            domain,
+            twiddles,
+        );
+        try prover_circle.poly.evaluateFourfoldExtensionBuffersWithTwiddles(
+            candidate_batch[0..],
+            domain,
+            twiddles,
+        );
+
+        try std.testing.expectEqualSlices(M31, explicit_a, candidate_a);
+        try std.testing.expectEqualSlices(M31, explicit_b, candidate_b);
+    }
 }

--- a/src/prover/poly/circle/poly.zig
+++ b/src/prover/poly/circle/poly.zig
@@ -275,7 +275,13 @@ pub const CircleCoefficients = struct {
         const values = try allocator.alloc(M31, domain.size());
         errdefer allocator.free(values);
         @memcpy(values[0..self.coeffs.len], self.coeffs);
-        if (self.coeffs.len * 2 == values.len) {
+        if (self.coeffs.len * 4 == values.len) {
+            transforms.evaluateFourfoldExtensionBufferWithTwiddles(
+                values,
+                domain,
+                twiddle_tree,
+            );
+        } else if (self.coeffs.len * 2 == values.len) {
             transforms.evaluateExtensionBufferWithTwiddles(values, domain, twiddle_tree);
         } else {
             if (self.coeffs.len < values.len) @memset(values[self.coeffs.len..], M31.zero());
@@ -455,6 +461,9 @@ pub const interpolateBuffersWithTwiddles = transforms.interpolateBuffersWithTwid
 pub const evaluateBuffersWithTwiddles = transforms.evaluateBuffersWithTwiddles;
 
 pub const evaluateExtensionBuffersWithTwiddles = transforms.evaluateExtensionBuffersWithTwiddles;
+
+pub const evaluateFourfoldExtensionBuffersWithTwiddles =
+    transforms.evaluateFourfoldExtensionBuffersWithTwiddles;
 
 fn checkedPow2(log_size: u32) PolyError!usize {
     if (log_size >= @bitSizeOf(usize)) return PolyError.InvalidLogSize;
@@ -716,6 +725,40 @@ test "prover poly circle poly: evaluate with twiddles matches evaluate" {
     defer alloc.free(@constCast(eval_with_twiddles.values));
 
     try std.testing.expectEqualSlices(M31, eval_direct.values, eval_with_twiddles.values);
+}
+
+test "prover poly circle poly: fourfold extension skips two degenerate layers exactly" {
+    const alloc = std.testing.allocator;
+    const coeff_log_size: u32 = 6;
+    const domain_log_size: u32 = coeff_log_size + 2;
+    const coeff_len = @as(usize, 1) << @intCast(coeff_log_size);
+    const domain_len = @as(usize, 1) << @intCast(domain_log_size);
+    const sentinel = M31.fromCanonical(0x5a5a);
+
+    const baseline = try alloc.alloc(M31, domain_len);
+    defer alloc.free(baseline);
+    const candidate = try alloc.alloc(M31, domain_len);
+    defer alloc.free(candidate);
+    for (0..coeff_len) |index| {
+        const value = M31.fromCanonical(@intCast((index * 31 + 17) % m31.Modulus));
+        baseline[index] = value;
+        candidate[index] = value;
+    }
+    @memset(baseline[coeff_len..], M31.zero());
+    @memset(candidate[coeff_len..], sentinel);
+
+    const domain = canonic.CanonicCoset.new(domain_log_size).circleDomain();
+    var twiddle_tree = try twiddles_mod.precomputeM31(alloc, domain.half_coset);
+    defer twiddles_mod.deinitM31(alloc, &twiddle_tree);
+    const twiddles: M31TwiddleTree = .{
+        .root_coset = twiddle_tree.root_coset,
+        .twiddles = twiddle_tree.twiddles,
+        .itwiddles = twiddle_tree.itwiddles,
+    };
+
+    transforms.evaluateBufferWithTwiddles(baseline, domain, twiddles);
+    transforms.evaluateFourfoldExtensionBufferWithTwiddles(candidate, domain, twiddles);
+    try std.testing.expectEqualSlices(M31, baseline, candidate);
 }
 
 test "prover poly circle poly: interpolate with twiddles matches interpolate" {

--- a/src/prover/poly/circle/transforms.zig
+++ b/src/prover/poly/circle/transforms.zig
@@ -146,6 +146,35 @@ pub fn evaluateExtensionBufferWithTwiddles(
     evaluateBufferTailLayers(values, domain, twiddle_tree, 1);
 }
 
+/// Evaluates a coefficient buffer whose upper three quarters are known to be
+/// zero — the 4x-blowup extension case.
+///
+/// The first largest-block layer pairs the lower half with zero and the second
+/// pairs each populated quarter with zero. Both layers therefore only
+/// duplicate their non-zero inputs, independent of their twiddles. Materialize
+/// the resulting four equal quarters once and skip both degenerate layers.
+pub fn evaluateFourfoldExtensionBufferWithTwiddles(
+    values: []M31,
+    domain: CircleDomain,
+    twiddle_tree: M31TwiddleTree,
+) void {
+    if (domain.logSize() <= 3) {
+        const quarter = values.len / 4;
+        @memset(values[quarter..], M31.zero());
+        evaluateBufferWithTwiddles(values, domain, twiddle_tree);
+        return;
+    }
+    materializeFourEqualQuarters(values);
+    evaluateBufferTailLayers(values, domain, twiddle_tree, 2);
+}
+
+fn materializeFourEqualQuarters(values: []M31) void {
+    std.debug.assert(values.len % 4 == 0);
+    const quarter = values.len / 4;
+    @memcpy(values[quarter .. 2 * quarter], values[0..quarter]);
+    @memcpy(values[2 * quarter ..], values[0 .. 2 * quarter]);
+}
+
 pub fn evaluateBufferWithTwiddles(
     values: []M31,
     domain: CircleDomain,
@@ -553,6 +582,25 @@ pub fn evaluateExtensionBuffersWithTwiddles(
         return evaluateBuffersWithTwiddles(values_batch, domain, twiddle_tree);
     }
     try evaluateBuffersTailLayers(values_batch, domain, twiddle_tree, 1, true);
+}
+
+/// Batched 4x-blowup counterpart to
+/// `evaluateFourfoldExtensionBufferWithTwiddles`.
+pub fn evaluateFourfoldExtensionBuffersWithTwiddles(
+    values_batch: []const []M31,
+    domain: CircleDomain,
+    twiddle_tree: M31TwiddleTree,
+) PolyError!void {
+    if (!domain.half_coset.isDoublingOf(twiddle_tree.root_coset)) return PolyError.InvalidLogSize;
+    if (domain.logSize() <= 3) {
+        for (values_batch) |values| {
+            const quarter = values.len / 4;
+            @memset(values[quarter..], M31.zero());
+        }
+        return evaluateBuffersWithTwiddles(values_batch, domain, twiddle_tree);
+    }
+    for (values_batch) |values| materializeFourEqualQuarters(values);
+    try evaluateBuffersTailLayers(values_batch, domain, twiddle_tree, 2, false);
 }
 
 fn evaluateBuffersTailLayers(


### PR DESCRIPTION
## What changed

Adds scalar and batched fourfold-extension paths that skip two zero-degenerate FFT layers and attaches the 2026-07-28 research record with claimed verdict and sanitized transcripts.

## Why

For exact fourfold geometry, the upper three coefficient quarters are zero and the first two layers reduce to deterministic duplication. Unsupported shapes retain the ordinary path.

## Evidence

Exact-frontier local S3 screen: R 0.975219, 95% portfolio CI [0.962243, 0.989400], 20 paired rounds, proof bytes identical, Rust oracle passed. The interval is directionally below parity but does not clear the configured significance threshold. The repository submission validator passes.