### PR TITLE
build(cairo): expose vendored bzip2 headers to facade modules

### DIFF
--- a/build_support/products/cairo_support.zig
+++ b/build_support/products/cairo_support.zig
@@ -40,6 +40,10 @@ pub fn createProductSupportModule(
     product: graph.Product,
     stwo: *std.Build.Module,
 ) *std.Build.Module {
+    // bzip2.zig belongs to the named Stwo facade module, so its @cImport
+    // needs the vendored header path on that module as well as on the final
+    // compile artifact configured by linkBzip2().
+    stwo.addIncludePath(b.path("third_party/bzip2"));
     const shared = graph.create(b, .{
         .product = product,
         .root_source_file = "src/products/cairo/shared/mod.zig",


### PR DESCRIPTION
## What changed

Attach the vendored bzip2 include directory to each named Stwo Cairo facade module created by the shared Cairo build helper. The final executable continues to own the C sources and libc link.

## Root cause

`src/interop/bzip2.zig` is compiled inside the named `stwo_cairo` module, while the existing include path was attached only to the final compile artifact. macOS masked this through a host bzip2 header; Linux correctly failed the `@cImport` with `bzlib.h file not found` even though the vendored header and C sources were present.

## Impact

The focused Linux Cairo CPU product can compile against the repository-owned bzip2 1.0.8 headers instead of depending on a host development package. This is a build-graph repair only; it does not change proof logic or performance code.

## Validation

- Reproduced the exact missing-header failure on clean `78556fe7` with Zig 0.15.2 targeting `x86_64-linux-gnu`.
- After the patch, the Linux-target Zig executable compile succeeds; the outer cross-build stops only at the separately offline Rust adapter dependency.
- `zig build test-cairo-cpu-product -Doptimize=ReleaseFast -j2` passes on Apple M2 Pro with Zig 0.15.2.
- `git diff --check` passes.