### PR TITLE
build(metal): admit source contract to aggregate closure

### DIFF
--- a/build_support/products/aggregate.zig
+++ b/build_support/products/aggregate.zig
@@ -53,6 +53,7 @@ const metal_allowed_files = common_allowed_files ++ .{
     "src/backends/metal/runtime.zig",
     "src/backends/metal/shader_manifest.zig",
     "src/backends/metal/shared_runtime.zig",
+    "src/backends/metal/source_contract.zig",
     "src/backends/metal/telemetry.zig",
 };
 


### PR DESCRIPTION
## What changed

Add `src/backends/metal/source_contract.zig` to the explicit aggregate Metal source-closure allow-list.

## Root cause

The Metal backend now imports its source-contract module transitively, but the opt-in aggregate product descriptor did not admit that exact file. The focused macOS aggregate lane therefore built and passed all 73 Zig tests, then failed closed in `check_product_closure.py` with `source outside product manifest`.

## Impact

The aggregate Metal product closure once again matches its actual transitive source graph. This changes only build ownership metadata; it does not broaden a prefix, alter runtime logic, or touch performance code.

## Validation

- Reproduced from the clean-main GitHub merge build at `78556fe7`; the failure names only `src/backends/metal/source_contract.zig` as outside the product manifest.
- `zig build test stwo-zig -Daggregate-metal=true -Doptimize=ReleaseSafe -j2` passes locally on Apple M2 Pro with Zig 0.15.2.
- Closure receipt: 476 transitive Zig sources, SHA-256 `f9dd04cabe40af4299934357bf4431c0be75720f9dea5afccc9e50b76448a7d6`.
- `git diff --check` passes.