### PR TITLE
Allow host-partitioned backend-tool configure closure

### DIFF
--- a/scripts/check_build_configure_closure.py
+++ b/scripts/check_build_configure_closure.py
@@ -177,6 +177,20 @@ def validate_actual_construction(
     # roots and no external tool invocations to observe. Constructors must
     # still match — the fail-closed registration is itself construction.
     fully_stubbed = not actual["module_roots"]
+    observed_probes = actual["runtime_probes"]
+    declared_probes = sorted(set(manifest["runtime_probes"]))
+    # A backend-tool scope may mix portable tools with host-only tools. On a
+    # host where none of the declared runtime probes exist, the portable
+    # construction remains observable while the host-only dependency graph is
+    # replaced by fail-closed step stubs. Accept only the non-empty declared
+    # subset in that partition; a capable host must still observe the exact
+    # dependency closure below.
+    dependency_partitioned = (
+        manifest.get("scope_role") == "backend_tools"
+        and bool(declared_probes)
+        and not observed_probes
+        and not fully_stubbed
+    )
     for field in (
         "constructors",
         "generated_module_roots",
@@ -191,6 +205,19 @@ def validate_actual_construction(
             and not observed
         ):
             continue
+        if field == "dependency_module_roots" and dependency_partitioned:
+            undeclared = sorted(set(observed) - set(declared))
+            if undeclared:
+                raise SystemExit(
+                    f"{scope} actual dependency_module_roots diverges from catalog: "
+                    f"undeclared={undeclared}"
+                )
+            if not observed:
+                raise SystemExit(
+                    f"{scope} actual dependency_module_roots diverges from catalog: "
+                    "partially constructed backend-tool scope observed no dependencies"
+                )
+            continue
         if observed != sorted(set(declared)):
             raise SystemExit(
                 f"{scope} actual {field} diverges from catalog: "
@@ -202,8 +229,6 @@ def validate_actual_construction(
     # nothing: a fully stubbed host observes none; any construction that
     # probes at all must observe exactly the declared set, and an undeclared
     # probe is fatal everywhere.
-    observed_probes = actual["runtime_probes"]
-    declared_probes = sorted(set(manifest["runtime_probes"]))
     undeclared_probes = sorted(set(observed_probes) - set(declared_probes))
     if undeclared_probes:
         raise SystemExit(

--- a/scripts/tests/test_ci.py
+++ b/scripts/tests/test_ci.py
@@ -138,6 +138,60 @@ class CiTests(unittest.TestCase):
         with self.assertRaisesRegex(SystemExit, "dependency_module_roots.*diverges"):
             validate_actual_construction(manifest, matrix, "focused")
 
+    def test_backend_tools_allow_declared_dependency_subset_without_host_probes(self) -> None:
+        manifest, matrix = self.construction_fixture()
+        manifest["scope_role"] = "backend_tools"
+        manifest["constructed_products"] = []
+        manifest["actual"]["products"] = []  # type: ignore[index]
+        manifest["dependency_module_roots"] = [
+            "dependency:portable:root.zig",
+            "dependency:host_only:root.zig",
+        ]
+        manifest["actual"]["dependency_module_roots"] = [  # type: ignore[index]
+            "dependency:portable:root.zig"
+        ]
+        manifest["actual"]["runtime_probes"] = []  # type: ignore[index]
+        validate_actual_construction(manifest, matrix, "focused")  # must not raise
+
+    def test_backend_tools_reject_undeclared_partitioned_dependency(self) -> None:
+        manifest, matrix = self.construction_fixture()
+        manifest["scope_role"] = "backend_tools"
+        manifest["constructed_products"] = []
+        manifest["actual"]["products"] = []  # type: ignore[index]
+        manifest["dependency_module_roots"] = ["dependency:portable:root.zig"]
+        manifest["actual"]["dependency_module_roots"] = [  # type: ignore[index]
+            "dependency:hidden:root.zig"
+        ]
+        manifest["actual"]["runtime_probes"] = []  # type: ignore[index]
+        with self.assertRaisesRegex(SystemExit, "dependency_module_roots.*undeclared"):
+            validate_actual_construction(manifest, matrix, "focused")
+
+    def test_backend_tools_reject_empty_partitioned_dependencies(self) -> None:
+        manifest, matrix = self.construction_fixture()
+        manifest["scope_role"] = "backend_tools"
+        manifest["constructed_products"] = []
+        manifest["actual"]["products"] = []  # type: ignore[index]
+        manifest["dependency_module_roots"] = ["dependency:portable:root.zig"]
+        manifest["actual"]["dependency_module_roots"] = []  # type: ignore[index]
+        manifest["actual"]["runtime_probes"] = []  # type: ignore[index]
+        with self.assertRaisesRegex(SystemExit, "observed no dependencies"):
+            validate_actual_construction(manifest, matrix, "focused")
+
+    def test_backend_tools_require_exact_dependencies_with_host_probes(self) -> None:
+        manifest, matrix = self.construction_fixture()
+        manifest["scope_role"] = "backend_tools"
+        manifest["constructed_products"] = []
+        manifest["actual"]["products"] = []  # type: ignore[index]
+        manifest["dependency_module_roots"] = [
+            "dependency:portable:root.zig",
+            "dependency:host_only:root.zig",
+        ]
+        manifest["actual"]["dependency_module_roots"] = [  # type: ignore[index]
+            "dependency:portable:root.zig"
+        ]
+        with self.assertRaisesRegex(SystemExit, "dependency_module_roots.*diverges"):
+            validate_actual_construction(manifest, matrix, "focused")
+
     def test_standard_plan_runs_tooling_then_release_gate(self) -> None:
         plan = command_plan(False, "ReleaseFast")
         self.assertEqual(sys.executable, plan[0][0])


### PR DESCRIPTION
## What changed

- allow a partially constructed `backend_tools` scope to observe a non-empty subset of its declared dependency roots when none of its declared host runtime probes are available;
- continue rejecting every undeclared dependency, an empty partial dependency graph, and any dependency omission on a capable host;
- add focused positive and adversarial tests for all four boundaries.

## Root cause

The `metal_tools` scope intentionally mixes portable Metal AOT tooling with legacy tools that are fail-closed stubs off macOS. On Linux the portable partition constructs real modules, so the scope is not fully stubbed, while the host-only partition correctly contributes no Apple-framework probes or dependency graph. The existing validator treated that legitimate partition as an exact-closure mismatch: 4 observed portable roots versus the 17-root cross-host catalog.

## Impact

Linux can validate the real portable construction without weakening macOS closure checks. Undeclared dependencies remain fatal everywhere, and a host that observes any declared runtime probe must still match the complete declared dependency closure exactly.

## Validation

- `python3 -m unittest scripts.tests.test_ci -v` — 33/33 passed
- `python3 -m unittest discover -s scripts/tests -q` with Python 3.14 and Zig 0.15.2 — 1,064 passed, 57 skipped
- `python3 scripts/check_build_configure_closure.py --receipt /tmp/stwo-build-graph-repair-macos.json` with Zig 0.15.2 — PASS across 21 catalog scopes, both CPU and Metal install manifests, and all negative checks
- `git diff --check`

The Linux `build_graph` lane on this draft PR is the authoritative reproduction of the host-partitioned manifest.