### PR TITLE
Derive change-scoped CI lane selection from the package graph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,16 +66,24 @@ jobs:
           # For PRs, diff against the live merge-base — the event's base.sha
           # can lag the base branch, which would count already-merged main
           # commits as part of the PR and select lanes the PR never touched.
+          #
+          # Pushes to main take the full matrix instead of a scoped selection:
+          # it is the post-merge safety net for any selection mistake a PR made,
+          # and it keeps every lane's compiler cache warm for the next PR.
+          SCOPE_ARGS=()
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE="$(git merge-base "origin/${{ github.base_ref }}" HEAD)"
           else
             BASE="${{ github.event.before }}"
+            SCOPE_ARGS+=(--full-matrix)
           fi
           python3 scripts/ci_scope_plan.py \
             --base "$BASE" \
             --head "${{ github.sha }}" \
             --output "$RUNNER_TEMP/focused-ci-plan.json" \
-            --github-output "$GITHUB_OUTPUT"
+            --github-output "$GITHUB_OUTPUT" \
+            --github-summary "$GITHUB_STEP_SUMMARY" \
+            "${SCOPE_ARGS[@]}"
 
       - name: Report capability-deferred lanes
         run: |

--- a/autoresearch/notes/2026-07-28-change-scoped-ci/note.md
+++ b/autoresearch/notes/2026-07-28-change-scoped-ci/note.md
@@ -1,0 +1,310 @@
+# Change-scoped CI: deriving the lane closure from the package graph
+
+- Implementation: Claude Opus 4.5
+- Orchestration: Claude Fable 5
+- Branch: `feat/change-scoped-ci` (base `191e409f`)
+- Date: 2026-07-28
+
+## Summary
+
+The increment was commissioned as "every PR runs every CI gate; build
+change-scoped CI". **The survey contradicted the premise.** Change-scoped CI
+already ships: `ci.yml`'s `focused-plan` job computes a lane matrix from the PR
+diff and the focused Linux/macOS/CUDA jobs consume it. A notes-only commit
+already runs 1 lane, not 34.
+
+The real defect is one level down. The package portion of that selection was a
+**hand-maintained per-prefix lane list** in `conformance/ci-touchpoints-v1.json`
+that duplicates the package dependency graph — and it had drifted, in the unsafe
+direction: it *under-selected* transitive consumers. Three concrete cases, so a
+change to `src/backend` could break `riscv_cpu_integration`'s build and no lane
+would notice.
+
+This increment replaces that list with a closure computed from the 17
+`package.contract.json` files and their 51 declared edges, and adds two
+workflow-level safety properties (full matrix on push to main; a visible
+selected/skipped lane table).
+
+Honest headline: **this is a correctness and maintainability fix, not a
+job-count win.** The job-count reduction was already banked by the pre-existing
+focused plan. Where the numbers move at all, they move *up* — 110 tracked files
+now select lanes they should always have selected.
+
+## Survey
+
+### Workflows that trigger on `pull_request`
+
+| Workflow | PR behaviour | Scoped today? |
+|---|---|---|
+| `ci.yml` | focused matrix via `focused-plan` → `ci_scope_plan.py` | yes — diff-scoped |
+| `riscv-sail-differential.yml` | `scope` job computes `live_required` from the merge-base diff | yes — same pattern |
+| `benchmark-pages.yml` | `on.pull_request.paths` anchor | yes — path filter |
+| `pr6-supremacy.yml` | `contract-smoke` runs unconditionally (~15 min) | **no** |
+| `validate.yml`, `judge.yml`, `promote.yml`, `automerge.yml`, `record.yml` | autoresearch harness | out of scope by instruction |
+
+`audit.yml`, `architecture-authority.yml`, `native-oracle.yml`,
+`metal-calibration.yml`, `qualify-fork.yml` are `workflow_dispatch`/`schedule`
+only — they never run on a PR. There is no release workflow, consistent with the
+stated non-goal.
+
+### The existing resolver
+
+`scripts/ci_scope_plan.py` (303 lines before this change) selects lanes from
+three sources, unioned per changed path:
+
+1. `always_lanes` — `["static"]`;
+2. the product catalog (`zig-out/identity/product-matrix.json`, built by
+   `zig build product-matrix-identity`) matched against each product's
+   `module_roots` / `allowed_prefixes`, mapped through `product_scope_lanes`;
+3. `rules[]` — hand-written `{prefixes, lanes}` pairs.
+
+Fail-open already exists and is correct: a path matching nothing, and not under
+`documentation_prefixes` or `externally_validated_prefixes`, selects the whole
+matrix. `scripts/ci.py`'s `FAST_PLAN` is a separate local pre-commit tier and is
+untouched.
+
+### Lane ↔ package mapping, as it actually is
+
+17 of the 34 lanes build exactly one package, and they say so themselves — each
+names that package's `build.zig` in a `--build-file` argument:
+
+```
+backend_contracts   src/backend            metal_session       src/tools/metal_session
+cairo_cpu_integration src/integrations/cairo_cpu   native_cuda_integration src/integrations/native_cuda
+cairo_cuda_integration src/integrations/cairo_cuda native_examples     src/examples
+cairo_frontend      src/frontends/cairo    proof_wire          src/interop/proof_wire
+cairo_metal_integration src/integrations/cairo_metal  prover         src/prover
+core                src/core               riscv_cpu_integration src/integrations/riscv_cpu
+cpu_backend         src/backends/cpu_scalar riscv_frontend     src/frontends/riscv
+cuda_backend        src/backends/cuda      riscv_metal_integration src/integrations/riscv_metal
+metal_backend       src/backends/metal
+```
+
+The other 17 are product, aggregate, oracle, and global lanes (`static`,
+`build_graph`, `package`, `native_cpu`, `native_oracle`, `riscv_cpu`,
+`cairo_cpu`, `cairo_metal`, `aggregate_cpu`, `aggregate_metal`, `deferred`,
+`native_cuda_static`, `native_cuda_device`, `native_metal`, `riscv_metal`,
+`metal_compile`, `metal_aot`). Their scope is *not* package-derivable — see
+residual risks — and they keep selecting through the catalog and the remaining
+rules, unchanged.
+
+### The drift
+
+Comparing each package's graph closure against the hand-written rule for its own
+prefix. Every difference is a **missing** lane; there were no spurious ones.
+
+| Changed prefix | Lanes the hand list omitted | Why the graph finds them |
+|---|---|---|
+| `src/backend` | `cairo_cpu_integration`, `riscv_cpu_integration`, `riscv_metal_integration` | reached via `cpu_backend` / `metal_backend`, not declared directly |
+| `src/backends/cpu_scalar` | `cairo_metal_integration`, `riscv_metal_integration` | reached via `metal_backend` |
+| `src/core` | `cuda_backend` | `cuda_backend` → `backend_contracts` → `core` |
+
+## Design
+
+### The resolver
+
+`scripts/ci_package_graph.py` (220 lines, stdlib only):
+
+- `load_packages(root)` reads every `src/**/package.contract.json`, keyed by
+  package name, and **resolves each declared relative dependency path back to a
+  package name**. A moved or renamed package fails loudly here rather than
+  silently dropping lanes.
+- `reverse_closure(packages, seeds)` iterates to a fixed point — terminates on a
+  cyclic graph even though the workspace validator rejects cycles separately.
+- `lane_packages(policy, packages)` derives lane → package from the lane's own
+  `--build-file` argument. A lane pointing at a build file no contract owns is an
+  error, because it would silently never be graph-selected.
+- `owning_package(path, packages)` — longest-prefix wins, so a nested package is
+  never shadowed by its parent. Returns `None` rather than guessing.
+- `selection(paths, ...)` returns `(lanes, unowned_paths)`. Unowned paths are
+  *returned*, not swallowed: the fail-open decision stays with the caller.
+
+`ci_scope_plan.select_lanes` unions the graph lanes in per path, before the
+existing rules and fail-open logic. Nothing was removed from the selection
+pipeline.
+
+### Path → package mapping
+
+A path belongs to the package whose contract directory is its longest matching
+prefix. Derived entirely from where the 17 contract files sit — there is no
+parallel path list to maintain, which was the point.
+
+### Always-run set (explicit)
+
+`always_lanes: ["static"]`, one lane, whose commands are the cheap global gates:
+
+- `zig fmt --check build.zig build_support src tools`
+- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'`
+- `scripts/check_build_monorepo_baseline.py`
+- `scripts/check_source_conformance.py`
+- `scripts/check_package_workspace.py` (the 17-package / 51-edge validator)
+- `scripts/check_upstream_pins.py`
+
+Plus the always-run workflow bookkeeping jobs, which are not lanes:
+`focused-plan` itself (`if:` is event-scoped only, never diff-scoped) and
+`focused-verdict` (`if: always()`), the single required check.
+
+### Fail-open rules (bias: when unsure, run more)
+
+| Changed path class | Selection |
+|---|---|
+| `build_support/**`, `scripts/**`, `.github/**`, `vectors/**`, `third_party/**`, root build files, anything else unmapped | **full matrix** |
+| `README.md`, `CONTRIBUTING.md`, `LICENSE`, `docs/**`, `archive/**`, `conformance/**` (`documentation_prefixes`) | always-run set only |
+| `autoresearch/**` (`externally_validated_prefixes` — validated by the harness's own workflow, constructs no product) | always-run set only |
+| package-owned path | always-run + graph closure + catalog + remaining rules |
+
+`*.md` at any depth inside those prefixes is covered; a `*.md` outside them
+(e.g. a new root-level `NOTES.md`) fails open to the full matrix, which is the
+correct direction.
+
+### Workflow wiring
+
+The existing shape is kept and I recommend keeping it:
+
+- `focused-plan` (one cheap ubuntu job) emits `linux_matrix`, `macos_matrix`,
+  `cuda_required`; the focused jobs consume them via `fromJSON`.
+- **`focused-verdict` is the branch-protection anchor** — one always-run job
+  that asserts each selected lane passed and each unselected one is genuinely
+  `skipped`. This is strictly better than 34 individually-required checks, which
+  is why I did **not** convert the matrix into 34 statically-declared jobs with
+  per-job `if:` guards. That would be a ~2000-line workflow rewrite for worse
+  branch-protection ergonomics.
+- Two changes, both additive:
+  - **push to main takes the full matrix** (`--full-matrix`), not a scoped
+    selection. Post-merge safety net for any selection mistake a PR made, and it
+    keeps every lane's compiler cache warm for the next PR.
+  - **`--github-summary`** writes a table of all 34 lanes with
+    selected/skipped and the triggering path, so a skipped lane is a visible,
+    explained decision rather than a job that never appeared. This is the cheap
+    substitute for statically-declared skipped jobs.
+
+## Replay evidence
+
+`FULL` = the 30 hosted-eligible lanes (4 of the 34 are `hosted: false` and never
+enter a hosted matrix). `BEFORE` = the shipped selection at `191e409f`.
+`AFTER` = this branch.
+
+| Case | Paths | FULL | BEFORE | AFTER | AFTER vs FULL | Note |
+|---|---|---|---|---|---|---|
+| (a) merged PR #125 `78556fe7...191e409f` | 117 | 30 | 30 | 30 | 0% | fails open — `scripts/riscv_poseidon_table_uniqueness.py`, `scripts/check_build_configure_closure.py`, `scripts/tests/test_ci.py` |
+| (a′) PR #125, `scripts/**` removed | 114 | 30 | 30 | 30 | 0% | **still** full: `build_support/products/aggregate.zig` and `cairo_support.zig` are unmapped and fail open too |
+| (b) notes-only `ceb5b32f` | 1 | 30 | 1 | 1 | **97%** | `static` only |
+| (c) riscv-only `e6303646` | 13 | 30 | 9 | 9 | **70%** | no cairo, metal-device, or cuda-device lane |
+| (c′) riscv-only `a0e594e6` | 31 | 30 | 9 | 9 | **70%** | same 9 lanes |
+| (d) metallib delivery `19026cae` | 2 | 30 | 30 | 30 | 0% | `vectors/**` fails open by design |
+| (e) synthetic `src/core/fields/m31.zig` | 1 | 30 | 24 | **25** | 17% | **+`cuda_backend`** — drift fixed |
+| (f) synthetic `src/frontends/cairo/air.zig` | 1 | 30 | 8 | 8 | **73%** | no `riscv_*`, no `native_cuda_device` |
+
+The PR #125 counterfactual was checked honestly and the expected answer did not
+hold: removing `scripts/**` does not bring it below full, because the same PR
+also touched two unmapped `build_support/products/*.zig` files. Both are
+correct fail-open triggers.
+
+### Exhaustive safety check
+
+The resolver was replayed over **all 6728 tracked files**, one at a time, old
+algorithm vs new:
+
+- **lanes dropped: 0** — no path selects less than it did before;
+- lanes added: 110 files, exactly the three drift classes above
+  (85 × `+cuda_backend`, 20 × `+cairo_cpu_integration, riscv_cpu_integration,
+  riscv_metal_integration`, 5 × `+cairo_metal_integration,
+  riscv_metal_integration`).
+
+### Gate content is untouched
+
+Every lane's `commands` array in `ci-touchpoints-v1.json` is byte-identical to
+`191e409f`. Only `rules[]` (which prefixes trigger which lanes) changed. Verify
+with:
+
+```
+git diff 191e409f -- conformance/ci-touchpoints-v1.json | grep -c '"commands"'   # 0
+```
+
+### Validation run
+
+- `scripts/tests/test_ci_package_graph.py` — 28 tests (synthetic diamond graph,
+  live repository graph, plan integration, fail-open, determinism)
+- full `python3 -m unittest discover -s scripts/tests` — 1089 tests, OK
+- `python3 scripts/check_source_conformance.py` — no new violations
+- `python3 scripts/check_package_workspace.py` — PASS (17 packages, 51 edges)
+- `zig fmt --check build.zig build_support src tools` — clean
+- `actionlint .github/workflows/ci.yml` — 13 findings before, 13 after,
+  identical set. All pre-existing (unknown self-hosted runner labels,
+  release-gated `if: ${{ false }}` jobs, `workflow_dispatch` input typing).
+
+## Governance callouts
+
+**The orchestrator and user must review the workflow diff line by line.**
+`.github/**` and the conformance CI-plan documents are human-review territory.
+
+### Policy documents this change amends
+
+1. **`conformance/ci-touchpoints-v1.json` — AMENDED (authoritative; must stay
+   consistent with the workflow).** This is the live input to
+   `ci_scope_plan.py`, not documentation, so it cannot be left stale. `rules[]`
+   goes 29 → 35 entries: 18 package-owned prefixes shed the package lanes the
+   graph now derives, and rules with mixed package/non-package prefixes were
+   split so non-package prefixes keep their original lanes verbatim.
+   `lanes`, `always_lanes`, `product_scope_lanes`, `documentation_prefixes`,
+   and `externally_validated_prefixes` are unchanged.
+   `test_policy_carries_no_hand_written_package_lane_for_owned_prefixes` fails
+   if a graph-derivable lane is ever restated by hand again.
+
+2. **`conformance/build-architecture-ci-plan-v1.json` — NOT TOUCHED, and not
+   superseded.** Despite the name it is not the PR-lane plan: it is the
+   `architecture-authority` session's per-role command plan (BG-00…BG-14
+   evidence phases), driven by a `workflow_dispatch`-only workflow that never
+   runs on a PR. It has no lane concept and no overlap with lane triggering.
+   Deliberately left alone.
+
+3. **`.github/workflows/ci.yml` — AMENDED, 2 hunks, both in `focused-plan`'s
+   "Select affected product lanes" step.** No job was added, removed, renamed,
+   or re-guarded; no `needs`, `if`, `runs-on`, `permissions`, or action pin
+   changed. Review targets: the `SCOPE_ARGS` array and that `--full-matrix` is
+   reached on push-to-main and *only* there.
+
+4. **Autoresearch workflows — untouched**, as instructed:
+   `validate.yml`, `judge.yml`, `promote.yml`, `automerge.yml`, `record.yml`.
+   No change to the autoresearch CLI, ledger, MANIFEST, or `vectors/**`.
+
+## Residual risks
+
+1. **17 lanes are not package-derivable.** Product, aggregate, oracle, and
+   global lanes still select via the catalog and the surviving hand rules. The
+   same drift class can therefore still exist *there* — this increment neither
+   fixed nor measured it. A follow-up should extend the derivation to product
+   lanes by reading each product's declared module roots from the catalog and
+   mapping them to packages.
+
+2. **Cache warmth on skipped lanes.** A lane skipped across many PRs restores
+   from an older `restore-keys` prefix and pays a cold-ish first build when it
+   is eventually selected. The full matrix on push to main is the mitigation and
+   is why it is worth its cost.
+
+3. **`focused-plan` is a single point of failure** — if it fails,
+   `focused-verdict` fails closed (`test "$PLAN_RESULT" = success`). Correct,
+   but it means a resolver bug blocks all PRs. The 28 new contract tests run in
+   the `static` lane, which is always selected.
+
+4. **The 51-edge count is pinned in a test.** Adding a legitimate dependency
+   makes `test_workspace_shape_is_pinned` fail. That is intentional — the
+   closure consequences should be reviewed — but it is a friction point worth
+   naming.
+
+5. **`pr6-supremacy.yml`'s `contract-smoke` still runs unconditionally on every
+   PR** (~15 min). Out of scope here; the obvious next reduction.
+
+6. **`vectors/**` fails open to the full matrix**, so metallib and trace-vector
+   deliveries pay for everything (case (d)). Correct under the stated bias, but
+   if vector deliveries are frequent it is the highest-value place to add a
+   *narrow, deliberately reviewed* mapping.
+
+7. **Not executed in CI.** Everything above is local replay against historical
+   diffs plus static validation. The first real hosted run is the PR itself, and
+   the push-to-main full matrix is what will confirm the post-merge path.
+
+## Human-in-the-loop
+
+A human reviews this before use. The workflow and conformance-policy diffs in
+particular need line-by-line review before merge.

--- a/autoresearch/notes/2026-07-28-change-scoped-ci/note.md
+++ b/autoresearch/notes/2026-07-28-change-scoped-ci/note.md
@@ -186,7 +186,7 @@ enter a hosted matrix). `BEFORE` = the shipped selection at `191e409f`.
 
 | Case | Paths | FULL | BEFORE | AFTER | AFTER vs FULL | Note |
 |---|---|---|---|---|---|---|
-| (a) merged PR #125 `78556fe7...191e409f` | 117 | 30 | 30 | 30 | 0% | fails open — `scripts/riscv_poseidon_table_uniqueness.py`, `scripts/check_build_configure_closure.py`, `scripts/tests/test_ci.py` |
+| (a) merged PR #125 `78556fe7...191e409f` | 117 | 30 | 30 | 30 | 0% | fails open — three `scripts/` paths (the RISC-V Poseidon table-uniqueness operator tool, the build-configure-closure check, and a script test) |
 | (a′) PR #125, `scripts/**` removed | 114 | 30 | 30 | 30 | 0% | **still** full: `build_support/products/aggregate.zig` and `cairo_support.zig` are unmapped and fail open too |
 | (b) notes-only `ceb5b32f` | 1 | 30 | 1 | 1 | **97%** | `static` only |
 | (c) riscv-only `e6303646` | 13 | 30 | 9 | 9 | **70%** | no cairo, metal-device, or cuda-device lane |
@@ -270,6 +270,22 @@ git diff 191e409f -- conformance/ci-touchpoints-v1.json | grep -c '"commands"'  
 
 ## Residual risks
 
+0. **The full matrix on push to main now runs the self-hosted CUDA lane on
+   every merge — decide this explicitly.** `emit_github_output` sets
+   `cuda_required=true` whenever `native_cuda_device` is in the plan, so
+   `--full-matrix` means `focused-cuda` fires on **every** push to main, not
+   only merges touching CUDA paths. That lane needs the `[self-hosted, linux,
+   x64, cuda]` runner and a single healthy GPU; it is the one lane for which
+   "cheap insurance" does not hold, and if the runner is offline every
+   push-to-main CI run fails or queues.
+
+   Implemented as briefed (full matrix on push), but this is a deliberate
+   decision for the reviewer, not an obviously-correct default. If the cost is
+   unwanted, the narrower version is to exclude `hosted: false` lanes from the
+   push expansion — one condition in `select_lanes`'s `full_matrix` branch —
+   which keeps the post-merge net for all 30 hosted lanes and leaves the
+   device lanes diff-scoped as they are today.
+
 1. **17 lanes are not package-derivable.** Product, aggregate, oracle, and
    global lanes still select via the catalog and the surviving hand rules. The
    same drift class can therefore still exist *there* — this increment neither
@@ -300,7 +316,16 @@ git diff 191e409f -- conformance/ci-touchpoints-v1.json | grep -c '"commands"'  
    if vector deliveries are frequent it is the highest-value place to add a
    *narrow, deliberately reviewed* mapping.
 
-7. **Not executed in CI.** Everything above is local replay against historical
+7. **Notes are script-reachability entry points.**
+   `scripts/tests/test_script_reachability.py` seeds its reachability walk from
+   `autoresearch/**/*.md`, so writing a literal `scripts/<name>.py` path in a
+   note marks that script "gate-reachable". The first draft of this note did
+   exactly that and failed the ratchet by sheltering a declared operator tool.
+   Worked around by naming the tool prosaically instead. The underlying
+   sharpness — prose can silence an anti-sprawl ratchet — is worth a separate
+   look; it is not this increment's to fix.
+
+8. **Not executed in CI.** Everything above is local replay against historical
    diffs plus static validation. The first real hosted run is the PR itself, and
    the push-to-main full matrix is what will confirm the post-merge path.
 

--- a/autoresearch/notes/2026-07-28-change-scoped-ci/note.md
+++ b/autoresearch/notes/2026-07-28-change-scoped-ci/note.md
@@ -170,9 +170,15 @@ The existing shape is kept and I recommend keeping it:
   per-job `if:` guards. That would be a ~2000-line workflow rewrite for worse
   branch-protection ergonomics.
 - Two changes, both additive:
-  - **push to main takes the full matrix** (`--full-matrix`), not a scoped
-    selection. Post-merge safety net for any selection mistake a PR made, and it
-    keeps every lane's compiler cache warm for the next PR.
+  - **push to main takes the full HOSTED matrix** (`--full-matrix`), not a
+    scoped selection. Post-merge safety net for any hosted-lane selection
+    mistake a PR made, and it keeps every hosted lane's compiler cache warm
+    for the next PR. Lanes marked `hosted: false` (the self-hosted device
+    lanes) keep the diff-scoped selection on push — exactly the behavior they
+    had before this change, so an unrelated merge can never summon an offline
+    device runner. (This section originally described an unconditional full
+    matrix; the hosted partition landed in a follow-up commit and this record
+    was amended to match — reviewer A finding F1.)
   - **`--github-summary`** writes a table of all 34 lanes with
     selected/skipped and the triggering path, so a skipped lane is a visible,
     explained decision rather than a job that never appeared. This is the cheap
@@ -223,7 +229,7 @@ git diff 191e409f -- conformance/ci-touchpoints-v1.json | grep -c '"commands"'  
 
 ### Validation run
 
-- `scripts/tests/test_ci_package_graph.py` — 28 tests (synthetic diamond graph,
+- `scripts/tests/test_ci_package_graph.py` — 30 tests (synthetic diamond graph,
   live repository graph, plan integration, fail-open, determinism)
 - full `python3 -m unittest discover -s scripts/tests` — 1089 tests, OK
 - `python3 scripts/check_source_conformance.py` — no new violations
@@ -270,21 +276,16 @@ git diff 191e409f -- conformance/ci-touchpoints-v1.json | grep -c '"commands"'  
 
 ## Residual risks
 
-0. **The full matrix on push to main now runs the self-hosted CUDA lane on
-   every merge — decide this explicitly.** `emit_github_output` sets
-   `cuda_required=true` whenever `native_cuda_device` is in the plan, so
-   `--full-matrix` means `focused-cuda` fires on **every** push to main, not
-   only merges touching CUDA paths. That lane needs the `[self-hosted, linux,
-   x64, cuda]` runner and a single healthy GPU; it is the one lane for which
-   "cheap insurance" does not hold, and if the runner is offline every
-   push-to-main CI run fails or queues.
-
-   Implemented as briefed (full matrix on push), but this is a deliberate
-   decision for the reviewer, not an obviously-correct default. If the cost is
-   unwanted, the narrower version is to exclude `hosted: false` lanes from the
-   push expansion — one condition in `select_lanes`'s `full_matrix` branch —
-   which keeps the post-merge net for all 30 hosted lanes and leaves the
-   device lanes diff-scoped as they are today.
+0. **RESOLVED before merge: the push-time full matrix spares self-hosted
+   lanes.** As first implemented, `--full-matrix` would have fired
+   `focused-cuda` on every push to main, wedging merges whenever the
+   `[self-hosted, linux, x64, cuda]` runner is offline. The narrower version
+   this risk proposed is what shipped: `hosted: false` lanes are excluded
+   from the push expansion and keep diff-scoped selection (three contract
+   tests pin the partition). Reviewer B additionally established that base
+   pushes were already entirely diff-scoped, so the shipped change strictly
+   EXPANDS push coverage for the 30 hosted lanes and leaves self-hosted push
+   behavior byte-identical to before.
 
 1. **17 lanes are not package-derivable.** Product, aggregate, oracle, and
    global lanes still select via the catalog and the surviving hand rules. The
@@ -300,7 +301,7 @@ git diff 191e409f -- conformance/ci-touchpoints-v1.json | grep -c '"commands"'  
 
 3. **`focused-plan` is a single point of failure** — if it fails,
    `focused-verdict` fails closed (`test "$PLAN_RESULT" = success`). Correct,
-   but it means a resolver bug blocks all PRs. The 28 new contract tests run in
+   but it means a resolver bug blocks all PRs. The 30 new contract tests run in
    the `static` lane, which is always selected.
 
 4. **The 51-edge count is pinned in a test.** Adding a legitimate dependency

--- a/autoresearch/notes/2026-07-28-change-scoped-ci/transcripts/session-01.md
+++ b/autoresearch/notes/2026-07-28-change-scoped-ci/transcripts/session-01.md
@@ -138,8 +138,8 @@ ones touching only RISC-V package paths (`e6303646`, `a0e594e6`), took the
 notes-only `ceb5b32f`, the metallib delivery `19026cae`, and PR #125's
 `78556fe7...191e409f`.
 
-The brief predicted PR #125 would fail open on
-`scripts/riscv_poseidon_table_uniqueness.py`, and asked for the counterfactual
+The brief predicted PR #125 would fail open on the RISC-V Poseidon
+table-uniqueness operator tool under `scripts/`, and asked for the counterfactual
 without it. It does fail open — but the counterfactual **also** comes out full,
 because the same PR touched `build_support/products/aggregate.zig` and
 `build_support/products/cairo_support.zig`, which are unmapped and fail open

--- a/autoresearch/notes/2026-07-28-change-scoped-ci/transcripts/session-01.md
+++ b/autoresearch/notes/2026-07-28-change-scoped-ci/transcripts/session-01.md
@@ -1,0 +1,204 @@
+# Session 01 — change-scoped CI
+
+Implementation: Claude Opus 4.5. Orchestration: Claude Fable 5.
+Worktree `/private/tmp/stwo-zig-cairo-native-throughput-10x`, branch
+`feat/change-scoped-ci`, base `191e409f`.
+
+## 1. Survey (and the premise failing)
+
+Brief: "every PR runs every CI gate (~35+ jobs) regardless of what the diff
+touches; build change-scoped CI."
+
+Enumerated `.github/workflows/` — 14 workflows. Extracted `on:` blocks. Only
+five trigger on `pull_request` at all, and three of those are already scoped:
+
+- `ci.yml` — job `focused-plan` runs `scripts/ci_scope_plan.py --base --head`
+  and emits `linux_matrix` / `macos_matrix` / `cuda_required`, consumed by
+  `focused-linux` / `focused-macos` / `focused-cuda` via `fromJSON`.
+- `riscv-sail-differential.yml` — a `scope` job computing `live_required` from
+  the merge-base diff, same pattern.
+- `benchmark-pages.yml` — `on.pull_request.paths` YAML anchor.
+- `pr6-supremacy.yml` — unconditional `contract-smoke`.
+- the autoresearch harness workflows — out of scope by instruction.
+
+The rest (`audit`, `architecture-authority`, `native-oracle`,
+`metal-calibration`, `qualify-fork`) are `workflow_dispatch`/`schedule` only.
+
+So the premise is stale. Decision: do **not** rebuild what exists. Find the
+actual defect in what exists.
+
+Read `ci_scope_plan.py` (303 lines) and `conformance/ci-touchpoints-v1.json`
+(404 lines). Selection is `always_lanes ∪ catalog(product_scope_lanes) ∪
+rules[]`, fail-open when a path matches nothing. The defect is in `rules[]`: it
+is a hand-written per-prefix lane list that duplicates the package dependency
+graph. The brief explicitly forbids exactly that ("do NOT hand-maintain a
+parallel path list for package-owned paths"), so the increment writes itself.
+
+Also read `conformance/build-architecture-ci-plan-v1.json` before touching
+anything. Despite the name it is *not* the PR lane plan — it is the
+`architecture-authority` session's per-role BG-00…BG-14 command plan, from a
+dispatch-only workflow, with no lane concept. Left alone.
+
+## 2. Establishing the graph and measuring the drift
+
+```
+packages 17  edges 51
+```
+matching `scripts/check_package_workspace.py`'s own report
+(`PASS (17 packages, 17 public modules, 51 dependency edges)`).
+
+Then the mapping question: how do lanes bind to packages? Rather than write a
+new table, noticed that 17 of the 34 lanes already name their package's
+`build.zig` in a `--build-file` argument. So lane → package is derivable from
+the policy itself — one fewer thing that can drift.
+
+Computed, per package, the reverse-dependency closure and compared it against
+the hand-written rule for that package's own prefix:
+
+```
+src/backend             MISSING=['cairo_cpu_integration', 'riscv_cpu_integration',
+                                 'riscv_metal_integration'] EXTRA=[]
+src/backends/cpu_scalar MISSING=['cairo_metal_integration',
+                                 'riscv_metal_integration'] EXTRA=[]
+src/core                MISSING=['cuda_backend'] EXTRA=[]
+```
+
+`EXTRA` empty everywhere: the hand list is a strict subset of the truth. It
+under-selects, which is the unsafe direction — a `src/backend` change could
+break `riscv_cpu_integration` and no lane would run.
+
+## 3. The resolver
+
+`scripts/ci_package_graph.py`, stdlib only, 220 lines. Notable decisions:
+
+- dependency *paths* in the contracts are resolved back to package *names*,
+  with `..` normalised; an unresolvable path raises rather than silently
+  dropping an edge;
+- `reverse_closure` iterates to a fixed point rather than recursing, so a cyclic
+  graph terminates here even though the workspace validator rejects cycles;
+- `owning_package` uses longest-prefix so a nested package is never shadowed,
+  and returns `None` rather than guessing — the fail-open decision belongs to
+  the caller, which is why `selection()` returns unowned paths instead of
+  swallowing them;
+- `lane_packages` raises if a lane's `--build-file` points at a directory no
+  contract owns, because such a lane would silently never be graph-selected.
+
+Smoke check:
+
+```
+packages 17 edges 51   bindings 17
+['src/core/fields/m31.zig']       -> 16 lanes
+['src/frontends/cairo/air.zig']   ->  4 lanes (cairo_* only)
+['src/backend/mod.zig']           -> 14 lanes
+['scripts/foo.py']                ->  0 lanes, unowned ['scripts/foo.py']
+```
+
+`src/core` selecting 16 of 17 is right: `stwo_metal_session` has no
+dependencies, so nothing reaches it from core.
+
+Wired into `ci_scope_plan.select_lanes` as an additional per-path union, before
+the existing rules and fail-open. Ran the pre-existing suites first with the
+graph *added but the policy not yet trimmed*: 51 tests OK. Backward compatible,
+because fixture policies have no `--build-file` lanes and so bind nothing.
+
+## 4. Trimming the policy
+
+Migration, applied programmatically rather than by hand: for each rule, partition
+prefixes into package-owned and other. Rules with mixed prefixes are **split**,
+so non-package prefixes keep their original lanes verbatim — otherwise stripping
+`native_cuda_integration` from a rule that also covers `scripts/cuda_` and
+`tools/stwo-cuda-adapter-rs` would have silently dropped coverage for those.
+Each package-owned prefix then sheds exactly the lanes its own graph closure
+derives.
+
+```
+rules 29 -> 35
+18 prefixes shed hand-listed package lanes
+```
+
+Then the property that actually matters. Replayed old algorithm vs new over
+**every tracked file**:
+
+```
+6728 tracked files
+=== DROPPED lanes (must be empty) ===
+  none — every path selects at least what it selected before
+=== ADDED lanes (drift fixed) ===
+  +['cuda_backend']  85 files
+  +['cairo_cpu_integration','riscv_cpu_integration','riscv_metal_integration']  20 files
+  +['cairo_metal_integration','riscv_metal_integration']  5 files
+```
+
+Exactly the three predicted drift classes, nothing else, nothing lost.
+
+## 5. Replay against real history
+
+Found real commits rather than inventing diffs: scanned 400 commits of main for
+ones touching only RISC-V package paths (`e6303646`, `a0e594e6`), took the
+notes-only `ceb5b32f`, the metallib delivery `19026cae`, and PR #125's
+`78556fe7...191e409f`.
+
+The brief predicted PR #125 would fail open on
+`scripts/riscv_poseidon_table_uniqueness.py`, and asked for the counterfactual
+without it. It does fail open — but the counterfactual **also** comes out full,
+because the same PR touched `build_support/products/aggregate.zig` and
+`build_support/products/cairo_support.zig`, which are unmapped and fail open
+too. Reported as measured, not as predicted.
+
+Full table in the note. The honest shape of the result: reductions of 97% / 70%
+/ 73% on notes-only, riscv-only, and cairo-only diffs were **already** being
+achieved before this branch. This increment's numbers move *up* in one case
+(`src/core`: 24 → 25 lanes, `+cuda_backend`). It is a correctness fix, not a
+job-count win, and the note says so in its first section.
+
+## 6. Workflow wiring
+
+Considered converting the `fromJSON` matrix into 34 statically-declared jobs
+with per-job `if:` guards, for visibly-skipped lanes. Rejected: `focused-verdict`
+already is the single always-run required check, and it asserts unselected lanes
+are genuinely `skipped` rather than merely absent. That is better
+branch-protection ergonomics than 34 required checks, and the conversion would
+be a ~2000-line rewrite of a working workflow.
+
+Two additive changes instead, both inside `focused-plan`'s scope step:
+
+- `--full-matrix` on push to main. Previously pushes were *also* diff-scoped,
+  so there was no post-merge safety net. Now there is, and it keeps every lane's
+  cache warm.
+- `--github-summary` writes a 34-row selected/skipped table with the triggering
+  path — the cheap substitute for statically-declared skipped jobs.
+
+Used a bash array (`SCOPE_ARGS+=(--full-matrix)`) rather than an unquoted
+variable so the shell stays lint-clean. Moved the `full_matrix` short-circuit
+above the empty-diff guard so a push with an unusable `github.event.before`
+still yields the full matrix rather than erroring.
+
+## 7. Validation
+
+```
+scripts.tests.test_ci_package_graph                       28 tests OK
+python3 -m unittest discover -s scripts/tests           1089 tests OK (18 skipped)
+python3 scripts/check_source_conformance.py             no new violations
+python3 scripts/check_package_workspace.py              PASS (17 packages, 51 edges)
+zig fmt --check build.zig build_support src tools        clean
+git diff 191e409f -- conformance/...json | grep -c '"commands"'   0
+actionlint .github/workflows/ci.yml                     13 findings before, 13 after,
+                                                        identical set (all pre-existing)
+```
+
+The `"commands"` count of 0 is the discipline check: no gate's *content* moved,
+only its triggering.
+
+## 8. Commits
+
+- `ef2f76aa` Derive focused CI package lanes from the package graph
+- packaging commit for this note and transcript
+
+## What I would not claim
+
+- No hosted CI run happened; this is local replay plus static validation.
+- The 17 non-package lanes (product, aggregate, oracle, global) were neither
+  derived nor audited for the same drift class. That is the obvious follow-up
+  and is listed as residual risk 1.
+- `vectors/**` and `pr6-supremacy.yml` remain unreduced. Both are named as
+  known, deliberate gaps rather than quietly left out.

--- a/conformance/ci-touchpoints-v1.json
+++ b/conformance/ci-touchpoints-v1.json
@@ -308,55 +308,71 @@
     },
     {
       "prefixes": ["src/backends/metal"],
-      "lanes": ["metal_backend", "riscv_metal_integration", "cairo_metal_integration", "package", "native_metal", "riscv_metal", "aggregate_metal", "metal_compile"]
+      "lanes": ["package", "native_metal", "riscv_metal", "aggregate_metal", "metal_compile"]
     },
     {
-      "prefixes": ["src/backends/metal/shaders", "src/backends/metal/kernels.metal", "src/backends/metal/shader_manifest.zig", "src/tools/metal_core_aot", "build_support/backends/metal_aot.zig", "scripts/metal_core_aot_receipt"],
+      "prefixes": ["src/tools/metal_core_aot", "build_support/backends/metal_aot.zig", "scripts/metal_core_aot_receipt"],
       "lanes": ["metal_aot"]
     },
     {
-      "prefixes": ["src/core", "src/prover", "src/backend", "src/backends/cpu_scalar", "src/examples", "src/interop/proof_wire", "tools/stwo-interop-rs"],
+      "prefixes": ["src/backends/metal/shaders", "src/backends/metal/kernels.metal", "src/backends/metal/shader_manifest.zig"],
+      "lanes": ["metal_aot"]
+    },
+    {
+      "prefixes": ["tools/stwo-interop-rs"],
+      "lanes": ["native_oracle"]
+    },
+    {
+      "prefixes": ["src/core", "src/prover", "src/backend", "src/backends/cpu_scalar", "src/examples", "src/interop/proof_wire"],
       "lanes": ["native_oracle"]
     },
     {
       "prefixes": ["src/core"],
-      "lanes": ["core", "backend_contracts", "prover", "riscv_frontend", "riscv_cpu_integration", "riscv_metal_integration", "cairo_frontend", "cairo_cpu_integration", "cairo_metal_integration", "cairo_cuda_integration", "cpu_backend", "metal_backend", "proof_wire", "native_examples", "native_cuda_integration", "package", "aggregate_metal"]
+      "lanes": ["package", "aggregate_metal"]
     },
     {
       "prefixes": ["src/backend"],
-      "lanes": ["backend_contracts", "prover", "riscv_frontend", "cairo_frontend", "cairo_metal_integration", "cairo_cuda_integration", "cpu_backend", "cuda_backend", "metal_backend", "native_examples", "native_cuda_integration", "package", "aggregate_metal"]
+      "lanes": ["package", "aggregate_metal"]
     },
     {
       "prefixes": ["src/prover"],
-      "lanes": ["prover", "riscv_frontend", "riscv_cpu_integration", "riscv_metal_integration", "cairo_frontend", "cairo_cpu_integration", "cairo_metal_integration", "cairo_cuda_integration", "cpu_backend", "metal_backend", "native_examples", "native_cuda_integration", "package", "aggregate_metal"]
+      "lanes": ["package", "aggregate_metal"]
     },
     {
       "prefixes": ["src/backends/cpu_scalar"],
-      "lanes": ["cpu_backend", "riscv_cpu_integration", "cairo_cpu_integration", "metal_backend", "native_examples", "native_cuda_integration", "cairo_cuda_integration", "package"]
+      "lanes": ["package"]
     },
     {
       "prefixes": ["src/frontends/riscv"],
-      "lanes": ["riscv_frontend", "riscv_cpu_integration", "riscv_metal_integration", "package", "riscv_cpu", "aggregate_cpu", "aggregate_metal"]
+      "lanes": ["package", "riscv_cpu", "aggregate_cpu", "aggregate_metal"]
     },
     {
       "prefixes": ["src/integrations/riscv_cpu"],
-      "lanes": ["riscv_cpu_integration", "package", "aggregate_metal"]
+      "lanes": ["package", "aggregate_metal"]
     },
     {
       "prefixes": ["src/frontends/cairo"],
-      "lanes": ["cairo_frontend", "cairo_cpu_integration", "cairo_metal_integration", "cairo_cuda_integration", "package", "cairo_cpu", "cairo_metal"]
+      "lanes": ["package", "cairo_cpu", "cairo_metal"]
     },
     {
       "prefixes": ["src/integrations/cairo_cpu"],
-      "lanes": ["cairo_cpu_integration", "package"]
+      "lanes": ["package"]
     },
     {
-      "prefixes": ["src/integrations/cairo_cpu", "src/products/cairo", "src/products/cairo_cpu", "src/stwo_cairo_cpu.zig", "build_support/products/cairo_cpu.zig", "build_support/products/cairo_cpu", "build_support/products/cairo_support.zig"],
+      "prefixes": ["src/products/cairo", "src/products/cairo_cpu", "src/stwo_cairo_cpu.zig", "build_support/products/cairo_cpu.zig", "build_support/products/cairo_cpu", "build_support/products/cairo_support.zig"],
       "lanes": ["cairo_cpu", "cairo_metal"]
     },
     {
-      "prefixes": ["src/integrations/cairo_metal", "src/backends/metal/cairo", "src/products/cairo_metal", "src/stwo_cairo_metal.zig", "build_support/products/cairo_metal.zig", "build_support/products/cairo_metal"],
+      "prefixes": ["src/integrations/cairo_cpu"],
+      "lanes": ["cairo_cpu", "cairo_metal"]
+    },
+    {
+      "prefixes": ["src/products/cairo_metal", "src/stwo_cairo_metal.zig", "build_support/products/cairo_metal.zig", "build_support/products/cairo_metal"],
       "lanes": ["cairo_metal_integration", "package", "cairo_metal", "metal_compile"]
+    },
+    {
+      "prefixes": ["src/integrations/cairo_metal", "src/backends/metal/cairo"],
+      "lanes": ["package", "cairo_metal", "metal_compile"]
     },
     {
       "prefixes": ["build_support/products/riscv_cuda.zig"],
@@ -368,31 +384,39 @@
     },
     {
       "prefixes": ["src/integrations/riscv_metal"],
-      "lanes": ["riscv_metal_integration", "package"]
+      "lanes": ["package"]
     },
     {
       "prefixes": ["src/tools/metal_session"],
-      "lanes": ["metal_session", "cairo_metal_integration", "package", "cairo_metal", "metal_compile"]
+      "lanes": ["package", "cairo_metal", "metal_compile"]
     },
     {
       "prefixes": ["src/interop/proof_wire"],
-      "lanes": ["proof_wire", "native_examples", "native_cuda_integration", "cairo_cuda_integration", "package", "native_cpu", "native_oracle", "riscv_cpu", "aggregate_cpu", "native_cuda_static", "native_cuda_device", "native_metal", "aggregate_metal", "metal_compile"]
+      "lanes": ["package", "native_cpu", "native_oracle", "riscv_cpu", "aggregate_cpu", "native_cuda_static", "native_cuda_device", "native_metal", "aggregate_metal", "metal_compile"]
     },
     {
       "prefixes": ["src/examples"],
-      "lanes": ["native_examples", "native_cuda_integration", "cairo_cuda_integration", "package", "native_cpu", "native_oracle", "aggregate_cpu", "native_cuda_static", "native_cuda_device", "native_metal", "aggregate_metal", "metal_compile"]
+      "lanes": ["package", "native_cpu", "native_oracle", "aggregate_cpu", "native_cuda_static", "native_cuda_device", "native_metal", "aggregate_metal", "metal_compile"]
     },
     {
       "prefixes": ["src/backends/cuda"],
-      "lanes": ["cuda_backend", "native_cuda_integration", "cairo_cuda_integration", "package", "native_cuda_static", "native_cuda_device"]
+      "lanes": ["package", "native_cuda_static", "native_cuda_device"]
     },
     {
-      "prefixes": ["build_support/products/native_cuda.zig", "build_support/backends/cuda.zig", "build_support/backends/cuda_tools.zig", "src/integrations/native_cuda", "src/products/native_cuda", "scripts/cuda_", "tests/cuda", "tools/stwo-cuda-adapter-rs"],
+      "prefixes": ["build_support/products/native_cuda.zig", "build_support/backends/cuda.zig", "build_support/backends/cuda_tools.zig", "src/products/native_cuda", "scripts/cuda_", "tests/cuda", "tools/stwo-cuda-adapter-rs"],
       "lanes": ["native_cuda_integration", "cairo_cuda_integration", "package", "native_cuda_static", "native_cuda_device"]
     },
     {
-      "prefixes": ["build_support/products/cairo_cuda.zig", "src/cairo_cuda.zig", "src/integrations/cairo_cuda", "src/products/cairo_cuda", "src/tools/cuda_native_ec_composite_oracle"],
+      "prefixes": ["src/integrations/native_cuda"],
+      "lanes": ["package", "native_cuda_static", "native_cuda_device"]
+    },
+    {
+      "prefixes": ["build_support/products/cairo_cuda.zig", "src/cairo_cuda.zig", "src/products/cairo_cuda", "src/tools/cuda_native_ec_composite_oracle"],
       "lanes": ["cairo_cuda_integration", "package", "native_cuda_static"]
+    },
+    {
+      "prefixes": ["src/integrations/cairo_cuda"],
+      "lanes": ["package", "native_cuda_static"]
     },
     {
       "prefixes": [".github/workflows", ".githooks", "scripts/ci_scope_plan.py", "scripts/ci_scope_run.py", "scripts/ci_scope_push.py", "conformance/ci-touchpoints-v1.json"],

--- a/scripts/ci_package_graph.py
+++ b/scripts/ci_package_graph.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Derive focused CI package lanes from the package-contract dependency graph.
+
+The repository declares one ``package.contract.json`` per independently
+buildable Zig package. Those contracts are the single machine-readable source
+of both package ownership (the contract's directory owns every path beneath it)
+and the dependency graph (``dependencies`` maps a dependency module name to a
+relative package path).
+
+A change inside a package must exercise that package's own focused lane and
+every lane whose package transitively depends on it — the reverse-dependency
+closure. Deriving that closure here replaces a hand-maintained per-prefix lane
+list, which had drifted: it under-selected transitive consumers (for example a
+``src/backend`` change did not select ``riscv_cpu_integration``, which reaches
+the backend contracts through ``cpu_backend``).
+
+Lane-to-package binding is derived, not declared: a focused lane that builds a
+package names that package's ``build.zig`` in its ``--build-file`` argument.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable, Mapping
+
+
+CONTRACT_NAME = "package.contract.json"
+CONTRACT_ROOT = "src"
+BUILD_FILE_FLAG = "--build-file"
+BUILD_FILE_NAME = "build.zig"
+
+
+class GraphError(ValueError):
+    """A package graph or lane binding that cannot be trusted for selection."""
+
+
+@dataclass(frozen=True)
+class Package:
+    """One independently buildable package and its declared dependencies."""
+
+    name: str
+    directory: str
+    dependencies: frozenset[str]
+
+
+def _posix(path: Path, root: Path) -> str:
+    return PurePosixPath(path.relative_to(root)).as_posix()
+
+
+def load_packages(root: Path) -> dict[str, Package]:
+    """Read every package contract under ``root`` into a name-keyed graph.
+
+    Dependency edges are resolved from the contract's declared relative paths
+    back to package names, so a renamed or moved package fails loudly here
+    rather than silently dropping lanes from the closure.
+    """
+    directories: dict[str, str] = {}
+    raw: dict[str, dict[str, str]] = {}
+    for contract_path in sorted((root / CONTRACT_ROOT).rglob(CONTRACT_NAME)):
+        try:
+            payload = json.loads(contract_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise GraphError(f"unreadable package contract {contract_path}: {error}") from error
+        if not isinstance(payload, dict):
+            raise GraphError(f"package contract is not an object: {contract_path}")
+        name = payload.get("package")
+        dependencies = payload.get("dependencies")
+        if not isinstance(name, str) or not name:
+            raise GraphError(f"package contract has no package name: {contract_path}")
+        if not isinstance(dependencies, dict) or any(
+            not isinstance(key, str) or not isinstance(value, str)
+            for key, value in dependencies.items()
+        ):
+            raise GraphError(f"package contract has malformed dependencies: {contract_path}")
+        if name in directories:
+            raise GraphError(f"duplicate package name in the workspace: {name}")
+        directory = _posix(contract_path.parent, root)
+        directories[name] = directory
+        raw[name] = dict(dependencies)
+
+    if not directories:
+        raise GraphError(f"no package contracts found under {root / CONTRACT_ROOT}")
+
+    by_directory = {directory: name for name, directory in directories.items()}
+    packages: dict[str, Package] = {}
+    for name, dependencies in raw.items():
+        resolved: set[str] = set()
+        for relative in dependencies.values():
+            target = (PurePosixPath(directories[name]) / relative).as_posix()
+            # PurePosixPath keeps ".." literal; normalize it so the declared
+            # relative dependency path resolves to a real package directory.
+            normalized = _normalize(target)
+            dependency = by_directory.get(normalized)
+            if dependency is None:
+                raise GraphError(
+                    f"package {name} depends on {relative}, which is not a package directory"
+                )
+            resolved.add(dependency)
+        packages[name] = Package(name, directories[name], frozenset(resolved))
+    return packages
+
+
+def _normalize(path: str) -> str:
+    parts: list[str] = []
+    for part in PurePosixPath(path).parts:
+        if part == ".":
+            continue
+        if part == "..":
+            if not parts:
+                raise GraphError(f"dependency path escapes the repository: {path}")
+            parts.pop()
+            continue
+        parts.append(part)
+    return PurePosixPath(*parts).as_posix() if parts else ""
+
+
+def edge_count(packages: Mapping[str, Package]) -> int:
+    """Total resolved dependency edges — the number the workspace validator sees."""
+    return sum(len(package.dependencies) for package in packages.values())
+
+
+def reverse_closure(packages: Mapping[str, Package], seeds: Iterable[str]) -> frozenset[str]:
+    """Every package that transitively depends on any seed, plus the seeds.
+
+    Iterated to a fixed point rather than recursively, so a cyclic graph (which
+    the workspace validator rejects independently) terminates here regardless.
+    """
+    affected = {name for name in seeds if name in packages}
+    while True:
+        additions = {
+            name
+            for name, package in packages.items()
+            if name not in affected and package.dependencies & affected
+        }
+        if not additions:
+            return frozenset(affected)
+        affected |= additions
+
+
+def lane_packages(policy: Mapping[str, Any], packages: Mapping[str, Package]) -> dict[str, str]:
+    """Map each focused lane that builds one package to that package's name.
+
+    Derived from the lane's own ``--build-file`` argument, so adding a package
+    lane to the policy needs no second declaration here. A lane pointing at a
+    build file that no package owns is an error: it would silently never be
+    selected by the graph.
+    """
+    lanes = policy.get("lanes")
+    if not isinstance(lanes, dict):
+        raise GraphError("CI touchpoint policy has no lanes")
+    by_directory = {package.directory: name for name, package in packages.items()}
+    bindings: dict[str, str] = {}
+    for lane, spec in sorted(lanes.items()):
+        if not isinstance(spec, dict):
+            raise GraphError(f"CI lane {lane} is malformed")
+        for command in spec.get("commands", []):
+            if not isinstance(command, list):
+                continue
+            for index, argument in enumerate(command):
+                if argument != BUILD_FILE_FLAG or index + 1 >= len(command):
+                    continue
+                build_file = PurePosixPath(str(command[index + 1]))
+                if build_file.name != BUILD_FILE_NAME:
+                    raise GraphError(f"CI lane {lane} builds an unexpected file: {build_file}")
+                directory = build_file.parent.as_posix()
+                package = by_directory.get(directory)
+                if package is None:
+                    raise GraphError(
+                        f"CI lane {lane} builds {build_file}, which no package contract owns"
+                    )
+                existing = bindings.get(lane)
+                if existing is not None and existing != package:
+                    raise GraphError(
+                        f"CI lane {lane} builds more than one package: {existing}, {package}"
+                    )
+                bindings[lane] = package
+    return bindings
+
+
+def owning_package(path: str, packages: Mapping[str, Package]) -> str | None:
+    """The package owning ``path``, or ``None`` when no package claims it.
+
+    Longest-prefix wins so a nested package directory is never shadowed by its
+    parent. ``None`` is the caller's fail-open signal, not a safe default.
+    """
+    best: str | None = None
+    best_length = -1
+    for name, package in packages.items():
+        directory = package.directory
+        if path == directory or path.startswith(directory + "/"):
+            if len(directory) > best_length:
+                best, best_length = name, len(directory)
+    return best
+
+
+def selection(
+    changed_paths: Iterable[str],
+    packages: Mapping[str, Package],
+    bindings: Mapping[str, str],
+) -> tuple[frozenset[str], frozenset[str]]:
+    """Return (selected lanes, unowned paths) for the package-owned diff slice.
+
+    Unowned paths are returned rather than ignored: the caller decides the
+    fail-open policy for them.
+    """
+    seeds: set[str] = set()
+    unowned: set[str] = set()
+    for path in changed_paths:
+        package = owning_package(path, packages)
+        if package is None:
+            unowned.add(path)
+        else:
+            seeds.add(package)
+    if not seeds:
+        return frozenset(), frozenset(unowned)
+    affected = reverse_closure(packages, seeds)
+    lanes = {lane for lane, package in bindings.items() if package in affected}
+    return frozenset(lanes), frozenset(unowned)

--- a/scripts/ci_scope_plan.py
+++ b/scripts/ci_scope_plan.py
@@ -198,11 +198,12 @@ def select_lanes(
     paths = sorted({normalize_path(path) for path in changed_paths})
     if full_matrix:
         # Post-merge safety net: pushes to main re-run every hosted lane
-        # regardless of the diff, so a selection mistake cannot reach main
-        # unnoticed and every hosted lane's compiler cache stays warm for the
-        # next PR. Lanes marked hosted=false run on scarce self-hosted
-        # hardware that must not be summoned by unrelated merges; they keep
-        # the diff-scoped selection even on push.
+        # regardless of the diff, so a HOSTED-lane selection mistake cannot
+        # reach main unnoticed and every hosted lane's compiler cache stays
+        # warm for the next PR. Lanes marked hosted=false run on scarce
+        # self-hosted hardware that must not be summoned by unrelated merges;
+        # they keep the diff-scoped selection on push, exactly as they had
+        # before the full-matrix expansion existed.
         hosted = [
             lane
             for lane in sorted(policy["lanes"])
@@ -211,7 +212,7 @@ def select_lanes(
         reasons = {lane: ["full-matrix"] for lane in hosted}
         if paths:
             scoped, scoped_reasons = select_lanes(
-                changed_paths, catalog, policy, packages, False
+                paths, catalog, policy, packages, False
             )
             for lane in scoped:
                 if not policy["lanes"][lane].get("hosted", True):

--- a/scripts/ci_scope_plan.py
+++ b/scripts/ci_scope_plan.py
@@ -197,10 +197,26 @@ def select_lanes(
     bindings = ci_package_graph.lane_packages(policy, packages)
     paths = sorted({normalize_path(path) for path in changed_paths})
     if full_matrix:
-        # Post-merge safety net: pushes to main re-run every lane regardless of
-        # the diff, so a selection mistake cannot reach main unnoticed and every
-        # lane's compiler cache stays warm for the next PR.
-        return sorted(policy["lanes"]), {lane: ["full-matrix"] for lane in sorted(policy["lanes"])}
+        # Post-merge safety net: pushes to main re-run every hosted lane
+        # regardless of the diff, so a selection mistake cannot reach main
+        # unnoticed and every hosted lane's compiler cache stays warm for the
+        # next PR. Lanes marked hosted=false run on scarce self-hosted
+        # hardware that must not be summoned by unrelated merges; they keep
+        # the diff-scoped selection even on push.
+        hosted = [
+            lane
+            for lane in sorted(policy["lanes"])
+            if policy["lanes"][lane].get("hosted", True)
+        ]
+        reasons = {lane: ["full-matrix"] for lane in hosted}
+        if paths:
+            scoped, scoped_reasons = select_lanes(
+                changed_paths, catalog, policy, packages, False
+            )
+            for lane in scoped:
+                if not policy["lanes"][lane].get("hosted", True):
+                    reasons[lane] = scoped_reasons[lane]
+        return sorted(reasons), reasons
     if not paths:
         raise PlanError("CI diff contains no changed paths")
     selected = set(policy["always_lanes"])

--- a/scripts/ci_scope_plan.py
+++ b/scripts/ci_scope_plan.py
@@ -10,7 +10,12 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path, PurePosixPath
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping
+
+try:
+    from scripts import ci_package_graph
+except ModuleNotFoundError:  # Direct execution adds scripts/, not the repository root.
+    import ci_package_graph  # type: ignore[no-redef]
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -163,12 +168,39 @@ def is_externally_validated(path: str, policy: dict[str, Any]) -> bool:
     )
 
 
+def graph_lanes(
+    path: str,
+    packages: Mapping[str, ci_package_graph.Package],
+    bindings: Mapping[str, str],
+) -> set[str]:
+    """Focused package lanes selected by the package-contract dependency graph.
+
+    The changed path's owning package plus every package that transitively
+    depends on it. Derived from the contracts themselves, so the policy carries
+    no parallel hand-maintained path list for package-owned paths.
+    """
+    lanes, _ = ci_package_graph.selection([path], packages, bindings)
+    return set(lanes)
+
+
 def select_lanes(
-    changed_paths: Iterable[str], catalog: dict[str, Any], policy: dict[str, Any],
+    changed_paths: Iterable[str],
+    catalog: dict[str, Any],
+    policy: dict[str, Any],
+    packages: Mapping[str, ci_package_graph.Package] | None = None,
+    full_matrix: bool = False,
 ) -> tuple[list[str], dict[str, list[str]]]:
     validate_policy(policy)
     validate_catalog(catalog, policy)
+    if packages is None:
+        packages = ci_package_graph.load_packages(ROOT)
+    bindings = ci_package_graph.lane_packages(policy, packages)
     paths = sorted({normalize_path(path) for path in changed_paths})
+    if full_matrix:
+        # Post-merge safety net: pushes to main re-run every lane regardless of
+        # the diff, so a selection mistake cannot reach main unnoticed and every
+        # lane's compiler cache stays warm for the next PR.
+        return sorted(policy["lanes"]), {lane: ["full-matrix"] for lane in sorted(policy["lanes"])}
     if not paths:
         raise PlanError("CI diff contains no changed paths")
     selected = set(policy["always_lanes"])
@@ -176,6 +208,7 @@ def select_lanes(
     all_lanes = set(policy["lanes"])
     for path in paths:
         path_lanes = catalog_lanes(path, catalog, policy)
+        path_lanes.update(graph_lanes(path, packages, bindings))
         for rule in policy["rules"]:
             if any(owns(path, prefix) for prefix in rule["prefixes"]):
                 path_lanes.update(rule["lanes"])
@@ -261,6 +294,26 @@ def emit_github_output(path: Path, plan: dict[str, Any], policy: dict[str, Any])
         )
 
 
+def emit_github_summary(path: Path, plan: dict[str, Any], policy: dict[str, Any]) -> None:
+    """Record every lane and whether it was selected, so a skipped lane is a
+    visible, explained decision rather than a job that silently never appeared."""
+    selected = set(plan["lanes"])
+    with path.open("a", encoding="utf-8") as stream:
+        stream.write("### Focused CI lane selection\n\n")
+        stream.write(f"{len(selected)} of {len(policy['lanes'])} lanes selected.\n\n")
+        stream.write("| Lane | Host | Status | Reason |\n|---|---|---|---|\n")
+        for lane in sorted(policy["lanes"]):
+            host = policy["lanes"][lane]["host"]
+            if lane in selected:
+                triggers = plan["reasons"].get(lane, [])
+                head = triggers[0] if triggers else "selected"
+                extra = f" (+{len(triggers) - 1} more)" if len(triggers) > 1 else ""
+                stream.write(f"| `{lane}` | {host} | selected | `{head}`{extra} |\n")
+            else:
+                stream.write(f"| `{lane}` | {host} | skipped | no changed path reaches it |\n")
+        stream.write("\n")
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", type=Path, default=ROOT)
@@ -271,6 +324,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--changed-file", action="append", default=[])
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--github-output", type=Path)
+    parser.add_argument("--github-summary", type=Path)
+    parser.add_argument(
+        "--full-matrix",
+        action="store_true",
+        help="select every lane regardless of the diff (post-merge safety net)",
+    )
     args = parser.parse_args(argv)
     try:
         policy = strict_json(args.policy)
@@ -278,7 +337,8 @@ def main(argv: list[str] | None = None) -> int:
         changed = args.changed_file or git_changed_paths(
             args.root, args.base or f"{args.head}^", args.head,
         )
-        lanes, reasons = select_lanes(changed, catalog, policy)
+        packages = ci_package_graph.load_packages(args.root)
+        lanes, reasons = select_lanes(changed, catalog, policy, packages, args.full_matrix)
         head, tree = source_identity(args.root, args.head)
         plan = {
             "schema": "ci-scope-plan-v1",
@@ -292,7 +352,16 @@ def main(argv: list[str] | None = None) -> int:
         write_json(args.output, plan)
         if args.github_output is not None:
             emit_github_output(args.github_output, plan, policy)
-    except (OSError, UnicodeError, json.JSONDecodeError, subprocess.CalledProcessError, PlanError) as error:
+        if args.github_summary is not None:
+            emit_github_summary(args.github_summary, plan, policy)
+    except (
+        OSError,
+        UnicodeError,
+        json.JSONDecodeError,
+        subprocess.CalledProcessError,
+        PlanError,
+        ci_package_graph.GraphError,
+    ) as error:
         print(f"CI scope plan: FAIL: {error}", file=sys.stderr)
         return 2
     print(f"CI scope plan: {len(lanes)} lanes ({','.join(lanes)})")

--- a/scripts/tests/test_ci_package_graph.py
+++ b/scripts/tests/test_ci_package_graph.py
@@ -287,7 +287,7 @@ class PlanIntegrationTest(unittest.TestCase):
             len(self.select("src/integrations/cairo_cpu/mod.zig")),
         )
 
-    def test_push_full_matrix_selects_every_lane(self) -> None:
+    def test_push_full_matrix_selects_every_hosted_lane(self) -> None:
         lanes, reasons = ci_scope_plan.select_lanes(
             ["autoresearch/notes/x/note.md"],
             self.catalog,
@@ -295,14 +295,60 @@ class PlanIntegrationTest(unittest.TestCase):
             self.packages,
             full_matrix=True,
         )
-        self.assertEqual(set(lanes), set(POLICY["lanes"]))
+        hosted = {
+            lane
+            for lane in POLICY["lanes"]
+            if POLICY["lanes"][lane].get("hosted", True)
+        }
+        self.assertEqual(set(lanes), hosted)
         self.assertEqual(reasons["static"], ["full-matrix"])
+
+    def test_push_full_matrix_spares_unselected_self_hosted_lanes(self) -> None:
+        lanes, reasons = ci_scope_plan.select_lanes(
+            ["autoresearch/notes/x/note.md"],
+            self.catalog,
+            POLICY,
+            self.packages,
+            full_matrix=True,
+        )
+        for lane in lanes:
+            if not POLICY["lanes"][lane].get("hosted", True):
+                self.fail(
+                    f"self-hosted lane {lane} entered the push full matrix "
+                    "on a notes-only diff"
+                )
+
+    def test_push_full_matrix_keeps_diff_selected_self_hosted_lanes(self) -> None:
+        self_hosted = {
+            lane
+            for lane in POLICY["lanes"]
+            if not POLICY["lanes"][lane].get("hosted", True)
+        }
+        if not self_hosted:
+            self.skipTest("policy declares no self-hosted lanes")
+        scoped, _ = ci_scope_plan.select_lanes(
+            ["build.zig"], self.catalog, POLICY, self.packages, full_matrix=False
+        )
+        expected = self_hosted & set(scoped)
+        if not expected:
+            self.skipTest("fail-open selection reaches no self-hosted lane")
+        lanes, reasons = ci_scope_plan.select_lanes(
+            ["build.zig"], self.catalog, POLICY, self.packages, full_matrix=True
+        )
+        for lane in expected:
+            self.assertIn(lane, lanes)
+            self.assertNotEqual(reasons[lane], ["full-matrix"])
 
     def test_full_matrix_survives_an_empty_diff(self) -> None:
         lanes, _ = ci_scope_plan.select_lanes(
             [], self.catalog, POLICY, self.packages, full_matrix=True
         )
-        self.assertEqual(set(lanes), set(POLICY["lanes"]))
+        hosted = {
+            lane
+            for lane in POLICY["lanes"]
+            if POLICY["lanes"][lane].get("hosted", True)
+        }
+        self.assertEqual(set(lanes), hosted)
 
     def test_summary_lists_every_lane_as_selected_or_skipped(self) -> None:
         lanes, reasons = ci_scope_plan.select_lanes(

--- a/scripts/tests/test_ci_package_graph.py
+++ b/scripts/tests/test_ci_package_graph.py
@@ -1,0 +1,332 @@
+"""Contract tests for graph-derived focused CI lane selection.
+
+Two layers are asserted here:
+
+* the resolver's behaviour on synthetic graphs, where the expected closure is
+  small enough to state by hand; and
+* the live repository's contracts and CI touchpoint policy, so the real graph
+  cannot drift away from the lanes it must select.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import ci_package_graph as graph
+from scripts import ci_scope_plan
+
+
+ROOT = Path(__file__).resolve().parents[2]
+POLICY = json.loads((ROOT / "conformance/ci-touchpoints-v1.json").read_text(encoding="utf-8"))
+
+# The workspace validator's edge count. A change here means a real dependency
+# was added or removed; update the number deliberately, with the closure
+# consequences reviewed.
+EXPECTED_PACKAGES = 17
+EXPECTED_EDGES = 51
+
+
+def contract(package: str, dependencies: dict[str, str]) -> str:
+    return json.dumps(
+        {
+            "schema": "stwo-zig-package-contract-v1",
+            "package": package,
+            "owner": "test",
+            "public_modules": {package: "mod.zig"},
+            "dependencies": dependencies,
+            "injected_modules": [],
+            "api_surface": [],
+            "ci": {"host": "any", "command": ["zig", "build", "test"]},
+        }
+    )
+
+
+def write_workspace(root: Path, layout: dict[str, dict[str, str]]) -> None:
+    """Materialise ``{directory: {dependency_name: relative_path}}`` contracts."""
+    for directory, dependencies in layout.items():
+        target = root / directory
+        target.mkdir(parents=True, exist_ok=True)
+        package = directory.rsplit("/", 1)[-1]
+        (target / graph.CONTRACT_NAME).write_text(
+            contract(package, dependencies), encoding="utf-8"
+        )
+
+
+def lane(build_file: str) -> dict[str, object]:
+    return {
+        "host": "linux",
+        "description": "test lane",
+        "commands": [["zig", "build", "test", "--build-file", build_file]],
+    }
+
+
+class SyntheticGraphTest(unittest.TestCase):
+    """A diamond graph: leaf <- middle_a, middle_b <- top."""
+
+    def setUp(self) -> None:
+        self._temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self._temporary.cleanup)
+        self.root = Path(self._temporary.name)
+        write_workspace(
+            self.root,
+            {
+                "src/leaf": {},
+                "src/middle_a": {"leaf": "../leaf"},
+                "src/middle_b": {"leaf": "../leaf"},
+                "src/top": {"middle_a": "../middle_a", "middle_b": "../middle_b"},
+                "src/detached": {},
+            },
+        )
+        self.packages = graph.load_packages(self.root)
+        self.policy = {
+            "lanes": {
+                name: lane(f"src/{name}/build.zig")
+                for name in ("leaf", "middle_a", "middle_b", "top", "detached")
+            }
+        }
+        self.bindings = graph.lane_packages(self.policy, self.packages)
+
+    def test_edges_resolve_to_package_names(self) -> None:
+        self.assertEqual(self.packages["top"].dependencies, frozenset({"middle_a", "middle_b"}))
+        self.assertEqual(graph.edge_count(self.packages), 4)
+
+    def test_leaf_change_selects_every_dependent_lane(self) -> None:
+        lanes, unowned = graph.selection(["src/leaf/mod.zig"], self.packages, self.bindings)
+        self.assertEqual(lanes, frozenset({"leaf", "middle_a", "middle_b", "top"}))
+        self.assertEqual(unowned, frozenset())
+
+    def test_sibling_change_does_not_select_the_other_branch(self) -> None:
+        lanes, _ = graph.selection(["src/middle_a/mod.zig"], self.packages, self.bindings)
+        self.assertEqual(lanes, frozenset({"middle_a", "top"}))
+
+    def test_top_change_selects_only_itself(self) -> None:
+        lanes, _ = graph.selection(["src/top/mod.zig"], self.packages, self.bindings)
+        self.assertEqual(lanes, frozenset({"top"}))
+
+    def test_detached_package_is_isolated(self) -> None:
+        lanes, _ = graph.selection(["src/detached/mod.zig"], self.packages, self.bindings)
+        self.assertEqual(lanes, frozenset({"detached"}))
+
+    def test_unowned_path_is_reported_rather_than_ignored(self) -> None:
+        lanes, unowned = graph.selection(
+            ["scripts/anything.py", "src/leaf/mod.zig"], self.packages, self.bindings
+        )
+        self.assertEqual(unowned, frozenset({"scripts/anything.py"}))
+        self.assertIn("leaf", lanes)
+
+    def test_selection_is_deterministic_and_order_independent(self) -> None:
+        forward, _ = graph.selection(
+            ["src/leaf/a.zig", "src/middle_b/b.zig"], self.packages, self.bindings
+        )
+        reverse, _ = graph.selection(
+            ["src/middle_b/b.zig", "src/leaf/a.zig"], self.packages, self.bindings
+        )
+        self.assertEqual(forward, reverse)
+
+    def test_nested_package_wins_over_its_parent(self) -> None:
+        write_workspace(self.root, {"src/leaf/inner": {}})
+        packages = graph.load_packages(self.root)
+        self.assertEqual(graph.owning_package("src/leaf/inner/mod.zig", packages), "inner")
+        self.assertEqual(graph.owning_package("src/leaf/mod.zig", packages), "leaf")
+
+    def test_cycle_terminates(self) -> None:
+        write_workspace(
+            self.root,
+            {"src/leaf": {"top": "../top"}},
+        )
+        packages = graph.load_packages(self.root)
+        self.assertEqual(
+            graph.reverse_closure(packages, ["src/leaf"]),
+            frozenset(),
+            "unknown seeds contribute nothing",
+        )
+        self.assertEqual(
+            graph.reverse_closure(packages, ["leaf"]),
+            frozenset({"leaf", "middle_a", "middle_b", "top"}),
+        )
+
+    def test_lane_building_an_unowned_file_is_rejected(self) -> None:
+        policy = {"lanes": {"stray": lane("src/absent/build.zig")}}
+        with self.assertRaises(graph.GraphError):
+            graph.lane_packages(policy, self.packages)
+
+    def test_unresolvable_dependency_is_rejected(self) -> None:
+        write_workspace(self.root, {"src/broken": {"absent": "../absent"}})
+        with self.assertRaises(graph.GraphError):
+            graph.load_packages(self.root)
+
+    def test_empty_workspace_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as empty:
+            with self.assertRaises(graph.GraphError):
+                graph.load_packages(Path(empty))
+
+
+class RepositoryGraphTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.packages = graph.load_packages(ROOT)
+        self.bindings = graph.lane_packages(POLICY, self.packages)
+
+    def test_workspace_shape_is_pinned(self) -> None:
+        self.assertEqual(len(self.packages), EXPECTED_PACKAGES)
+        self.assertEqual(graph.edge_count(self.packages), EXPECTED_EDGES)
+
+    def test_every_package_has_exactly_one_focused_lane(self) -> None:
+        bound = sorted(self.bindings.values())
+        self.assertEqual(bound, sorted(self.packages))
+
+    def test_core_change_selects_every_dependent_package_lane(self) -> None:
+        lanes, _ = graph.selection(["src/core/fields/m31.zig"], self.packages, self.bindings)
+        # Every package except the two with no path to stwo_core.
+        detached = {"metal_session"}
+        self.assertEqual(lanes, frozenset(set(self.bindings) - detached))
+
+    def test_cairo_only_change_avoids_riscv_and_native_lanes(self) -> None:
+        lanes, _ = graph.selection(["src/frontends/cairo/air.zig"], self.packages, self.bindings)
+        self.assertEqual(
+            lanes,
+            frozenset(
+                {
+                    "cairo_frontend",
+                    "cairo_cpu_integration",
+                    "cairo_metal_integration",
+                    "cairo_cuda_integration",
+                }
+            ),
+        )
+        self.assertNotIn("riscv_frontend", lanes)
+        self.assertNotIn("riscv_cpu_integration", lanes)
+        self.assertNotIn("riscv_metal_integration", lanes)
+        self.assertNotIn("cuda_backend", lanes)
+        self.assertNotIn("native_examples", lanes)
+
+    def test_riscv_frontend_change_avoids_cairo_and_cuda_lanes(self) -> None:
+        lanes, _ = graph.selection(["src/frontends/riscv/air.zig"], self.packages, self.bindings)
+        self.assertEqual(
+            lanes,
+            frozenset({"riscv_frontend", "riscv_cpu_integration", "riscv_metal_integration"}),
+        )
+
+    def test_backend_contracts_reach_transitive_integration_lanes(self) -> None:
+        """The drift this resolver removes: these three reach src/backend only
+        through cpu_backend or metal_backend, and the superseded hand-written
+        rule omitted them."""
+        lanes, _ = graph.selection(["src/backend/mod.zig"], self.packages, self.bindings)
+        for expected in ("riscv_cpu_integration", "cairo_cpu_integration", "riscv_metal_integration"):
+            self.assertIn(expected, lanes)
+
+    def test_policy_carries_no_hand_written_package_lane_for_owned_prefixes(self) -> None:
+        """Package-owned prefixes must not restate lanes the graph derives."""
+        package_lanes = set(self.bindings)
+        for rule in POLICY["rules"]:
+            for prefix in rule["prefixes"]:
+                if graph.owning_package(prefix, self.packages) is None:
+                    continue
+                derived, _ = graph.selection([prefix], self.packages, self.bindings)
+                restated = (set(rule["lanes"]) & package_lanes) & derived
+                self.assertEqual(
+                    restated,
+                    set(),
+                    f"{prefix} restates graph-derived lanes {sorted(restated)}",
+                )
+
+
+class PlanIntegrationTest(unittest.TestCase):
+    """The graph must reach the plan, and the fail-open bias must survive it."""
+
+    def setUp(self) -> None:
+        self.packages = graph.load_packages(ROOT)
+        self.catalog = {
+            "schema": "stwo-product-catalog-v2",
+            "products": [
+                {
+                    "scope": scope,
+                    "state": "released",
+                    "module_roots": [],
+                    "allowed_files": [],
+                    "configure_allowed_files": [],
+                    "allowed_prefixes": [],
+                    "configure_allowed_prefixes": [],
+                }
+                for scope in POLICY["product_scope_lanes"]
+            ],
+        }
+
+    def select(self, *paths: str) -> set[str]:
+        lanes, _ = ci_scope_plan.select_lanes(paths, self.catalog, POLICY, self.packages)
+        return set(lanes)
+
+    def test_always_lanes_are_the_documentation_floor(self) -> None:
+        self.assertEqual(self.select("README.md"), set(POLICY["always_lanes"]))
+        self.assertEqual(
+            self.select("autoresearch/notes/2026-07-28-x/note.md"),
+            set(POLICY["always_lanes"]),
+        )
+        self.assertEqual(self.select("docs/deep/nested/page.md"), set(POLICY["always_lanes"]))
+
+    def test_unmapped_path_fails_open_to_the_full_matrix(self) -> None:
+        self.assertEqual(self.select("scripts/riscv_poseidon_table_uniqueness.py"), set(POLICY["lanes"]))
+        self.assertEqual(self.select("build_support/anything_new.zig"), set(POLICY["lanes"]))
+        self.assertEqual(self.select("third_party/vendored.c"), set(POLICY["lanes"]))
+
+    def test_workflow_change_fails_open_to_the_full_matrix(self) -> None:
+        self.assertEqual(self.select(".github/workflows/ci.yml"), set(POLICY["lanes"]))
+
+    def test_package_change_selects_graph_lanes_through_the_plan(self) -> None:
+        selected = self.select("src/frontends/cairo/air.zig")
+        self.assertIn("cairo_frontend", selected)
+        self.assertIn("cairo_metal_integration", selected)
+        self.assertNotIn("riscv_frontend", selected)
+        self.assertNotIn("native_cuda_device", selected)
+
+    def test_core_change_selects_more_lanes_than_a_leaf_change(self) -> None:
+        self.assertGreater(
+            len(self.select("src/core/fields/m31.zig")),
+            len(self.select("src/integrations/cairo_cpu/mod.zig")),
+        )
+
+    def test_push_full_matrix_selects_every_lane(self) -> None:
+        lanes, reasons = ci_scope_plan.select_lanes(
+            ["autoresearch/notes/x/note.md"],
+            self.catalog,
+            POLICY,
+            self.packages,
+            full_matrix=True,
+        )
+        self.assertEqual(set(lanes), set(POLICY["lanes"]))
+        self.assertEqual(reasons["static"], ["full-matrix"])
+
+    def test_full_matrix_survives_an_empty_diff(self) -> None:
+        lanes, _ = ci_scope_plan.select_lanes(
+            [], self.catalog, POLICY, self.packages, full_matrix=True
+        )
+        self.assertEqual(set(lanes), set(POLICY["lanes"]))
+
+    def test_summary_lists_every_lane_as_selected_or_skipped(self) -> None:
+        lanes, reasons = ci_scope_plan.select_lanes(
+            ["src/frontends/cairo/air.zig"], self.catalog, POLICY, self.packages
+        )
+        plan = {"lanes": lanes, "reasons": reasons}
+        with tempfile.TemporaryDirectory() as directory:
+            summary = Path(directory) / "summary.md"
+            ci_scope_plan.emit_github_summary(summary, plan, POLICY)
+            text = summary.read_text(encoding="utf-8")
+        for name in POLICY["lanes"]:
+            self.assertIn(f"`{name}`", text, f"{name} is absent from the summary")
+        self.assertIn("| selected |", text)
+        self.assertIn("| skipped |", text)
+
+    def test_plan_is_deterministic(self) -> None:
+        first = ci_scope_plan.select_lanes(
+            ["src/core/a.zig", "README.md"], self.catalog, POLICY, self.packages
+        )
+        second = ci_scope_plan.select_lanes(
+            ["README.md", "src/core/a.zig"], self.catalog, POLICY, self.packages
+        )
+        self.assertEqual(first, second)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this is

The requested change-scoped CI sweep — with a premise correction discovered en route: **change-scoped CI already exists** (`focused-plan` computes a lane matrix from the PR diff via `scripts/ci_scope_plan.py` + `conformance/ci-touchpoints-v1.json`; notes-only commits already ran 1 lane of 34). The real defect was that the *package* portion of lane selection was a hand-maintained per-prefix list duplicating the package graph — and it had **drifted in the unsafe direction**, under-selecting transitive consumers.

## Changes

1. **Lane selection for package-owned paths is now derived from the package graph** (`scripts/ci_package_graph.py`): path → owning package via contract directories, affected set via reverse-dependency closure over the 51 declared edges, packages → lanes via each lane's own `--build-file` binding in the policy. Zero new hand-maintained data.
2. **`conformance/ci-touchpoints-v1.json` amended** (it is the live resolver input, not documentation): 18 package-owned prefixes shed their graph-derivable lane lists; mixed rules split so non-package prefixes keep their original lanes verbatim. Every lane's `commands` array is byte-identical — **no gate's content changed, only triggering**.
3. **`ci.yml`: 10-line diff, both hunks inside `focused-plan`'s scope step** — adds `--full-matrix` on push-to-main (post-merge safety net + cache warmth) and `--github-summary`. No job added/removed/renamed/re-guarded.
4. **Self-hosted lanes are spared from the push-time full matrix** — `hosted=false` lanes (the real-device CUDA/Metal runners) keep diff-scoped selection even on push, so an unrelated merge can never wedge on an offline self-hosted runner (as happened today).

## Effect, replayed against real history

| case | lanes before | after | note |
|---|---|---|---|
| notes-only commit (`ceb5b32f`) | 1 | 1 | already scoped |
| riscv-only commits | 9 | 9 | already scoped (70% saved vs full) |
| cairo-frontend-only change | 8 | 8 | 73% saved, no riscv/cuda lanes |
| `src/core/fields/m31.zig` | 24 | **25** | **+cuda_backend — the drift, fixed** |
| PR #125 diff | 30 | 30 | fails open on scripts/ + build_support/ paths, by design |
| exhaustive: all 6,728 tracked files | — | — | **0 lanes dropped anywhere; 110 files gain lanes the hand list missed** |

The honest headline: this is a **correctness fix** (under-selection eliminated), not a job-count win — the scoping wins were already banked; the only number this moves goes *up*.

## Reviewer guidance (please read these line-by-line)

- `.github/workflows/ci.yml` — the 10-line diff described above.
- `conformance/ci-touchpoints-v1.json` — the amended rules; verify `commands` untouched (`git diff main -- conformance/ci-touchpoints-v1.json | grep -c '"commands"'` → 0).
- `conformance/build-architecture-ci-plan-v1.json` — read, deliberately NOT touched (it is the dispatch-only architecture session's plan, no lane concept).

## Known residuals (in the note, ranked)

17 non-package lanes (product/aggregate/oracle/global) still select via catalog rules and were not audited for the same drift class; `vectors/**` fails open to full (correct bias; narrow mapping is the highest-value follow-up if metallib deliveries become frequent); `pr6-supremacy.yml`'s contract-smoke still runs unconditionally; `focused-plan` is a fail-closed single point of failure whose 28 contract tests live in the always-run static lane.

Full survey, design, and replay evidence: `autoresearch/notes/2026-07-28-change-scoped-ci/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
