### PR TITLE
RISC-V: production-path malicious prover harness (#131)

### DIFF
--- a/.github/workflows/riscv-sail-differential.yml
+++ b/.github/workflows/riscv-sail-differential.yml
@@ -132,6 +132,32 @@ jobs:
             --prepare-on-miss \
             --report-out "$RUNNER_TEMP/riscv-sail-differential-report.json"
 
+      # This is the only job in the repository with a verified pinned oracle,
+      # so it is the only place the Sail leg of the malicious-prover harness
+      # can be REQUIRED instead of skipped. On every other host and job that
+      # leg reports "SKIP: pinned Sail oracle unavailable", which is
+      # indistinguishable from a passing check in a summary line.
+      # STWO_ZIG_REQUIRE_SAIL_ORACLE makes an unavailable verdict return
+      # error.SailOracleUnavailable -- a failure that names the absent oracle
+      # and stays distinct from a Sail disagreement, so absence is refused
+      # here without being redefined as divergence anywhere.
+      #
+      # Renaming the malicious-prover tests does NOT silently empty this step:
+      # -Driscv-test-filter carries EmptySelectionGuard, which fails the build
+      # when the filter matches no test name. Keep the filter aligned with
+      # src/tests/riscv/malicious_prover_*.zig anyway -- the guard reports a
+      # drifted filter, it does not repair one.
+      - name: Require the Sail leg of the malicious-prover harness
+        env:
+          STWO_RISCV_FORMAL_WORKSPACE: ${{ runner.tool_cache }}/stwo-zig/riscv-formal
+          STWO_ZIG_REQUIRE_SAIL_ORACLE: "1"
+        run: |
+          # Probe first so a provisioning fault reads as one, rather than
+          # surfacing minutes later inside a test binary.
+          python3 scripts/riscv_sail_oracle.py probe
+          zig build test-riscv-release-exhaustive \
+            -Driscv-test-filter="malicious prover" -Doptimize=ReleaseSafe
+
       # Save even after a red differential: a divergence investigation needs
       # the warm toolchain far more than a green run does.
       - name: Save pinned formal toolchain workspace

--- a/build_support/graph/delegation.zig
+++ b/build_support/graph/delegation.zig
@@ -18,6 +18,7 @@ pub const Options = struct {
     cuda_build_jobs: ?u16,
     metal_core_aot_bundle: ?[]const u8,
     cairo_test_filter: ?[]const u8,
+    riscv_test_filter: ?[]const u8,
     identity: ?build_identity.Identity,
 
     pub fn read(b: *std.Build) Options {
@@ -63,6 +64,11 @@ pub const Options = struct {
                 []const u8,
                 "cairo-test-filter",
                 "Compile and run Cairo tests whose names contain this text",
+            ),
+            .riscv_test_filter = b.option(
+                []const u8,
+                "riscv-test-filter",
+                "Run RISC-V tests whose names contain this text",
             ),
             .identity = resolveIdentity(b, .{
                 .commit = implementation_commit,
@@ -166,6 +172,12 @@ fn commandFor(
     if (std.mem.eql(u8, scope, "compatibility_tools")) {
         if (options.cairo_test_filter) |filter| command.addArg(b.fmt(
             "-Dcairo-test-filter={s}",
+            .{filter},
+        ));
+    }
+    if (std.mem.eql(u8, scope, "riscv_cpu") or std.mem.eql(u8, scope, "riscv_cpu_compat")) {
+        if (options.riscv_test_filter) |filter| command.addArg(b.fmt(
+            "-Driscv-test-filter={s}",
             .{filter},
         ));
     }

--- a/build_support/products/riscv_cpu.zig
+++ b/build_support/products/riscv_cpu.zig
@@ -139,30 +139,30 @@ pub fn addProduct(context: Context) void {
     const core_prover_tests = addCoreProverTests(context);
     const exhaustive_tests = addExhaustiveTests(context);
     const air_satisfaction_exports = addAirSatisfactionExportTests(context);
-    const run_air_satisfaction_exports = context.b.addRunArtifact(air_satisfaction_exports);
+    const run_air_satisfaction_exports = test_filter.addRun(context.b, air_satisfaction_exports);
     const test_step = context.b.step(
         "test-riscv-cpu-product",
         "Test the focused RISC-V CPU product shell and capability surface",
     );
     test_step.dependOn(&context.b.addRunArtifact(tests).step);
-    test_step.dependOn(&context.b.addRunArtifact(integration_tests).step);
+    test_step.dependOn(test_filter.addRun(context.b, integration_tests));
     context.b.step(
         "test-riscv-release-exhaustive",
         "Run the exhaustive RISC-V proof and adversarial release suites",
-    ).dependOn(&context.b.addRunArtifact(exhaustive_tests).step);
+    ).dependOn(test_filter.addRun(context.b, exhaustive_tests));
     context.b.step(
         "test-riscv-prover-core",
         "Run the RISC-V prover corpus without the separately retained committed-witness mutation suites",
-    ).dependOn(&context.b.addRunArtifact(core_prover_tests).step);
+    ).dependOn(test_filter.addRun(context.b, core_prover_tests));
     context.b.step(
         "test-riscv-rigidity",
         "Run the full witness-rigidity sweep over every committed opcode column",
-    ).dependOn(&context.b.addRunArtifact(addRigidityTests(context)).step);
+    ).dependOn(test_filter.addRun(context.b, addRigidityTests(context)));
     const air_satisfaction_export_step = context.b.step(
         "test-riscv-air-satisfaction-export",
         "Export committed traces for the independent AIR satisfaction checker",
     );
-    air_satisfaction_export_step.dependOn(&run_air_satisfaction_exports.step);
+    air_satisfaction_export_step.dependOn(run_air_satisfaction_exports);
     const air_satisfaction_check = context.b.addSystemCommand(&.{
         "python3",
         "-m",
@@ -170,7 +170,7 @@ pub fn addProduct(context: Context) void {
         "scripts.tests.test_air_satisfaction",
         "scripts.tests.test_air_satisfaction_infrastructure",
     });
-    air_satisfaction_check.step.dependOn(&run_air_satisfaction_exports.step);
+    air_satisfaction_check.step.dependOn(run_air_satisfaction_exports);
     context.b.step(
         "test-riscv-air-satisfaction",
         "Export and independently check all RISC-V AIR main-trace components",

--- a/build_support/products/riscv_cpu.zig
+++ b/build_support/products/riscv_cpu.zig
@@ -7,6 +7,7 @@ const graph_identity = @import("../graph/identity.zig");
 const graph = @import("../graph/modules.zig");
 const integration_graph = @import("../graph/integrations.zig");
 const product_policy = @import("../graph/product.zig");
+const test_filter = @import("riscv_test_filter.zig");
 const product = graph.Product{
     .name = "stwo-riscv-cpu",
     .frontend = .riscv,
@@ -397,7 +398,7 @@ fn addTestRoot(context: Context, options: TestRoot) *std.Build.Step.Compile {
     test_options.addOption(bool, "riscv_committed_mutations", options.committed_mutations);
     test_options.addOption(bool, "riscv_rigidity_exhaustive", options.rigidity_exhaustive);
     root.addOptions("test_options", test_options);
-    return b.addTest(.{ .root_module = root, .filters = options.filters });
+    return b.addTest(.{ .root_module = root, .filters = test_filter.apply(b, options.filters) });
 }
 
 fn createStwoModule(

--- a/build_support/products/riscv_test_filter.zig
+++ b/build_support/products/riscv_test_filter.zig
@@ -24,13 +24,23 @@
 //!    narrowing it, which is the opposite of what a focus flag should do. A
 //!    step run under this flag is whatever the caller asked for, not the step's
 //!    advertised scope.
-//!  - **A filter that matches nothing exits 0.** The test runner reports
-//!    success for an empty selection, so a typo is indistinguishable from a
-//!    passing suite — verified: `-Driscv-test-filter=zzz-no-such-test` returns
-//!    0. Read the runtime, not just the exit code, and never let this flag
-//!    stand in for a gate. That is the same silent-green shape the flag exists
-//!    to prevent, moved rather than removed; enforcing a non-empty selection
-//!    would need a run wrapper that counts executed tests.
+//!  - A filter that matches nothing is a build FAILURE, not a green run. The
+//!    compiler applies `filters` when it compiles the test binary, dropping
+//!    every named test the text misses. An unmatched filter therefore leaves a
+//!    binary holding nothing but the anonymous `test { _ = @import(...) }`
+//!    aggregation blocks — those declare no name, so no filter ever excludes
+//!    them — which run in milliseconds and exit 0. That is the same silent-green
+//!    shape the flag exists to prevent, so every filtered run carries
+//!    `EmptySelectionGuard`: it reads the test-name table the build runner
+//!    already collects over the test runner's IPC channel and fails the build
+//!    unless some executed test name contains the filter text. The guard is
+//!    attached only when `-Driscv-test-filter` is supplied; an unfiltered gate
+//!    run keeps exactly the steps, caching and runtime it had before.
+//!
+//! The guard covers the flag, not the pinned literals: a step whose own
+//! `TestRoot.filters` stopped matching still reports green. Those literals are
+//! reviewed source, and guarding them would put a new failure mode in the
+//! unfiltered gate path.
 
 const std = @import("std");
 
@@ -40,6 +50,65 @@ pub fn apply(b: *std.Build, pinned: []const []const u8) []const []const u8 {
     const requested = read(b) orelse return pinned;
     return b.allocator.dupe([]const u8, &.{requested}) catch @panic("out of memory");
 }
+
+/// Run one RISC-V test artifact and return the step to depend on. Unfiltered,
+/// that is the plain run, unchanged. Under `-Driscv-test-filter` it is a guard
+/// that fails the build when the filter selected no test.
+pub fn addRun(b: *std.Build, tests: *std.Build.Step.Compile) *std.Build.Step {
+    const run = b.addRunArtifact(tests);
+    const requested = read(b) orelse return &run.step;
+
+    // The guard reads the run's test-name table, which only the invocation that
+    // actually executed the binary populates: a cache hit leaves it null and
+    // would fail closed on every repeat of a *correct* filter. Marking the run
+    // side-effecting keeps it out of the run cache so the table is always real.
+    // Re-executing is what a focus run wants anyway; gate runs never get here.
+    run.has_side_effects = true;
+
+    const guard = b.allocator.create(EmptySelectionGuard) catch @panic("out of memory");
+    guard.* = .{
+        .step = std.Build.Step.init(.{
+            .id = .custom,
+            .name = "riscv-test-filter selection guard",
+            .owner = b,
+            .makeFn = EmptySelectionGuard.make,
+        }),
+        .run = run,
+        .filter = requested,
+    };
+    guard.step.dependOn(&run.step);
+    return &guard.step;
+}
+
+/// Turns "the filter matched nothing" from a zero exit into a named failure.
+const EmptySelectionGuard = struct {
+    step: std.Build.Step,
+    run: *std.Build.Step.Run,
+    filter: []const u8,
+
+    fn make(step: *std.Build.Step, _: std.Build.Step.MakeOptions) anyerror!void {
+        const guard: *EmptySelectionGuard = @fieldParentPtr("step", step);
+        // Same substring rule the compiler used to decide what to compile in,
+        // over the same fully qualified names, so a match here means the filter
+        // selected something and not just the always-present anonymous blocks.
+        if (guard.run.cached_test_metadata) |metadata| {
+            for (0..metadata.names.len) |index| {
+                const name = metadata.testName(@intCast(index));
+                if (std.mem.indexOf(u8, name, guard.filter) != null) return;
+            }
+            return step.fail(
+                \\-Driscv-test-filter='{s}' matched no test name.
+                \\  The compiler dropped every named test, leaving only unnamed aggregation
+                \\  blocks, so the suite exits 0 without proving anything. Correct the filter
+                \\  text, or drop the flag to run the step's own pinned scope.
+            , .{guard.filter});
+        }
+        return step.fail(
+            "-Driscv-test-filter='{s}': the run reported no test names, so the selection could not be verified",
+            .{guard.filter},
+        );
+    }
+};
 
 /// `std.Build.option` panics if the same option name is declared twice and
 /// every test step routes through `apply`, so the flag is read once and the

--- a/build_support/products/riscv_test_filter.zig
+++ b/build_support/products/riscv_test_filter.zig
@@ -1,0 +1,63 @@
+//! Command-line focus for the RISC-V test steps: `-Driscv-test-filter=<text>`.
+//!
+//! The exhaustive gate is tens of minutes of end-to-end proving, and in its
+//! default `-Doptimize=Debug` a profile of it is dominated by Blake2s Merkle
+//! commitment. Focusing it used to mean hand-editing the `TestRoot` literals in
+//! `riscv_cpu.zig`, which is how a temporary `.filters = &.{"malicious prover"}`
+//! once reached `addExhaustiveTests` and quietly reduced the whole adversarial
+//! gate to a handful of tests while still reporting green. A command-line
+//! filter removes the reason to edit that file at all.
+//!
+//! Fast local loop, about two orders of magnitude off the full Debug gate:
+//!
+//!     zig build test-riscv-release-exhaustive \
+//!         -Driscv-test-filter="malicious prover" -Doptimize=ReleaseSafe
+//!
+//! `-Doptimize=ReleaseSafe` keeps every safety check (bounds, overflow) and
+//! only drops the debug-mode slowdown, so it is a legitimate iteration
+//! configuration. Gates still run what CI pins.
+//!
+//! Two properties worth knowing before trusting a filtered run:
+//!
+//!  - The flag REPLACES a step's pinned filters rather than adding to them.
+//!    `filters` is an OR, so appending would broaden a scoped step instead of
+//!    narrowing it, which is the opposite of what a focus flag should do. A
+//!    step run under this flag is whatever the caller asked for, not the step's
+//!    advertised scope.
+//!  - **A filter that matches nothing exits 0.** The test runner reports
+//!    success for an empty selection, so a typo is indistinguishable from a
+//!    passing suite — verified: `-Driscv-test-filter=zzz-no-such-test` returns
+//!    0. Read the runtime, not just the exit code, and never let this flag
+//!    stand in for a gate. That is the same silent-green shape the flag exists
+//!    to prevent, moved rather than removed; enforcing a non-empty selection
+//!    would need a run wrapper that counts executed tests.
+
+const std = @import("std");
+
+/// The filter set for one test step: the caller's `-Driscv-test-filter` when
+/// present, otherwise whatever the step pinned for itself.
+pub fn apply(b: *std.Build, pinned: []const []const u8) []const []const u8 {
+    const requested = read(b) orelse return pinned;
+    return b.allocator.dupe([]const u8, &.{requested}) catch @panic("out of memory");
+}
+
+/// `std.Build.option` panics if the same option name is declared twice and
+/// every test step routes through `apply`, so the flag is read once and the
+/// answer reused. Build-graph construction is single-threaded, which is what
+/// makes this safe.
+var state: union(enum) { unread, known: ?[]const u8 } = .unread;
+
+fn read(b: *std.Build) ?[]const u8 {
+    switch (state) {
+        .unread => {
+            const value = b.option(
+                []const u8,
+                "riscv-test-filter",
+                "Run RISC-V tests whose names contain this text",
+            );
+            state = .{ .known = value };
+            return value;
+        },
+        .known => |value| return value,
+    }
+}

--- a/conformance/2026-07-26-riscv-sail-contract.md
+++ b/conformance/2026-07-26-riscv-sail-contract.md
@@ -192,7 +192,13 @@ weaker authority when the pinned binary is absent (exit 3, UNAVAILABLE):
 - `scripts/riscv_sail_oracle.py` asks one question -- does pinned Sail
   agree with a runner retirement trace? -- with the four-verdict contract
   EQUIVALENT/DIVERGENT/ERROR/UNAVAILABLE that `runner/sail_oracle.zig`
-  consumes from tests.
+  consumes from tests. UNAVAILABLE stays a visible skip there by default,
+  but a gate may refuse to accept absence: with
+  `STWO_ZIG_REQUIRE_SAIL_ORACLE` set, every UNAVAILABLE verdict becomes
+  `error.SailOracleUnavailable`, a named failure that is deliberately not
+  the disagreement error. Only a job that has provisioned the pinned
+  workspace may set it; the `differential` job of
+  `.github/workflows/riscv-sail-differential.yml` is currently the only one.
 - `scripts/riscv_operand_classes.py` derives the operand classes the ISA
   admits and the AIR's limb structure distinguishes, executes one case per
   class on pinned Sail over RVFI-DII, and commits Sail's architectural

--- a/conformance/riscv-sail-differential-gate.md
+++ b/conformance/riscv-sail-differential-gate.md
@@ -94,6 +94,13 @@ soundness argument — runner ≡ Sail on the corpus. It says nothing about AIR
 satisfaction or uniqueness (legs 2 and 3), and corpus equivalence is not
 all-input equivalence.
 
+The job additionally runs the Sail leg of the malicious-prover harness with
+`STWO_ZIG_REQUIRE_SAIL_ORACLE=1`, because this is the only job with a
+verified pinned oracle. Everywhere else that leg reports a visible skip,
+which is indistinguishable from a passing check in a summary line; here an
+absent oracle is `error.SailOracleUnavailable`, a failure that names the
+absence and is deliberately not the disagreement error.
+
 ## Known limits, recorded deliberately
 
 - **Hosted cold path is estimated, not yet observed.** Every piece is proven
@@ -104,6 +111,26 @@ all-input equivalence.
   fallbacks are, in order: a scheduled job that only refreshes the cache, a
   larger runner, or demoting the PR gate to merge-queue/nightly — each of
   which must be recorded here.
+- **The required malicious-prover leg adds a cold Zig build to this job.**
+  It compiles the RISC-V exhaustive test binary at `-Doptimize=ReleaseSafe`
+  with no warm Zig cache (the restored cache holds the formal toolchain
+  only), which is minutes on top of the differential and eats into the same
+  60-minute budget as the cold toolchain path. If the two together stop
+  fitting, the fallbacks in order are: cache the Zig build alongside the
+  toolchain, or split the required leg into its own job that restores the
+  same workspace — not dropping the requirement, which would return the leg
+  to a skip nobody reads.
+- **A drifted filter fails the step rather than emptying it.** The required
+  leg selects tests with `-Driscv-test-filter="malicious prover"`. The RISC-V
+  test runner does report success for an empty selection -- unnamed
+  `test { _ = @import(...) }` aggregation blocks are never filtered out, so
+  the binary is never actually empty and the exit code alone proves nothing --
+  which is why the flag carries `EmptySelectionGuard`
+  (`build_support/products/riscv_test_filter.zig`): it compares the executed
+  test names against the filter text and fails the build when none match.
+  Renaming `src/tests/riscv/malicious_prover_*.zig` therefore turns this step
+  red instead of hollowing it out. The guard reports the drift; it does not
+  repair it, so the filter still has to be updated with the rename.
 - **A forged snapshot passes `bind`.** Binding is arithmetic over committed
   files; only the live run re-derives truth. The live run is triggered by
   every path that could carry such a forgery (the evidence file itself lives

--- a/soundness/ROADMAP.md
+++ b/soundness/ROADMAP.md
@@ -480,9 +480,34 @@ security-bit accounting, and no universal AIR-to-Sail refinement proof.
       `TODO(soundness)` in `air/semantics/div.zig` is replaced by a pointer to
       the test. The DIV divisor byte range still has no row-local check in
       `semantics/div.zig` itself and no recorded adversarial self-check.
-- [ ] Add a deliberately malicious prover harness for skipped instructions,
+- [x] Add a deliberately malicious prover harness for skipped instructions,
       stale reads, forged outputs, and altered completion.
-      Tracked in [GitHub issue #131](https://github.com/teddyjfpender/stwo-zig/issues/131).
+      `src/tests/riscv/malicious_prover_harness.zig` enters the real proving
+      transaction — witness forgeries are installed before lookup ingestion, so
+      Tree 1, the multiplicities and Tree 2 all derive from the forged witness;
+      statement forgeries are the prover's original public statement, mixed
+      before any challenge is drawn — and each of the four attacks pins both
+      the stage that refuses it and the exact error, in
+      `malicious_prover_{skipped,stale_read,forged_output,completion}_test.zig`.
+      `attempt` classifies four errors and lets every other one escape, so a
+      broken fixture fails the test instead of masquerading as a rejection.
+      The stale read is the load-bearing case: row-locally admissible, it
+      reaches a complete proof and dies at verification with `LogupSumNonZero`,
+      with `memory_access` pinned as the only one of twelve relation domains
+      that fails to close. Forged output likewise dies at verification;
+      an altered-but-canonical halt tuple is refused at admission
+      (`InvalidStatement`) with the channel observably pristine.
+      Two limits are recorded rather than smoothed over. A padded active row is
+      refused at lookup-source ingestion (`source_ingest.zig`,
+      `InactiveRealRow`) strictly before composition, so the active-row
+      placement constraint is pinned row-locally as the unique failing direct
+      constraint but is never reached end to end; a genuinely shortened trace
+      cannot change that, because `is_active` and the committed `active()` are
+      two readings of one row list and a skip shortens the declared geometry
+      instead of leaving a hole in it — such a trace loses on the access chain
+      (`InvalidRegisterAccessChain`) instead. And the Sail leg of the honest
+      obligation skips wherever the pinned oracle is absent.
+      Delivered for [GitHub issue #131](https://github.com/teddyjfpender/stwo-zig/issues/131).
 - [ ] Exhaustively check small-limb component domains where enumeration is
       feasible, with Sail transitions as the reference relation.
 - [ ] Maintain serialized-proof bit-flip, truncation, splice, and wrong-statement

--- a/src/frontends/riscv/runner/sail_oracle.zig
+++ b/src/frontends/riscv/runner/sail_oracle.zig
@@ -6,11 +6,21 @@
 //! retirement field (pc, instruction, rd, rd_value, next_pc, memory effect).
 //!
 //! The verdict contract is the load-bearing part. `unavailable` means the
-//! pinned Sail binary cannot be consulted on this host and must surface as a
-//! *visible skip* naming what was not checked; `divergent` and
+//! pinned Sail binary cannot be consulted on this host and by default must
+//! surface as a *visible skip* naming what was not checked; `divergent` and
 //! `protocol_error` must fail the test. Conflating absence with disagreement
 //! is how a dead oracle starts to read as coverage, which is worse than no
 //! check at all.
+//!
+//! A gate may nonetheless refuse to accept absence. Setting
+//! `STWO_ZIG_REQUIRE_SAIL_ORACLE` makes every `unavailable` verdict return
+//! `error.SailOracleUnavailable` after printing the same not-checked report.
+//! Absence is still absence: that error names the missing oracle and stays
+//! distinct from `error.SailDisagreesWithRunner`, so a job that demands the
+//! oracle goes red for the provisioning failure it actually has and never
+//! borrows the language of a soundness signal. Unset, nothing changes, since
+//! on a host with no pinned Sail a hard failure would be noise rather than
+//! evidence.
 
 const std = @import("std");
 const trace_mod = @import("trace.zig");
@@ -49,6 +59,92 @@ pub const Verdict = enum {
     /// broken harness that skipped would be indistinguishable from coverage.
     protocol_error,
 };
+
+/// Opt-in gate switch: when set, an `unavailable` verdict is a failure.
+///
+/// An environment variable rather than a build option on purpose — every
+/// consumer of this module is a plain `zig test` binary, so a CI job that has
+/// provisioned the pinned oracle can require it without any build plumbing,
+/// and a job that has not provisioned it keeps today's behaviour by doing
+/// nothing.
+pub const REQUIRE_AVAILABLE_ENV = "STWO_ZIG_REQUIRE_SAIL_ORACLE";
+
+/// The two errors an `unavailable` verdict can produce. Neither is
+/// `error.SailDisagreesWithRunner`: absence never speaks as disagreement.
+pub const UnavailableError = error{ SkipZigTest, SailOracleUnavailable };
+
+/// What an `unavailable` verdict means to this process.
+pub const AbsencePolicy = enum {
+    /// Default. Absence is a visible skip naming what went unchecked.
+    skip,
+    /// A gate required the oracle, so absence is a named failure.
+    fail,
+
+    /// Read `REQUIRE_AVAILABLE_ENV` from a raw value, `null` when unset.
+    ///
+    /// Unset, empty, `0`, `false`, `no`, and `off` (any case, surrounding
+    /// whitespace ignored) keep the default skip. Every other value requires
+    /// the oracle: this is a gate switch, so a value we do not recognise must
+    /// fail closed rather than quietly disarm the gate a job asked for.
+    pub fn fromEnvValue(raw: ?[]const u8) AbsencePolicy {
+        const value = std.mem.trim(u8, raw orelse return .skip, " \t\r\n");
+        if (value.len == 0) return .skip;
+        for ([_][]const u8{ "0", "false", "no", "off" }) |disabled| {
+            if (std.ascii.eqlIgnoreCase(value, disabled)) return .skip;
+        }
+        return .fail;
+    }
+
+    /// The error a call site returns once it has printed its report.
+    pub fn err(self: AbsencePolicy) UnavailableError {
+        return switch (self) {
+            .skip => error.SkipZigTest,
+            .fail => error.SailOracleUnavailable,
+        };
+    }
+};
+
+/// `REQUIRE_AVAILABLE_ENV` as this process sees it.
+pub fn absencePolicy(allocator: std.mem.Allocator) AbsencePolicy {
+    const raw = std.process.getEnvVarOwned(allocator, REQUIRE_AVAILABLE_ENV) catch |err| switch (err) {
+        error.EnvironmentVariableNotFound => return .skip,
+        // Fail closed: an environment we could not read is not a reason to
+        // stop requiring an oracle a job explicitly asked for.
+        else => return .fail,
+    };
+    defer allocator.free(raw);
+    return AbsencePolicy.fromEnvValue(raw);
+}
+
+/// The single seam every `unavailable` verdict goes through.
+///
+/// `unchecked` names what did NOT happen ("the forged-trace rejection"), and
+/// is printed either way: a required run must say exactly as much about the
+/// gap as a skipping one, because the report is the only record of what the
+/// oracle would have covered. Always returns an error.
+pub fn reportUnavailable(
+    allocator: std.mem.Allocator,
+    unchecked: []const u8,
+    report: []const u8,
+) UnavailableError!void {
+    const policy = absencePolicy(allocator);
+    switch (policy) {
+        .skip => std.debug.print(
+            "SKIP: pinned Sail oracle unavailable; {s} was NOT checked.\n{s}\n",
+            .{ unchecked, report },
+        ),
+        // Name the error in the log too: the Zig test runner prints captured
+        // stderr rather than the error name, and a reader of a red CI job
+        // must be able to tell this apart from a Sail disagreement.
+        .fail => std.debug.print(
+            "FAIL (error.SailOracleUnavailable, NOT a disagreement): pinned Sail " ++
+                "oracle unavailable while " ++ REQUIRE_AVAILABLE_ENV ++
+                " requires it; {s} was NOT checked.\n{s}\n",
+            .{ unchecked, report },
+        ),
+    }
+    return policy.err();
+}
 
 pub const Outcome = struct {
     verdict: Verdict,
@@ -148,7 +244,9 @@ pub fn checkTraceJson(
 }
 
 /// The consumer-facing seam: pass on agreement, skip VISIBLY when the pinned
-/// oracle is absent, and fail loudly on disagreement or harness breakage.
+/// oracle is absent (or fail with `error.SailOracleUnavailable` when
+/// `REQUIRE_AVAILABLE_ENV` demands it), and fail loudly on disagreement or
+/// harness breakage.
 ///
 /// `guest_label` names the guest in every notice, because a skip that does
 /// not say *what* went unchecked reads as coverage from the summary line.
@@ -165,12 +263,13 @@ pub fn requireAgreement(
     switch (outcome.verdict) {
         .equivalent => {},
         .unavailable => {
-            std.debug.print(
-                "SKIP: pinned Sail oracle unavailable; runner-vs-Sail agreement " ++
-                    "was NOT checked for guest '{s}'.\n{s}\n",
-                .{ guest_label, outcome.report },
+            const unchecked = try std.fmt.allocPrint(
+                allocator,
+                "runner-vs-Sail agreement for guest '{s}'",
+                .{guest_label},
             );
-            return error.SkipZigTest;
+            defer allocator.free(unchecked);
+            return reportUnavailable(allocator, unchecked, outcome.report);
         },
         .divergent => {
             std.debug.print(
@@ -226,6 +325,20 @@ fn findOracleScript(allocator: std.mem.Allocator) ![]u8 {
 
 const runner = @import("mod.zig");
 
+// WARNING, measured 2026-07-28: the two tests below do not run in any build
+// step. `zig test` collects tests only from its ROOT module, and every step
+// that reaches this file reaches it as an imported dependency
+// (`stwo_riscv_frontend`), so their names are absent from every compiled test
+// binary's name table — checked directly. They are exactly the self-check
+// ("does the oracle answer at all?") and the disagreement check ("is a forged
+// trace really DIVERGENT?"), so this is the module's own failure mode turned
+// on itself: a check nobody runs reads as coverage. Making them live means
+// referencing this file from the package test root
+// (`src/frontends/riscv/mod.zig`), which is a scope decision, not a rename.
+//
+// The `AbsencePolicy` coverage therefore lives in
+// `src/tests/riscv/unit_test.zig`, which is collected and does run.
+
 test "sail_oracle: runner agrees with pinned Sail on a small guest (skips visibly when Sail absent; ~0.3s when present)" {
     const alloc = std.testing.allocator;
     const elf = trace_dump.buildTestElf(4, .{
@@ -271,14 +384,11 @@ test "sail_oracle: a forged integer write is DIVERGENT, never a pass or a skip (
     defer outcome.deinit(alloc);
     switch (outcome.verdict) {
         .divergent => {},
-        .unavailable => {
-            std.debug.print(
-                "SKIP: pinned Sail oracle unavailable; the forged-trace rejection " ++
-                    "was NOT checked.\n{s}\n",
-                .{outcome.report},
-            );
-            return error.SkipZigTest;
-        },
+        .unavailable => return reportUnavailable(
+            alloc,
+            "the forged-trace rejection",
+            outcome.report,
+        ),
         else => {
             std.debug.print("expected DIVERGENT, got: {s}\n", .{outcome.report});
             return error.ForgedTraceNotRejected;

--- a/src/tests/riscv/committed_forgery_harness.zig
+++ b/src/tests/riscv/committed_forgery_harness.zig
@@ -216,8 +216,9 @@ pub const Guest = struct {
     /// exactly the rows the prover commits — through the pinned Sail model,
     /// seeding the fixture's declared input word so the prologue's public
     /// input load compares against Sail's own read. Skips visibly (naming
-    /// the guest) when the pinned oracle is absent; any disagreement or
-    /// harness breakage fails the test.
+    /// the guest) when the pinned oracle is absent, unless
+    /// `STWO_ZIG_REQUIRE_SAIL_ORACLE` makes that absence a failure; any
+    /// disagreement or harness breakage fails the test.
     pub fn requireSailAgreement(self: *const Guest, guest_label: []const u8) !void {
         const image = guest_elf.initialMemory();
         try sail_oracle.requireAgreement(
@@ -578,7 +579,7 @@ test "forgery harness: the honest row of a body instruction is admissible where 
 
 // Runtime: about a second when the pinned Sail is present — three oracle
 // round-trips over a nine-instruction guest, no proofs. Skips visibly when the
-// pinned oracle is absent.
+// pinned oracle is absent, or fails under `STWO_ZIG_REQUIRE_SAIL_ORACLE`.
 test "forgery harness: the Sail assertion rejects a forged retirement and a forged input seed" {
     // An oracle never observed disagreeing is not evidence that it agrees.
     // This is the disagreement half of `requireSailAgreement`, on the very
@@ -605,14 +606,11 @@ test "forgery harness: the Sail assertion rejects a forged retirement and a forg
     defer baseline.deinit(allocator);
     switch (baseline.verdict) {
         .equivalent => {},
-        .unavailable => {
-            std.debug.print(
-                "SKIP: pinned Sail oracle unavailable; the forged-retirement and " ++
-                    "forged-seed rejections were NOT checked for the fixture guest.\n{s}\n",
-                .{baseline.report},
-            );
-            return error.SkipZigTest;
-        },
+        .unavailable => return sail_oracle.reportUnavailable(
+            allocator,
+            "the forged-retirement and forged-seed rejections for the fixture guest",
+            baseline.report,
+        ),
         else => {
             std.debug.print("honest fixture guest not EQUIVALENT: {s}\n", .{baseline.report});
             return error.TestUnexpectedResult;

--- a/src/tests/riscv/malicious_prover_completion_test.zig
+++ b/src/tests/riscv/malicious_prover_completion_test.zig
@@ -1,0 +1,360 @@
+//! Malicious prover: an ALTERED COMPLETION CONDITION.
+//!
+//! The prover keeps the honest witness and honestly executes the guest, then
+//! claims it stopped at a different moment: the public halt tuple is rewritten
+//! so the halt access clock names the *previous* instruction bucket. The
+//! forgery is deliberately canonical rather than malformed — one whole access
+//! stride back keeps the ordinal, keeps the value inside the protocol's
+//! subclock lattice, and keeps it inside this execution's clock window — so
+//! `PublicData.validate` accepts it and the refusal cannot be a shape check.
+//!
+//! # Why this is not a post-hoc mutation of a proof
+//!
+//! The altered tuple is the prover's ORIGINAL public statement. It is the
+//! `public_data` argument of `runRiscVWithEngineAndPublicDataUsingChannel`, so
+//! it is the statement the whole transaction is derived from, not a field
+//! edited on a `RunOutput` after a proof existed. Nothing about serialization
+//! or proof integrity is exercised here; the question is whether the prover
+//! will *accept the job* of proving a completion its own memory image does not
+//! support.
+//!
+//! # What the committed completion word is
+//!
+//! `runner.runWithInput` captures the RW-memory snapshot the proof commits to
+//! (`runner/mod.zig:312`, `memory_state.capture`), and the aligned word at
+//! `__halt_flag` is flagged `role.is_public_completion` inside it. That word
+//! carries `final_word` and `final_clock` — the value the store wrote and the
+//! access clock it wrote at. The honest statement's completion tuple is that
+//! word: `committedHaltWord` below reads it out of `guest.run.rw_memory` and
+//! the first test pins the three-way equality. So the admission check is a
+//! comparison against committed data, not a recomputation of the statement
+//! from itself.
+//!
+//! # Pinned stage and error, and why "before transcript mixing" holds
+//!
+//! Pinned: `Stage.admission` with `error.InvalidStatement`, raised by
+//! `prover/commitment_witness.zig:51-59` — the loop that requires the claimed
+//! address to carry the public-completion role, the claimed value and the
+//! claimed clock.
+//!
+//! That check runs inside `derive`, called from `proveStages` at
+//! `prover/orchestration.zig:184`; `bindCompletion` is its first statement
+//! (`prover/orchestration.zig:330`). The first two transcript events of the
+//! production path are `pcs_config.mixInto(channel)` and
+//! `statement.public_data.mixInto(channel)` at `prover/orchestration.zig:193`
+//! and `:194`. So the refusal is strictly before Fiat-Shamir opens, and the
+//! second test observes that positively rather than by reading the source: the
+//! caller-owned channel still holds its pristine digest and zero draws after
+//! the rejected run, while a reference channel that has taken only the *first*
+//! production event already reads differently.
+//!
+//! # Deviation from the issue's predicted behaviour
+//!
+//! The prediction (`.admission` / `error.InvalidStatement`) holds exactly. The
+//! one prediction that does NOT hold is the suggested `+STRIDE` strengthening:
+//! the honest halt access is the last access of the last instruction, so its
+//! clock is exactly `access_clock.maximum(step_count)` and a forward stride
+//! leaves the execution window. That alteration is refused by the structural
+//! clock range check instead of by the committed-word comparison — a weaker
+//! property, and the last test pins it as such so the difference is recorded
+//! rather than hidden. The equality-not-bound-check claim is instead carried by
+//! `canonical-but-wrong halt tuples`, which moves the clock inside the window
+//! in both the ordinal and the instruction direction and also moves the value
+//! and the address.
+
+const std = @import("std");
+
+const riscv_cpu = @import("stwo_riscv_cpu_integration");
+const frontend = @import("stwo_riscv_frontend");
+const access_clock = frontend.access_clock;
+const memory_state = frontend.runner.memory_state;
+const orchestration = frontend.testing.prover_orchestration;
+const public_data = frontend.air.public_data;
+
+const committed = @import("committed_forgery_harness.zig");
+const harness = @import("malicious_prover_harness.zig");
+
+const Channel = riscv_cpu.CpuProverEngine.Channel;
+
+/// The word the committed RW-memory snapshot carries at `address`.
+fn committedWordAt(
+    guest: *const committed.Guest,
+    address: u32,
+) !memory_state.WordState {
+    for (guest.run.rw_memory.words) |word| {
+        if (word.addr == address) return word;
+    }
+    return error.AddressAbsentFromCommittedSnapshot;
+}
+
+/// The committed memory word the honest halt tuple is read out of.
+///
+/// Located by the same two facts `bindCompletion` uses — the aligned address
+/// and the public-completion role — so a snapshot that stopped carrying the
+/// role fails this fixture instead of silently making every forgery below
+/// unfalsifiable.
+fn committedHaltWord(
+    guest: *const committed.Guest,
+    address: u32,
+) !memory_state.WordState {
+    const word = try committedWordAt(guest, address);
+    if (!word.role.is_public_completion) return error.NoCommittedCompletionWord;
+    return word;
+}
+
+/// The prover's original public statement with the halt tuple replaced.
+///
+/// Everything else — registers, clocks, roots, the whole I/O block — is the
+/// honest derivation, so the only thing the pipeline can object to is the
+/// completion record.
+fn withCompletion(
+    honest: public_data.PublicData,
+    completion: public_data.Completion,
+) public_data.PublicData {
+    var forged = honest;
+    forged.completion = completion;
+    return forged;
+}
+
+fn withClock(honest: public_data.Completion, clock: u32) public_data.Completion {
+    var altered = honest;
+    altered.clock = clock;
+    return altered;
+}
+
+// Runtime: milliseconds. The forged statement is refused before any tree is
+// committed, so no proof is attempted; the honest proof is the shared
+// harness's obligation and is not repeated here.
+test "malicious prover: an altered but canonical halt clock is refused at admission" {
+    var guest = try committed.Guest.init(std.testing.allocator, harness.SPEC);
+    defer guest.deinit();
+
+    const honest = guest.public.data.completion orelse
+        return error.FixtureHasNoCompletion;
+    try std.testing.expectEqual(public_data.CompletionKind.halt_flag, honest.kind);
+
+    // The honest tuple IS the committed memory word: same value, same access
+    // clock. This is what makes the rejection below a disagreement with
+    // committed data rather than with a second derivation of the statement.
+    const word = try committedHaltWord(&guest, honest.address);
+    try std.testing.expectEqual(word.final_word, honest.value);
+    try std.testing.expectEqual(word.final_clock, honest.clock);
+
+    // And that clock is the store access of the last retired instruction —
+    // the epilogue's `SW x2, 0(x1)`, whose third access sets the flag.
+    try std.testing.expectEqual(
+        access_clock.encode(guest.public.data.clock, .third),
+        honest.clock,
+    );
+
+    // The forgery: one whole access stride back, i.e. the same ordinal in the
+    // previous instruction's bucket.
+    try std.testing.expect(honest.clock > access_clock.STRIDE);
+    const altered = withClock(honest, honest.clock - access_clock.STRIDE);
+    const forged = withCompletion(guest.public.data, altered);
+
+    // Structurally valid, and canonical in the protocol's own sense: it is a
+    // real subclock of a real instruction of this execution. `validate` is the
+    // shape check `statement_validation.zig:68` runs, so a rejection there is
+    // ruled out before the pipeline is asked.
+    try std.testing.expect(access_clock.isCanonical(altered.clock));
+    try std.testing.expect(
+        access_clock.isWithinExecution(altered.clock, guest.public.data.clock, false),
+    );
+    try forged.validate();
+
+    // ... and it disagrees with the committed word, which is the only thing
+    // left for the pipeline to notice.
+    try std.testing.expect(altered.clock != word.final_clock);
+
+    try harness.expectRejected(
+        &guest,
+        .{ .statement = forged },
+        .admission,
+        error.InvalidStatement,
+    );
+}
+
+// Runtime: milliseconds. The rejected run allocates a proof workspace and
+// stops in `derive`; no tree is committed and no challenge is drawn.
+test "malicious prover: the altered halt tuple is refused before any transcript event" {
+    const allocator = std.testing.allocator;
+    var guest = try committed.Guest.init(allocator, harness.SPEC);
+    defer guest.deinit();
+
+    const honest = guest.public.data.completion orelse
+        return error.FixtureHasNoCompletion;
+    const forged = withCompletion(
+        guest.public.data,
+        withClock(honest, honest.clock - access_clock.STRIDE),
+    );
+
+    var observed = Channel{};
+    const pristine = observed.digestBytes();
+
+    // A channel that had reached even the FIRST production transcript event
+    // would no longer read `pristine`. Replaying the opening two events of
+    // `proveStages` on a separate channel is what makes "the digest did not
+    // move" evidence instead of an assertion about an inert value.
+    var reference = Channel{};
+    committed.PCS_CONFIG.mixInto(&reference);
+    const after_config = reference.digestBytes();
+    try std.testing.expect(!std.mem.eql(u8, &pristine, &after_config));
+    guest.public.data.mixInto(&reference);
+    const after_statement = reference.digestBytes();
+    try std.testing.expect(!std.mem.eql(u8, &after_config, &after_statement));
+
+    // The production transaction, entered with the malicious statement and a
+    // channel this test owns.
+    try std.testing.expectError(
+        error.InvalidStatement,
+        orchestration.runRiscVWithEngineAndPublicDataUsingChannel(
+            riscv_cpu.CpuProverEngine,
+            .prove,
+            allocator,
+            committed.PCS_CONFIG,
+            &guest.run.execution_trace,
+            &guest.run.state_chain_tracker,
+            &guest.run.rw_memory,
+            null,
+            forged,
+            &observed,
+            null,
+            null,
+        ),
+    );
+
+    const after_rejection = observed.digestBytes();
+    try std.testing.expectEqualSlices(u8, &pristine, &after_rejection);
+    try std.testing.expectEqual(@as(u32, 0), observed.n_draws);
+}
+
+// Runtime: milliseconds. Four rejected statements, none of which reaches a
+// commitment.
+test "malicious prover: every canonical-but-wrong halt tuple is refused at admission" {
+    var guest = try committed.Guest.init(std.testing.allocator, harness.SPEC);
+    defer guest.deinit();
+
+    const honest = guest.public.data.completion orelse
+        return error.FixtureHasNoCompletion;
+    const word = try committedHaltWord(&guest, honest.address);
+    const last_instruction = guest.public.data.clock;
+
+    // Each case moves one field of the halt tuple off the committed word while
+    // staying inside everything `PublicData.validate` can see. The clock moves
+    // at two different granularities — one ordinal back inside the halting
+    // instruction's own bucket, then a whole instruction back — and the value
+    // and the address move too, so the refusal is a field-wise equality against
+    // committed data rather than a range check on the clock.
+    const cases = [_]struct {
+        label: []const u8,
+        completion: public_data.Completion,
+    }{
+        .{
+            .label = "the halting instruction's second access",
+            .completion = withClock(honest, access_clock.encode(last_instruction, .second)),
+        },
+        .{
+            // A different bucket AND a different ordinal from the case above.
+            // `encode(last_instruction - 1, .third)` would be the same word as
+            // test 1's `honest.clock - access_clock.STRIDE`, which would make
+            // this row a re-run rather than a second granularity.
+            .label = "the previous instruction's first access",
+            .completion = withClock(honest, access_clock.encode(last_instruction - 1, .first)),
+        },
+        .{
+            .label = "a halt word one greater than the committed word",
+            .completion = .{
+                .kind = honest.kind,
+                .address = honest.address,
+                .value = honest.value + 1,
+                .clock = honest.clock,
+            },
+        },
+        .{
+            // The published output word: aligned, committed, and carrying the
+            // wrong role, so the completion loop refuses it on the role rather
+            // than on the address being absent.
+            .label = "the published output word instead of the halt flag",
+            .completion = .{
+                .kind = honest.kind,
+                .address = guest.public.data.io_entries.output_data_addr,
+                .value = honest.value,
+                .clock = honest.clock,
+            },
+        },
+    };
+
+    // The last case names a word the snapshot really carries, so what refuses
+    // it is the completion role of a committed word and not an address the
+    // memory image never mentions.
+    const output_word = try committedWordAt(
+        &guest,
+        guest.public.data.io_entries.output_data_addr,
+    );
+    try std.testing.expect(output_word.role.is_public_output);
+    try std.testing.expect(!output_word.role.is_public_completion);
+
+    for (cases) |case| {
+        const forged = withCompletion(guest.public.data, case.completion);
+        expectCanonicalRefusal(&guest, forged, word) catch |err| {
+            std.debug.print(
+                "altered halt tuple ({s}) was not refused at admission: {s}\n",
+                .{ case.label, @errorName(err) },
+            );
+            return err;
+        };
+    }
+}
+
+/// One canonical-but-wrong halt tuple: structurally valid, unequal to the
+/// committed word, refused at admission.
+fn expectCanonicalRefusal(
+    guest: *const committed.Guest,
+    forged: public_data.PublicData,
+    word: memory_state.WordState,
+) !void {
+    try forged.validate();
+    const completion = forged.completion.?;
+    try std.testing.expect(
+        completion.address != word.addr or
+            completion.value != word.final_word or
+            completion.clock != word.final_clock,
+    );
+    try harness.expectRejected(
+        guest,
+        .{ .statement = forged },
+        .admission,
+        error.InvalidStatement,
+    );
+}
+
+// Runtime: microseconds. Row-local: it decides a statement, not a proof.
+test "malicious prover: a forward halt-clock shift is refused by the structural window" {
+    var guest = try committed.Guest.init(std.testing.allocator, harness.SPEC);
+    defer guest.deinit();
+
+    const honest = guest.public.data.completion orelse
+        return error.FixtureHasNoCompletion;
+
+    // The honest halt access is the last access of the last instruction, so it
+    // sits exactly on the execution bound. Recorded here because it is the
+    // reason the attack above moves backward: a forward stride is still a
+    // well-formed subclock, but it is not one this execution could have.
+    try std.testing.expectEqual(
+        access_clock.maximum(guest.public.data.clock),
+        @as(u64, honest.clock),
+    );
+
+    const forward = withClock(honest, honest.clock + access_clock.STRIDE);
+    try std.testing.expect(access_clock.isCanonical(forward.clock));
+    try std.testing.expect(
+        !access_clock.isWithinExecution(forward.clock, guest.public.data.clock, false),
+    );
+
+    // So this one never reaches the committed-word comparison: the shape check
+    // owns it. Pinning the exact structural error keeps the distinction between
+    // the two refusals visible.
+    const forged = withCompletion(guest.public.data, forward);
+    try std.testing.expectError(error.InvalidCompletionClock, forged.validate());
+}

--- a/src/tests/riscv/malicious_prover_forged_output_test.zig
+++ b/src/tests/riscv/malicious_prover_forged_output_test.zig
@@ -1,0 +1,381 @@
+//! Forged public output: the prover publishes an output word its execution
+//! never wrote, and publishes it as the *original* statement of the proof.
+//!
+//! # The attack
+//!
+//! The fixture guest's epilogue publishes two public output words: the length
+//! word (`output_len = 4`) and one data word holding the register the spec
+//! names — here `x6 = 9`. The malicious prover copies the honest output words,
+//! raises the data word's value by one, and proves *that* statement. Nothing in
+//! the witness is touched: the committed trace, the RW-memory snapshot and both
+//! Merkle roots are the honest ones. The prover simply asserts a different
+//! answer than the execution it is proving.
+//!
+//! The forgery is deliberately confined to the data word. `PublicData.validate`
+//! ties `output_words[0].value` to `io_entries.output_len` — so raising the
+//! length word is a *format* violation, refused before the transcript opens —
+//! while a data word's value is unconstrained by the statement's own shape.
+//! Both halves are pinned below, because the interesting claim is that the
+//! surviving forgery is caught by the protocol and not by a format check.
+//!
+//! # Why this is not a post-hoc mutation
+//!
+//! "The attacks must not be post-hoc mutations of an honest proof" means the
+//! forged value must be inside the Fiat-Shamir statement the proof is built
+//! over, not spliced into a finished proof. Three independent facts establish
+//! that here, and the second and third are executable:
+//!
+//!  1. Source order. `prover/orchestration.zig:proveStages` opens the
+//!     transcript with exactly two events —
+//!     `pcs_config.mixInto(channel); statement.public_data.mixInto(channel);` —
+//!     before `Engine.init`, before Tree 0, Tree 1 and Tree 2 are committed and
+//!     before `interaction_trace.drawChallenges` draws a single relation
+//!     challenge. `statement.public_data` is the caller's statement verbatim:
+//!     `statement_geometry.build` assigns `statement.public_data = public_data`
+//!     and `bindCommitmentRoots` afterwards overwrites only the three commitment
+//!     roots, never `io_entries`. `prover/verifier.zig` opens with the same two
+//!     calls on the proof's own statement, so prover and verifier commit to the
+//!     same forged words. This attack file therefore hands its statement to
+//!     `harness.attempt`, which passes it to the production entrypoint as the
+//!     prover's own public data; there is no second statement anywhere.
+//!  2. Transcript preimage. `the forged public output word is the transcript's
+//!     own preimage` replays those two production calls on the production
+//!     channel type and shows that the honest and forged mixes differ in
+//!     exactly one `u32` — the forged value, in the output-word slot that
+//!     `air/public_data.zig`'s pinned mix-order test fixes — that the resulting
+//!     channel digests differ, and that the relation challenges drawn from the
+//!     forged prefix differ from the honest ones. Restoring the word reproduces
+//!     the honest digest bit for bit, so the difference is attributable to that
+//!     word alone.
+//!  3. Attribution. `the forged public output word moves only the
+//!     memory-access public term` decomposes `public_logup.relationSums` over
+//!     the four public domains under one fixed production-shaped challenge set:
+//!     `registers_state`, `merkle` and `program_access` are bit-identical
+//!     between the honest and forged statements, and only `memory_access`
+//!     moves. That is the same attribution `public_relation_binding_test.zig`
+//!     pins for this mutation on the diagnostic path; this file adds the
+//!     end-to-end leg the diagnostic cannot give.
+//!
+//! # The pinned stage and error
+//!
+//! `.verification` / `error.LogupSumNonZero`, exactly as the issue predicts.
+//! The proving path never evaluates the public compensation — the only caller
+//! of `logup.verifyGlobalCancellation` in the frontend is `prover/verifier.zig`
+//! — so the forged statement is admitted, a complete and internally consistent
+//! proof is produced over it, and the verifier's global LogUp closure is what
+//! refuses it: the public boundary consumes a memory tuple carrying the forged
+//! word, the committed memory trace emits the honest one, and the two no longer
+//! cancel.
+//!
+//! Pinning the stage is what makes this evidence. A statement forgery caught at
+//! `.admission` would mean a format check, not the protocol, rejected it; a
+//! `.prover_constraints` rejection would mean it never reached the interaction
+//! argument at all. Only `.verification` says the forgery survived commitment
+//! and lost to the lookup argument.
+//!
+//! The honest control — the unmodified statement of this same guest verifying
+//! through this same `attempt` path — is the shared harness's
+//! `the unmodified request is accepted` self-check and is not repeated here; a
+//! second honest proof would cost about eleven seconds for an obligation
+//! already discharged.
+//!
+//! Runtime: milliseconds for the three statement-local tests and for the
+//! admission attempt, which is decided before the transcript opens; about
+//! eleven seconds for the end-to-end one, which produces one real proof over
+//! the forged statement.
+
+const std = @import("std");
+
+const QM31 = @import("stwo_core").fields.qm31.QM31;
+
+const riscv_cpu = @import("stwo_riscv_cpu_integration");
+const frontend = @import("stwo_riscv_frontend");
+const public_data_mod = frontend.air.public_data;
+const public_logup = frontend.air.public_logup;
+const relation_challenges = frontend.air.relation_challenges;
+
+const committed = @import("committed_forgery_harness.zig");
+const harness = @import("malicious_prover_harness.zig");
+
+const OutputWord = public_data_mod.OutputWord;
+const PublicData = public_data_mod.PublicData;
+
+/// Index of the length word in `io_entries.output_words`, whose value the
+/// statement's own shape ties to `output_len`.
+const LENGTH_WORD: usize = 0;
+/// Index of the single published data word: the vehicle of the attack.
+const DATA_WORD: usize = 1;
+/// Both of them, and no others: the fixture's epilogue publishes one word.
+const OUTPUT_WORD_COUNT: usize = 2;
+
+/// What the honest run stores at `output_data_addr`: the third body `ADDI`
+/// computes `x6 = x3 + 1 = 9` and the epilogue publishes `x6`.
+const HONEST_PUBLISHED_VALUE: u32 = 9;
+
+/// The honest output words with word `index` raised by one. Caller-owned.
+///
+/// A copy, not an in-place edit of the guest's own words: the guest's public
+/// data is the honest baseline every one of these tests compares against, and
+/// a shared buffer would make the "restoring the word reproduces the honest
+/// digest" control vacuous.
+fn forgedOutputWords(
+    allocator: std.mem.Allocator,
+    guest: *const committed.Guest,
+    index: usize,
+) ![]OutputWord {
+    const words = try allocator.alloc(OutputWord, guest.public.output_words.len);
+    @memcpy(words, guest.public.output_words);
+    words[index].value +%= 1;
+    return words;
+}
+
+/// The guest's honest statement with `words` substituted for its output words.
+fn withOutputWords(honest: PublicData, words: []const OutputWord) PublicData {
+    var forged = honest;
+    forged.io_entries.output_words = words;
+    return forged;
+}
+
+/// The production Fiat-Shamir prefix over `statement`, replayed with the two
+/// calls `proveStages` and `verifyRiscVWithEngineUsingChannel` open with, in
+/// that order, on the production channel type.
+fn transcriptPrefix(statement: PublicData) riscv_cpu.CpuProverEngine.Channel {
+    var channel = riscv_cpu.CpuProverEngine.Channel{};
+    committed.PCS_CONFIG.mixInto(&channel);
+    statement.mixInto(&channel);
+    return channel;
+}
+
+/// Every `u32` a statement offers the transcript, in `mixInto` order.
+///
+/// `PublicData.mixInto` reaches the channel only through `mixU32s`, so
+/// recording that one call captures the whole Fiat-Shamir preimage of the
+/// statement. The field order it produces is pinned by
+/// `air/public_data.zig`'s `transcript mix order matches pinned Stark-V`.
+const MixRecorder = struct {
+    words: [256]u32 = undefined,
+    len: usize = 0,
+
+    pub fn mixU32s(self: *MixRecorder, values: []const u32) void {
+        std.debug.assert(self.len + values.len <= self.words.len);
+        @memcpy(self.words[self.len..][0..values.len], values);
+        self.len += values.len;
+    }
+
+    fn record(statement: PublicData) MixRecorder {
+        var recorder = MixRecorder{};
+        statement.mixInto(&recorder);
+        return recorder;
+    }
+
+    fn slice(self: *const MixRecorder) []const u32 {
+        return self.words[0..self.len];
+    }
+};
+
+/// The one honest statement fact every test below forges against, asserted
+/// rather than assumed: two output words, a length word whose value is the
+/// declared length, and one data word at `output_data_addr` holding the
+/// published register.
+fn expectHonestOutputShape(guest: *const committed.Guest) !void {
+    const io = guest.public.data.io_entries;
+    try std.testing.expectEqual(OUTPUT_WORD_COUNT, io.output_words.len);
+    try std.testing.expectEqual(io.output_len, io.output_words[LENGTH_WORD].value);
+    try std.testing.expectEqual(io.output_data_addr, io.output_words[DATA_WORD].addr);
+    try std.testing.expectEqual(HONEST_PUBLISHED_VALUE, io.output_words[DATA_WORD].value);
+}
+
+// Runtime: milliseconds. One eleven-instruction run, no proof.
+test "malicious prover: the forged public output word is structurally valid" {
+    var guest = try committed.Guest.init(std.testing.allocator, harness.SPEC);
+    defer guest.deinit();
+    try expectHonestOutputShape(&guest);
+    try guest.public.data.validate();
+
+    // The load-bearing assertion of the whole attack: the forged statement is
+    // well-formed public data. Whatever refuses it downstream is refusing the
+    // claim it makes about the execution, not its shape.
+    const forged_data = try forgedOutputWords(std.testing.allocator, &guest, DATA_WORD);
+    defer std.testing.allocator.free(forged_data);
+    const forged = withOutputWords(guest.public.data, forged_data);
+    try forged.validate();
+    try std.testing.expectEqual(
+        HONEST_PUBLISHED_VALUE + 1,
+        forged.io_entries.output_words[DATA_WORD].value,
+    );
+
+    // The contrast that makes "structurally valid" a real property rather than
+    // a description: the length word carries a shape invariant, so the same
+    // one-word bump there is a format violation.
+    const forged_length = try forgedOutputWords(std.testing.allocator, &guest, LENGTH_WORD);
+    defer std.testing.allocator.free(forged_length);
+    try std.testing.expectError(
+        error.OutputLengthWordMismatch,
+        withOutputWords(guest.public.data, forged_length).validate(),
+    );
+}
+
+// Runtime: milliseconds. One eleven-instruction run, no proof.
+test "malicious prover: the forged public output word is the transcript's own preimage" {
+    const allocator = std.testing.allocator;
+    var guest = try committed.Guest.init(allocator, harness.SPEC);
+    defer guest.deinit();
+    try expectHonestOutputShape(&guest);
+
+    const forged_words = try forgedOutputWords(allocator, &guest, DATA_WORD);
+    defer allocator.free(forged_words);
+    const forged = withOutputWords(guest.public.data, forged_words);
+
+    // The forged value is *in* the Fiat-Shamir preimage, and it is the only
+    // thing in it that moved.
+    const honest_mix = MixRecorder.record(guest.public.data);
+    const forged_mix = MixRecorder.record(forged);
+    try std.testing.expectEqual(honest_mix.len, forged_mix.len);
+    var differing: usize = 0;
+    var position: usize = 0;
+    for (honest_mix.slice(), forged_mix.slice(), 0..) |honest_word, forged_word, index| {
+        if (honest_word == forged_word) continue;
+        differing += 1;
+        position = index;
+    }
+    try std.testing.expectEqual(@as(usize, 1), differing);
+    try std.testing.expectEqual(HONEST_PUBLISHED_VALUE, honest_mix.slice()[position]);
+    try std.testing.expectEqual(HONEST_PUBLISHED_VALUE + 1, forged_mix.slice()[position]);
+
+    // `mixInto` emits `{addr, value, clock}` per output word after the fixed
+    // header and the input words, so the moved slot is the data word's value.
+    const header = honest_mix.len - 3 * OUTPUT_WORD_COUNT;
+    try std.testing.expectEqual(header + 3 * DATA_WORD + 1, position);
+
+    // The transcript state the production prover and verifier both reach after
+    // their two opening events already distinguishes the two statements, so
+    // every challenge drawn afterwards is a function of the forged statement.
+    const honest_prefix = transcriptPrefix(guest.public.data);
+    var forged_prefix = transcriptPrefix(forged);
+    try std.testing.expect(!std.mem.eql(
+        u8,
+        &honest_prefix.digestBytes(),
+        &forged_prefix.digestBytes(),
+    ));
+
+    var honest_channel = honest_prefix;
+    const honest_relations = try relation_challenges.Relations.draw(allocator, &honest_channel);
+    const forged_relations = try relation_challenges.Relations.draw(allocator, &forged_prefix);
+    try std.testing.expect(
+        !honest_relations.memory_access.z.eql(forged_relations.memory_access.z),
+    );
+    try std.testing.expect(
+        !honest_relations.registers_state.alpha.eql(forged_relations.registers_state.alpha),
+    );
+
+    // The control: the divergence above is attributable to that one word and
+    // to nothing else about how these statements were built.
+    forged_words[DATA_WORD].value -%= 1;
+    const restored = transcriptPrefix(withOutputWords(guest.public.data, forged_words));
+    try std.testing.expectEqualSlices(
+        u8,
+        &honest_prefix.digestBytes(),
+        &restored.digestBytes(),
+    );
+}
+
+// Runtime: milliseconds. One eleven-instruction run, no proof.
+test "malicious prover: the forged public output word moves only the memory-access public term" {
+    const allocator = std.testing.allocator;
+    var guest = try committed.Guest.init(allocator, harness.SPEC);
+    defer guest.deinit();
+    try expectHonestOutputShape(&guest);
+
+    const forged_words = try forgedOutputWords(allocator, &guest, DATA_WORD);
+    defer allocator.free(forged_words);
+    const forged = withOutputWords(guest.public.data, forged_words);
+
+    // One challenge set for both statements — a comparison under two different
+    // challenge sets would say nothing about which domain moved. This is a
+    // fixed, transcript-derived challenge set, not production's relation
+    // challenges: production draws those in `interaction_trace.drawChallenges`
+    // (`orchestration.zig:237`), after the tree roots are mixed, whereas this
+    // channel has seen only the two opening events. The only property the
+    // comparison needs is that both statements are measured under one and the
+    // same set.
+    var channel = transcriptPrefix(guest.public.data);
+    const relations = try relation_challenges.Relations.draw(allocator, &channel);
+
+    const honest_sums = try public_logup.relationSums(&guest.public.data, &relations);
+    const forged_sums = try public_logup.relationSums(&forged, &relations);
+
+    // The three domains the forgery must not disturb. A moved `registers_state`
+    // or `program_access` term would mean the rejection below could be
+    // explained by the CPU boundary or the completion sentinel instead of by
+    // the public memory word the attack actually forged.
+    try std.testing.expect(honest_sums.registers_state.eql(forged_sums.registers_state));
+    try std.testing.expect(honest_sums.merkle.eql(forged_sums.merkle));
+    try std.testing.expect(honest_sums.program_access.eql(forged_sums.program_access));
+    try std.testing.expect(!honest_sums.memory_access.eql(forged_sums.memory_access));
+
+    // The public boundary is exactly the term `verifyGlobalCancellation` adds
+    // to the committed claims, so a nonzero delta here is a closure that no
+    // longer closes: the honest total cancels the committed trace and the
+    // forged one cannot.
+    const honest_total = try public_logup.sum(&guest.public.data, &relations);
+    const forged_total = try public_logup.sum(&forged, &relations);
+    try std.testing.expect(honest_sums.total().eql(honest_total));
+    try std.testing.expect(!forged_total.sub(honest_total).eql(QM31.zero()));
+
+    // The control, again: restoring the word restores every domain exactly.
+    forged_words[DATA_WORD].value -%= 1;
+    const restored = try public_logup.relationSums(
+        &withOutputWords(guest.public.data, forged_words),
+        &relations,
+    );
+    try std.testing.expect(honest_sums.memory_access.eql(restored.memory_access));
+    try std.testing.expect(honest_sums.total().eql(restored.total()));
+}
+
+// Runtime: about eleven seconds. One real proof over the forged statement; the
+// honest leg is the shared harness's, not repeated here.
+test "malicious prover: a forged public output word is rejected at verification" {
+    const allocator = std.testing.allocator;
+    var guest = try committed.Guest.init(allocator, harness.SPEC);
+    defer guest.deinit();
+    try expectHonestOutputShape(&guest);
+
+    const forged_words = try forgedOutputWords(allocator, &guest, DATA_WORD);
+    defer allocator.free(forged_words);
+    const forged = withOutputWords(guest.public.data, forged_words);
+    // Asserted here too, immediately before the attempt, so the end-to-end
+    // rejection cannot be read as a refusal of malformed public data.
+    try forged.validate();
+
+    try harness.expectRejected(
+        &guest,
+        .{ .statement = forged },
+        .verification,
+        error.LogupSumNonZero,
+    );
+}
+
+// Runtime: milliseconds. Admission is decided before any transcript event, so
+// this attempt costs a witness derivation and no proof.
+test "malicious prover: a forged public output length word is refused at admission" {
+    // The boundary of the attack above. The length word is the one output word
+    // the statement's own shape constrains, so forging it never reaches the
+    // interaction argument: `statement_validation.validate` maps
+    // `PublicData.validate`'s refusal onto `error.InvalidStatement` before the
+    // channel has seen a single event. Pinning it keeps the verification
+    // rejection above meaningful — it shows that reaching verification at all
+    // required a forgery the format check cannot see.
+    const allocator = std.testing.allocator;
+    var guest = try committed.Guest.init(allocator, harness.SPEC);
+    defer guest.deinit();
+    try expectHonestOutputShape(&guest);
+
+    const forged_words = try forgedOutputWords(allocator, &guest, LENGTH_WORD);
+    defer allocator.free(forged_words);
+    try harness.expectRejected(
+        &guest,
+        .{ .statement = withOutputWords(guest.public.data, forged_words) },
+        .admission,
+        error.InvalidStatement,
+    );
+}

--- a/src/tests/riscv/malicious_prover_harness.zig
+++ b/src/tests/riscv/malicious_prover_harness.zig
@@ -1,0 +1,313 @@
+//! Production-path malicious-prover harness.
+//!
+//! Ordinary execution agreement starts with an honest runner trace.  That is
+//! necessary, but it cannot answer whether an adversarial prover can choose a
+//! different witness or public statement and still obtain an accepted proof.
+//! This harness enters the real proving transaction at those two adversarial
+//! boundaries and records the exact stage that refuses the attempt:
+//!
+//!  - precommit ingestion, before the lookup sources exist;
+//!  - admission, before any transcript event;
+//!  - the prover's direct-constraint check, before a proof exists; or
+//!  - verification, after a proof was produced from the malicious witness.
+//!
+//! The four attacks are deliberately not mutations of an honest proof.
+//! Skipped and stale rows are installed before lookup ingestion, so Tree 1,
+//! lookup multiplicities and Tree 2 all derive from the same forged witness.
+//! Forged output and completion values enter as the prover's original public
+//! statement, before Fiat-Shamir challenges are drawn.  A rejection therefore
+//! exercises proof admission rather than serialization integrity.
+//!
+//! Each attack lives in its own `malicious_prover_*_test.zig` beside this
+//! module; this file owns the transaction entry point, the stage taxonomy and
+//! the shared three-ADDI fixture they all forge against.
+
+const std = @import("std");
+
+const riscv_cpu = @import("stwo_riscv_cpu_integration");
+const frontend = @import("stwo_riscv_frontend");
+const access_clock = frontend.access_clock;
+const public_data = frontend.air.public_data;
+const orchestration = frontend.testing.prover_orchestration;
+const trace_mod = frontend.runner.trace;
+
+const committed = @import("committed_forgery_harness.zig");
+const guest_elf = @import("guest_elf_fixture.zig");
+const layout = @import("committed_row_layout.zig");
+
+pub const Guest = committed.Guest;
+pub const Row = committed.Row;
+pub const ColumnValue = committed.ColumnValue;
+
+/// Where the production pipeline refused a malicious request.
+///
+/// The order is the order the pipeline itself decides in, which is what makes
+/// a pinned stage evidence: an attack pinned to a later stage would have been
+/// caught earlier if the earlier check covered it.
+pub const Stage = enum {
+    /// Lookup-source ingestion, before any table is committed. Structural
+    /// admission of the committed rows themselves.
+    precommit_ingestion,
+    /// Public-statement admission, before any transcript event.
+    admission,
+    /// The prover's direct-constraint check, before a proof exists.
+    prover_constraints,
+    /// Verification, after a proof was produced from the malicious witness.
+    verification,
+};
+
+pub const Rejection = struct {
+    stage: Stage,
+    reason: anyerror,
+};
+
+pub const Decision = union(enum) {
+    verified,
+    rejected: Rejection,
+};
+
+/// One adversarial proving request.  Both fields are borrowed for the duration
+/// of `attempt`; the ordinary case passes the guest's honest public data and no
+/// mutation.
+pub const Attempt = struct {
+    statement: public_data.PublicData,
+    witness: ?committed.Mutation = null,
+};
+
+/// Run an adversarial request through the production CPU prover and verifier.
+///
+/// Only the deliberate refusals are classified, and each is classified to the
+/// stage that raised it. Every other error escapes to fail the test rather
+/// than being counted as evidence that the attack was rejected: a harness that
+/// mapped `anyerror` onto "rejected" would pass on a broken fixture, which is
+/// the failure mode this whole file exists to rule out.
+pub fn attempt(guest: *const committed.Guest, malicious: Attempt) !Decision {
+    var channel = riscv_cpu.CpuProverEngine.Channel{};
+    const output = orchestration.runRiscVWithEngineAndPublicDataUsingChannel(
+        riscv_cpu.CpuProverEngine,
+        .prove,
+        guest.allocator,
+        committed.PCS_CONFIG,
+        &guest.run.execution_trace,
+        &guest.run.state_chain_tracker,
+        &guest.run.rw_memory,
+        null,
+        malicious.statement,
+        &channel,
+        malicious.witness,
+        null,
+    ) catch |err| switch (err) {
+        // Structural admission of the committed rows, raised by
+        // `air/lookups/tables/source_ingest.zig` before any table is
+        // committed. Only the two placement errors are classified; the rest of
+        // that module's error set describes a malformed source rather than a
+        // forged row and must not be able to satisfy an attack's expectation.
+        error.InactiveRealRow, error.NonZeroPadding => return .{ .rejected = .{
+            .stage = .precommit_ingestion,
+            .reason = err,
+        } },
+        error.InvalidStatement => return .{ .rejected = .{
+            .stage = .admission,
+            .reason = err,
+        } },
+        error.ConstraintsNotSatisfied => return .{ .rejected = .{
+            .stage = .prover_constraints,
+            .reason = err,
+        } },
+        else => return err,
+    };
+
+    // Verification consumes the proof on both success and failure.  The boxed
+    // interaction claim remains caller-owned.
+    defer output.deinitAfterProofMoved(guest.allocator);
+    riscv_cpu.verifyRiscV(
+        guest.allocator,
+        committed.PCS_CONFIG,
+        output.statement,
+        output.proof,
+        output.interaction_claim,
+    ) catch |err| return .{ .rejected = .{
+        .stage = .verification,
+        .reason = err,
+    } };
+    return .verified;
+}
+
+/// Asserts the request is refused at exactly `expected_stage` with exactly
+/// `expected_reason`. Both are pinned so that an unrelated failure elsewhere
+/// in the pipeline cannot satisfy the test.
+pub fn expectRejected(
+    guest: *const committed.Guest,
+    malicious: Attempt,
+    expected_stage: Stage,
+    expected_reason: anyerror,
+) !void {
+    switch (try attempt(guest, malicious)) {
+        .verified => {
+            std.debug.print(
+                "malicious prover unexpectedly produced an accepted proof\n",
+                .{},
+            );
+            return error.TestUnexpectedResult;
+        },
+        .rejected => |actual| {
+            if (actual.stage != expected_stage or actual.reason != expected_reason) {
+                std.debug.print(
+                    "malicious-prover rejection mismatch: expected {s}/{s}, got {s}/{s}\n",
+                    .{
+                        @tagName(expected_stage),
+                        @errorName(expected_reason),
+                        @tagName(actual.stage),
+                        @errorName(actual.reason),
+                    },
+                );
+            }
+            try std.testing.expectEqual(expected_stage, actual.stage);
+            try std.testing.expectEqual(expected_reason, actual.reason);
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The shared fixture
+// ---------------------------------------------------------------------------
+
+// The body creates two historical versions of x3, then reads x3 into x6:
+//
+//   ADDI x3, x0, 7
+//   ADDI x3, x3, 1      // x3 = 8
+//   ADDI x6, x3, 1      // honest x6 = 9
+//
+// The stale-read attack rewrites only the third row to consume x3 = 7 at the
+// first write's clock and coherently derive x6 = 8.
+pub const BODY = [_]u32{
+    0x0070_0193,
+    0x0011_8193,
+    0x0011_8313,
+};
+pub const SPEC = guest_elf.Spec{ .body = &BODY, .publish = 6 };
+pub const FAMILY = trace_mod.OpcodeFamily.base_alu_imm;
+pub const TARGET: committed.Target = .{ .opcode = .{ .family = FAMILY } };
+
+/// Rows the fixture materialises for `FAMILY`: the three body ADDIs plus the
+/// epilogue's two ADDIs. The prologue (`LUI`, `LUI`, `LW`) retires no row of
+/// this family, so body instruction `i` is logical row `i`.
+pub const FAMILY_ROWS: usize = 5;
+
+pub const RS1_PREV_0 = layout.columnOf(FAMILY, "rs1_prev_0");
+pub const RS1_CLOCK_PREV = layout.columnOf(FAMILY, "rs1_clock_prev");
+pub const RS1_NEXT_0 = layout.columnOf(FAMILY, "rs1_next_0");
+pub const RD_NEXT_0 = layout.columnOf(FAMILY, "rd_next_0");
+pub const RESULT_0 = layout.columnOf(FAMILY, "result_0");
+
+pub const RowValues = struct {
+    values: [trace_mod.MAX_FAMILY_COLUMNS]committed.ColumnValue = undefined,
+    len: usize = 0,
+
+    pub fn set(self: *RowValues, column: usize, value: u32) void {
+        self.values[self.len] = .{ .column = @intCast(column), .value = value };
+        self.len += 1;
+    }
+
+    pub fn slice(self: *const RowValues) []const committed.ColumnValue {
+        return self.values[0..self.len];
+    }
+};
+
+/// Canonical padding over every column of a row: the committed-trace shape of
+/// an instruction the prover declines to retire.
+pub fn skippedRow(n_columns: usize) RowValues {
+    var result = RowValues{};
+    for (0..n_columns) |column| result.set(column, 0);
+    return result;
+}
+
+/// The third ADDI rewritten to consume the older real x3 = 7 and the access
+/// clock of its first write, with the result coherently recomputed. Every
+/// row-local relation still holds; only the global access chain disagrees.
+pub fn staleRead() RowValues {
+    var result = RowValues{};
+    result.set(RS1_PREV_0, 7);
+    result.set(RS1_CLOCK_PREV, access_clock.encode(guest_elf.bodyClock(0), .second));
+    result.set(RS1_NEXT_0, 7);
+    result.set(RD_NEXT_0, 8);
+    result.set(RESULT_0, 8);
+    return result;
+}
+
+pub fn override(logical_row: u32, values: []const committed.ColumnValue) committed.Mutation {
+    return .{ .main_row = .{
+        .target = TARGET,
+        .logical_row = logical_row,
+        .values = values,
+    } };
+}
+
+/// Pins that a forgery moved the memory-access bus while leaving the
+/// register-state and program buses untouched, so a rejection attributable to
+/// the access chain cannot be explained by a coincidental disturbance of those
+/// two.
+///
+/// This compares exactly three of the twelve relation domains and deliberately
+/// says nothing about the rest. A stale read also moves the range-check buses —
+/// `entry.accessChain` requests a `range_check_20` over the clock gap and
+/// `base_alu_imm` requests `range_check_8_8` over the changed result limbs — so
+/// this is emphatically not a claim that the forgery moved one bus in total.
+/// Whether the forgery is caught is decided by global closure over every
+/// domain, which is a separate assertion; do not read this helper as covering
+/// it.
+pub fn expectOnlyMemoryBusMoved(
+    honest: *const committed.Row,
+    forged: *const committed.Row,
+) !void {
+    try std.testing.expect(
+        try committed.busFingerprint(FAMILY, honest.slice(), .memory_access) !=
+            try committed.busFingerprint(FAMILY, forged.slice(), .memory_access),
+    );
+    try std.testing.expectEqual(
+        try committed.busFingerprint(FAMILY, honest.slice(), .registers_state),
+        try committed.busFingerprint(FAMILY, forged.slice(), .registers_state),
+    );
+    try std.testing.expectEqual(
+        try committed.busFingerprint(FAMILY, honest.slice(), .program_access),
+        try committed.busFingerprint(FAMILY, forged.slice(), .program_access),
+    );
+}
+
+test "malicious prover harness: the unmodified request is accepted" {
+    var guest = try committed.Guest.init(std.testing.allocator, SPEC);
+    defer guest.deinit();
+    try std.testing.expectEqual(
+        Decision.verified,
+        try attempt(&guest, .{ .statement = guest.public.data }),
+    );
+}
+
+// The honest leg every attack depends on. Each malicious test asserts a
+// rejection, and a rejection is only evidence if the same guest is provable
+// at all — otherwise every attack in this suite would pass vacuously against
+// a guest that simply cannot be proven. Sail agreement rides along here so
+// the run that is proven is the run the pinned model has seen. It lives in
+// the shared module rather than in each attack file so the four attacks pay
+// for it once.
+test "malicious prover harness: the fixture guest proves, verifies and agrees with Sail" {
+    var guest = try committed.Guest.init(std.testing.allocator, SPEC);
+    defer guest.deinit();
+    try guest.proveAndVerify("malicious-prover state-history guest");
+}
+
+test "malicious prover harness: the fixture retires the expected rows" {
+    var guest = try committed.Guest.init(std.testing.allocator, SPEC);
+    defer guest.deinit();
+    try std.testing.expectEqual(FAMILY_ROWS, try guest.familyRowCount(FAMILY));
+
+    // The stale-read attack is only meaningful if the honest third body row
+    // really does consume the *newer* x3 = 8 at the second write's clock.
+    const honest_third = try guest.honestRow(FAMILY, 2);
+    try std.testing.expectEqual(@as(u32, 8), honest_third.m31At(RS1_PREV_0).toU32());
+    try std.testing.expectEqual(
+        access_clock.encode(guest_elf.bodyClock(1), .second),
+        honest_third.m31At(RS1_CLOCK_PREV).toU32(),
+    );
+    try std.testing.expectEqual(@as(u32, 9), honest_third.m31At(RESULT_0).toU32());
+}

--- a/src/tests/riscv/malicious_prover_skipped_test.zig
+++ b/src/tests/riscv/malicious_prover_skipped_test.zig
@@ -1,0 +1,257 @@
+//! Malicious prover, skipped instruction: an active opcode row committed as
+//! all-zero padding.
+//!
+//! The attack is the cheapest thing a prover can do to a step it does not want
+//! on the record: retire the instruction in the run, then commit its row as
+//! padding, so the step's register write, its program access and its
+//! state-chain link never reach any bus. It is not a post-hoc mutation of an
+//! honest proof. The padding is installed by the witness hook in
+//! `prover/main_trace.zig`, between opcode-witness generation and
+//! `lookup_sources.ingest`, so the lookup multiplicities, the committed Tree 1
+//! and the Tree 2 interactions all derive from the padded witness. There is no
+//! honest artefact left for it to disagree with.
+//!
+//! ## What is pinned, and why it is not what the issue predicted
+//!
+//! The issue's acceptance criterion reads "an active opcode row replaced by
+//! padding is rejected by the active-row placement constraint", which predicts
+//! `prover_constraints` / `error.ConstraintsNotSatisfied`. Production refuses
+//! the request strictly earlier, at `.precommit_ingestion` with
+//! `error.InactiveRealRow`, raised by `air/lookups/tables/source_ingest.zig`
+//! (`if (row < shard.n_real_rows and !active) return error.InactiveRealRow;`)
+//! before any table is committed and therefore before any composition
+//! polynomial exists. That is the honest answer, and it is what the end-to-end
+//! test pins. Note also that the prover's own `validateDirectSemantics` cannot
+//! see this forgery: `prover/opcode_trace.zig` runs it on the generated witness,
+//! before the hook rewrites the row.
+//!
+//! A stage on its own would understate the criterion, so the first two tests
+//! below are a pair and the pairing is the argument:
+//!
+//!  - row-locally, the active-row placement constraint is the *unique* direct
+//!    constraint the padded row fails, so the criterion's claim about the AIR
+//!    holds exactly as stated; and
+//!  - end-to-end, production never gets that far, because structural admission
+//!    of the committed rows rejects the padding first.
+//!
+//! Shipping either half alone would be misleading: the row-local half would not
+//! show the forgery is reachable, and the end-to-end half would not show which
+//! constraint owns the criterion. Both controls -- the honest row is admissible
+//! and ingestion-active, the padded row asks nothing of any bus -- are there so
+//! neither half can pass because the pipeline refuses everything.
+//!
+//! ## The structurally shortened trace (the deeper threat model)
+//!
+//! The handoff also asked whether a prover could *genuinely* omit an
+//! instruction, recompute the geometry, survive ingestion, and be caught by the
+//! placement constraint at composition instead. It cannot, and the third test
+//! pins both halves of why.
+//!
+//! Placement cannot fire, structurally. `runner/trace.zig` `columnsForFamily`
+//! packs a family's rows contiguously from index 0 and reports `n_real_rows` as
+//! the count it wrote; `prover/opcode_trace.zig` derives each shard's
+//! `n_real_rows` from the same row list, and `prover/statement_geometry.zig`
+//! derives the shard lengths from `groupByOpcodeFamily` over that same list. So
+//! `is_active` and the committed `row.active()` are two readings of one row
+//! list: omitting an instruction shortens the declared geometry instead of
+//! leaving a hole in it, every real row stays active, and `active() - is_active`
+//! vanishes by construction. The only way to desynchronise the two is a
+//! cell-level forgery inside the real region -- this file's attack, which
+//! ingestion refuses first. The composition-time placement rejection is
+//! therefore defence in depth behind `source_ingest`, not a reachable
+//! production verdict.
+//!
+//! What does catch the shortened trace is the register-access chain.
+//! `air/opcode_memory.zig` `deriveRegisterBoundary` replays every row's register
+//! accesses and requires each one to continue the boundary it has built so far;
+//! dropping a retirement leaves the next reader of that register naming a
+//! previous clock and value nobody produced, so it returns
+//! `error.InvalidRegisterAccessChain`. `prover.zig:66` runs it on the entry
+//! point that derives the statement from the trace, which is exactly the
+//! "recompute the geometry" prover. The skip is therefore an access-chain
+//! violation, not a placement violation -- a different acceptance criterion,
+//! owned by the bus-soundness surface.
+//!
+//! The one case this file deliberately does not construct is a shortened trace
+//! carried on the public-data entry point with a *recomputed* statement, which
+//! bypasses `prover.zig:66`. There is no production surface for it: a statement
+//! is derived by `diagnostics/public_values.derive` from a `runner.RunResult`,
+//! and a `RunResult` is only ever produced by `runner/mod.zig` executing an ELF
+//! faithfully, so a self-consistent statement for a trace the runner did not
+//! produce cannot be built through shipped code.
+
+const std = @import("std");
+const QM31 = @import("stwo_core").fields.qm31.QM31;
+
+const opcode_entries = @import("stwo_riscv_frontend").air.lookups.opcode_entries;
+const opcode_memory = @import("stwo_riscv_frontend").air.opcode_memory;
+const semantic_eval = @import("stwo_riscv_frontend").air.semantic_eval;
+const trace_mod = @import("stwo_riscv_frontend").runner.trace;
+
+const committed = @import("committed_forgery_harness.zig");
+const guest_elf = @import("guest_elf_fixture.zig");
+const harness = @import("malicious_prover_harness.zig");
+
+/// Logical row of the family the prover declines to retire: the fixture's first
+/// body instruction, `ADDI x3, x0, 7`. The body's rows precede the epilogue's
+/// two `ADDI`s in the family, so this names one specific instruction.
+const SKIPPED_ROW: u32 = 0;
+
+/// Smallest domain `source_ingest` admits (`size < 16` is `InvalidDomainSize`),
+/// which is also the domain the production shard of this fixture uses.
+const SHORT_LOG_SIZE: u32 = 4;
+
+/// The active-row placement constraint's index in `semantic_eval` order.
+///
+/// `evaluateModule` appends `placementConstraint` after the family's own
+/// `N_CONSTRAINTS`, so the placement constraint is always the family's last.
+fn placementConstraintIndex() usize {
+    return semantic_eval.constraintCount(harness.FAMILY) - 1;
+}
+
+/// Ingestion's own notion of an active row, recomputed row-locally.
+///
+/// `source_ingest.scanShard` calls a committed row active when any entry it
+/// emits carries a non-zero numerator, and refuses a row below `n_real_rows`
+/// that is not. Recomputing that predicate here is what lets the end-to-end
+/// `error.InactiveRealRow` be attributed to the padding itself rather than to
+/// some other property of the run.
+fn emitsActiveRequest(columns: []const QM31) !bool {
+    const list = try opcode_entries.fromMain(harness.FAMILY, columns);
+    for (list.entries[0..list.len]) |emitted| {
+        if (!emitted.numerator.isZero()) return true;
+    }
+    return false;
+}
+
+/// The fixture's retirement sequence with the skipped instruction genuinely
+/// absent, as a prover that declines to retire it would present.
+///
+/// The caller owns the returned trace.
+fn shortenedTrace(
+    allocator: std.mem.Allocator,
+    honest: *const trace_mod.Trace,
+) !trace_mod.Trace {
+    var short = trace_mod.Trace.init(allocator);
+    errdefer short.deinit();
+    short.initial_pc = honest.initial_pc;
+    short.final_pc = honest.final_pc;
+    var dropped: usize = 0;
+    for (honest.rows.items) |row| {
+        if (row.pc == guest_elf.bodyPc(0)) {
+            dropped += 1;
+            continue;
+        }
+        try short.append(row);
+    }
+    // The fixture is straight-line, so the skipped instruction's pc identifies
+    // exactly one retirement.
+    if (dropped != 1) return error.TestUnexpectedResult;
+    return short;
+}
+
+// Runtime: milliseconds. One run of the fixture guest, no proof.
+test "malicious prover: the active-row placement constraint alone rejects a padded opcode row" {
+    var guest = try committed.Guest.init(std.testing.allocator, harness.SPEC);
+    defer guest.deinit();
+    try std.testing.expectEqual(harness.FAMILY_ROWS, try guest.familyRowCount(harness.FAMILY));
+
+    // Control. Without it, "the padded row is rejected" would also be satisfied
+    // by a pipeline that refuses every row of this family, and the end-to-end
+    // `InactiveRealRow` would also be satisfied by a fixture whose honest rows
+    // are inactive to begin with.
+    const honest = try guest.honestRow(harness.FAMILY, SKIPPED_ROW);
+    try committed.expectAccepted(harness.FAMILY, honest.slice());
+    try std.testing.expect(try emitsActiveRequest(honest.slice()));
+
+    var padded = honest;
+    const padding = harness.skippedRow(honest.n_columns);
+    padded.apply(padding.slice());
+    for (padded.slice()) |cell| try std.testing.expect(cell.isZero());
+
+    // The acceptance criterion, row-locally: the active-row placement
+    // constraint is the unique direct constraint the padded row fails. A second
+    // failing constraint would mean the criterion is being satisfied by some
+    // incidental incoherence of the all-zero row instead.
+    try committed.expectOnlyConstraint(
+        harness.FAMILY,
+        padded.slice(),
+        placementConstraintIndex(),
+    );
+
+    // And the padded row asks nothing of any bus, which is exactly the
+    // condition `source_ingest` refuses below `n_real_rows` -- the reason the
+    // end-to-end verdict below is an ingestion verdict and not a composition
+    // one.
+    try std.testing.expect(!(try emitsActiveRequest(padded.slice())));
+}
+
+// Runtime: seconds. One proving attempt, stopped before Tree 1 is committed.
+test "malicious prover: a skipped instruction is refused at lookup-source ingestion" {
+    var guest = try committed.Guest.init(std.testing.allocator, harness.SPEC);
+    defer guest.deinit();
+
+    const honest = try guest.honestRow(harness.FAMILY, SKIPPED_ROW);
+    const padding = harness.skippedRow(honest.n_columns);
+    try harness.expectRejected(
+        &guest,
+        .{
+            .statement = guest.public.data,
+            .witness = harness.override(SKIPPED_ROW, padding.slice()),
+        },
+        .precommit_ingestion,
+        error.InactiveRealRow,
+    );
+}
+
+// Runtime: milliseconds. One run of the fixture guest, no proof.
+test "malicious prover: a structurally shortened trace loses on the access chain, not on placement" {
+    const allocator = std.testing.allocator;
+    var guest = try committed.Guest.init(allocator, harness.SPEC);
+    defer guest.deinit();
+    var short = try shortenedTrace(allocator, &guest.run.execution_trace);
+    defer short.deinit();
+
+    // The declared geometry shrank with the trace instead of keeping a hole:
+    // `n_real_rows` is the count of rows actually written, and the statement's
+    // shard length comes from the same row list.
+    var columns = try short.columnsForFamily(allocator, harness.FAMILY, SHORT_LOG_SIZE);
+    defer columns.deinit(allocator);
+    try std.testing.expectEqual(harness.FAMILY_ROWS - 1, columns.n_real_rows);
+
+    // So over the whole shard domain, under the `is_active` that the prover and
+    // the verifier both derive from that geometry, every constraint vanishes --
+    // the placement constraint included -- and no real row is inactive. The
+    // skip would survive both `source_ingest` and composition.
+    const size = @as(usize, 1) << @intCast(SHORT_LOG_SIZE);
+    for (0..size) |logical_row| {
+        var cells: [trace_mod.MAX_FAMILY_COLUMNS]QM31 = undefined;
+        for (
+            cells[0..columns.n_columns],
+            columns.columns[0..columns.n_columns],
+        ) |*cell, column| {
+            cell.* = QM31.fromBase(column[logical_row]);
+        }
+        const real = logical_row < columns.n_real_rows;
+        const evaluation = try semantic_eval.evaluate(
+            harness.FAMILY,
+            cells[0..columns.n_columns],
+            if (real) QM31.one() else QM31.zero(),
+        );
+        try std.testing.expect(evaluation.allZero());
+        try std.testing.expectEqual(real, try emitsActiveRequest(cells[0..columns.n_columns]));
+    }
+
+    // What refuses it instead, on the entry point that recomputes the statement
+    // from the trace (`prover.zig` `proveRiscVWithEngineUsingChannel`): the
+    // register-access chain no longer closes, because the next reader of the
+    // skipped instruction's destination names a previous clock and value that
+    // no retirement produced. The honest rows are the control -- the same
+    // derivation accepts them, so the rejection is the omission and not the
+    // fixture.
+    _ = try opcode_memory.deriveRegisterBoundary(guest.run.execution_trace.rows.items);
+    try std.testing.expectError(
+        error.InvalidRegisterAccessChain,
+        opcode_memory.deriveRegisterBoundary(short.rows.items),
+    );
+}

--- a/src/tests/riscv/malicious_prover_stale_read_test.zig
+++ b/src/tests/riscv/malicious_prover_stale_read_test.zig
@@ -1,0 +1,399 @@
+//! Malicious prover, stale register read: a locally perfect row that only
+//! global memory closure can refuse.
+//!
+//! The attack. The shared fixture retires three `ADDI`s — `x3 := 7`,
+//! `x3 := x3 + 1`, `x6 := x3 + 1` — so `x3` has two real historical versions
+//! and the third instruction is the only consumer of the newer one. The
+//! adversarial prover rewrites that third row to consume the *older* real
+//! version: `rs1_prev = 7` at the access clock of the first write, re-emitted
+//! unchanged as `rs1_next = 7`, with the destination coherently recomputed to
+//! `x6 = 8`. Nothing in the row is inconsistent with itself. The addition is
+//! right, the byte ranges hold, the read-only source binding holds
+//! (`next == previous`), the clock gap is still positive and in range, and the
+//! program and state tuples are untouched. `harness.staleRead` is exactly this
+//! row, and every value it names is a value the run really produced.
+//!
+//! Why this is not a post-hoc mutation. The forgery is installed through the
+//! production witness hook *before* lookup ingestion, so Tree 1, the lookup
+//! multiplicities and Tree 2 are all generated from the forged witness, and the
+//! Fiat-Shamir challenges are drawn over commitments to it. The prover here is
+//! not editing a finished proof; it is choosing a different witness for the
+//! same public statement and proving that.
+//!
+//! What the rejection means. The pinned stage is `.verification` with
+//! `error.LogupSumNonZero`: the forged row survives every row-local check the
+//! prover applies and does produce a complete proof, and the verifier's global
+//! LogUp cancellation is what refuses it. That is the strongest form this
+//! evidence can take. A rejection at `.prover_constraints` would have said some
+//! direct constraint already covered the row, and a rejection at
+//! `.precommit_ingestion` would have said the row was structurally malformed;
+//! neither would show that the *global* memory argument is load-bearing.
+//!
+//! Attribution, in three widening steps, so "rejected" is never the whole
+//! claim:
+//!
+//!  - row-locally the forgery is ADMISSIBLE (`committed.expectAccepted`), and
+//!    only the `memory_access` bus fingerprint moves — the register-state and
+//!    program buses are bit-identical, so no collateral disturbance can explain
+//!    the rejection;
+//!  - the moved tuple is named exactly: the forged row consumes the very tuple
+//!    body row 1 already consumed, and orphans the tuple body row 1 emitted, so
+//!    the access chain is double-spent at a named address and clock rather than
+//!    merely different;
+//!  - and the same forged transaction re-run in `.relation_diagnostic` mode
+//!    shows `memory_access` is the ONLY one of the twelve relation domains
+//!    whose committed sum fails to cancel against the public boundary. A test
+//!    that only said "some LogUp sum was non-zero" would also pass if the
+//!    forgery had broken the program bus instead.
+//!
+//! Runtime: about 40 s. One `.prove` run whose verification must fail, plus two
+//! `.relation_diagnostic` runs, which stop before proof assembly. The row-local
+//! tests are milliseconds. The honest proof-and-Sail leg is paid once for all
+//! four attacks by `malicious_prover_harness.zig` and is deliberately not
+//! repeated here.
+
+const std = @import("std");
+const QM31 = @import("stwo_core").fields.qm31.QM31;
+
+const riscv_cpu = @import("stwo_riscv_cpu_integration");
+const frontend = @import("stwo_riscv_frontend");
+const access_clock = frontend.access_clock;
+const entry_mod = frontend.air.lookups.entry;
+const opcode_entries = frontend.air.lookups.opcode_entries;
+const orchestration = frontend.testing.prover_orchestration;
+const prover_mod = frontend.prover_mod;
+
+const committed = @import("committed_forgery_harness.zig");
+const guest_elf = @import("guest_elf_fixture.zig");
+const harness = @import("malicious_prover_harness.zig");
+
+/// The register the fixture writes twice and reads once.
+const SOURCE_REG: u32 = 3;
+
+/// Family-relative index of each body `ADDI`. The prologue retires no
+/// `base_alu_imm` row, so the three body instructions are logical rows 0..2 and
+/// the epilogue's two `ADDI`s follow them.
+const FIRST_WRITE: u32 = 0;
+const SECOND_WRITE: u32 = 1;
+const STALE_READER: u32 = 2;
+
+// ---------------------------------------------------------------------------
+// Memory-access tuples of one committed row
+// ---------------------------------------------------------------------------
+
+/// The `memory_access` tuples one committed row offers, split by side.
+///
+/// Fingerprints say *that* the bus moved. Naming the tuples says *which*
+/// obligation moved and where it went, which is what turns "the memory
+/// argument rejects this" into "this row double-spends `x3` at the first
+/// write's access clock".
+const MemoryTuples = struct {
+    /// `base_alu_imm` emits two access chains — `rs1` then `rd` — and each
+    /// contributes one consumed and one emitted tuple.
+    const CAPACITY: usize = 4;
+
+    consumed: [CAPACITY][7]QM31 = undefined,
+    n_consumed: usize = 0,
+    emitted: [CAPACITY][7]QM31 = undefined,
+    n_emitted: usize = 0,
+
+    /// The `rs1` chain is emitted before the `rd` chain, which the ordering
+    /// assertions in the first test below verify rather than assume.
+    fn sourceConsumed(self: *const MemoryTuples) [7]QM31 {
+        return self.consumed[0];
+    }
+
+    fn sourceEmitted(self: *const MemoryTuples) [7]QM31 {
+        return self.emitted[0];
+    }
+
+    fn destinationConsumed(self: *const MemoryTuples) [7]QM31 {
+        return self.consumed[1];
+    }
+
+    fn destinationEmitted(self: *const MemoryTuples) [7]QM31 {
+        return self.emitted[1];
+    }
+};
+
+/// Read the activated `memory_access` entries of `row` out of the AIR's own
+/// entry builder — the same call the interaction trace is generated from — and
+/// classify each by the sign of its numerator: `accessChain` consumes the
+/// predecessor with `-enabler` and emits the successor with `+enabler`.
+fn memoryTuples(row: *const committed.Row) !MemoryTuples {
+    const list = try opcode_entries.fromMain(harness.FAMILY, row.slice());
+    var result = MemoryTuples{};
+    for (list.entries[0..list.len]) |emitted| {
+        if (emitted.domain != .memory_access) continue;
+        if (emitted.numerator.isZero()) continue;
+        try std.testing.expectEqual(
+            entry_mod.expectedArity(.memory_access),
+            emitted.arity,
+        );
+        if (emitted.numerator.eql(QM31.one())) {
+            result.emitted[result.n_emitted] = emitted.values[0..7].*;
+            result.n_emitted += 1;
+            continue;
+        }
+        try std.testing.expect(emitted.numerator.eql(QM31.one().neg()));
+        result.consumed[result.n_consumed] = emitted.values[0..7].*;
+        result.n_consumed += 1;
+    }
+    try std.testing.expectEqual(MemoryTuples.CAPACITY / 2, result.n_consumed);
+    try std.testing.expectEqual(MemoryTuples.CAPACITY / 2, result.n_emitted);
+    return result;
+}
+
+/// A register access tuple as the bus sees it: address space 0, the register
+/// number, the access clock, then the four value limbs.
+fn registerTuple(register: u32, clock: u32, value: u32) [7]QM31 {
+    return .{
+        base(0),
+        base(register),
+        base(clock),
+        base(value & 0xff),
+        base((value >> 8) & 0xff),
+        base((value >> 16) & 0xff),
+        base(value >> 24),
+    };
+}
+
+fn base(value: u32) QM31 {
+    return QM31.fromBase(@import("stwo_core").fields.m31.M31.fromU64(value));
+}
+
+fn expectTuple(expected: [7]QM31, actual: [7]QM31) !void {
+    try std.testing.expectEqualSlices(QM31, &expected, &actual);
+}
+
+/// The fixture guest with the stale-read forgery applied to body row 2.
+fn staleReadAttempt(guest: *const committed.Guest, values: *const harness.RowValues) harness.Attempt {
+    return .{
+        .statement = guest.public.data,
+        .witness = harness.override(STALE_READER, values.slice()),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Row-local evidence
+// ---------------------------------------------------------------------------
+
+// Runtime: milliseconds. One nine-instruction run, no proof.
+test "malicious prover: the stale register read is row-locally admissible" {
+    var guest = try committed.Guest.init(std.testing.allocator, harness.SPEC);
+    defer guest.deinit();
+
+    const honest = try guest.honestRow(harness.FAMILY, STALE_READER);
+    try committed.expectAccepted(harness.FAMILY, honest.slice());
+
+    // The predecessor the forgery reaches back to is real: body row 0 wrote
+    // `x3 = 7` and body row 1 consumed it. A stale read of a value the run
+    // never produced would be a different, weaker attack.
+    const first_write = try guest.honestRow(harness.FAMILY, FIRST_WRITE);
+    try std.testing.expectEqual(
+        @as(u32, 7),
+        first_write.m31At(harness.RD_NEXT_0).toU32(),
+    );
+
+    var forged = honest;
+    const values = harness.staleRead();
+    forged.apply(values.slice());
+
+    // The forged row consumes the older version at the older clock, re-emits
+    // it unchanged (the read-only source binding), and carries the addition
+    // through coherently: 7 + 1 = 8 rather than 8 + 1 = 9.
+    try std.testing.expectEqual(@as(u32, 7), forged.m31At(harness.RS1_PREV_0).toU32());
+    try std.testing.expectEqual(
+        access_clock.encode(guest_elf.bodyClock(FIRST_WRITE), .second),
+        forged.m31At(harness.RS1_CLOCK_PREV).toU32(),
+    );
+    try std.testing.expectEqual(@as(u32, 7), forged.m31At(harness.RS1_NEXT_0).toU32());
+    try std.testing.expectEqual(@as(u32, 8), forged.m31At(harness.RD_NEXT_0).toU32());
+    try std.testing.expectEqual(@as(u32, 8), forged.m31At(harness.RESULT_0).toU32());
+
+    // The load-bearing assertion of the whole attack: every direct constraint
+    // of the family vanishes and every activated preprocessed request is in
+    // its table. No row-local check rejects this row, so whatever refuses it
+    // downstream can only be the global argument.
+    try committed.expectAccepted(harness.FAMILY, forged.slice());
+}
+
+// Runtime: milliseconds.
+test "malicious prover: the stale register read moves the memory-access bus and leaves the state and program buses untouched" {
+    var guest = try committed.Guest.init(std.testing.allocator, harness.SPEC);
+    defer guest.deinit();
+
+    const honest = try guest.honestRow(harness.FAMILY, STALE_READER);
+    var forged = honest;
+    const values = harness.staleRead();
+    forged.apply(values.slice());
+
+    // The register-state chain is `(pc, clk) -> (pc + 4, clk + 1)` and the
+    // program tuple is the fetched word: neither reads a register value, so a
+    // forgery of the access chain must leave both untouched. If either moved,
+    // the rejection below could be explained by a bus this attack is not about.
+    try harness.expectOnlyMemoryBusMoved(&honest, &forged);
+
+    const honest_tuples = try memoryTuples(&honest);
+    const forged_tuples = try memoryTuples(&forged);
+    const second_write = try guest.honestRow(harness.FAMILY, SECOND_WRITE);
+    const second_write_tuples = try memoryTuples(&second_write);
+
+    const first_write_clock = access_clock.encode(guest_elf.bodyClock(FIRST_WRITE), .second);
+    const second_write_clock = access_clock.encode(guest_elf.bodyClock(SECOND_WRITE), .second);
+    const read_clock = access_clock.encode(guest_elf.bodyClock(STALE_READER), .first);
+
+    // Emission order within the row: the `rs1` chain precedes the `rd` chain.
+    // Checked here so the accessors above name what they claim to name.
+    try expectTuple(
+        registerTuple(SOURCE_REG, second_write_clock, 8),
+        honest_tuples.sourceConsumed(),
+    );
+    try expectTuple(
+        registerTuple(SOURCE_REG, read_clock, 8),
+        honest_tuples.sourceEmitted(),
+    );
+
+    // The honest row links the chain: it consumes exactly what body row 1
+    // emitted.
+    try expectTuple(second_write_tuples.destinationEmitted(), honest_tuples.sourceConsumed());
+
+    // The forgery double-spends instead: it consumes exactly the tuple body
+    // row 1 already consumed, at the same address and the same access clock.
+    // That tuple is now taken twice and emitted once, and body row 1's own
+    // emission is orphaned — the two halves of the non-cancellation.
+    try expectTuple(
+        registerTuple(SOURCE_REG, first_write_clock, 7),
+        forged_tuples.sourceConsumed(),
+    );
+    try expectTuple(second_write_tuples.sourceConsumed(), forged_tuples.sourceConsumed());
+    try expectTuple(
+        registerTuple(SOURCE_REG, read_clock, 7),
+        forged_tuples.sourceEmitted(),
+    );
+
+    // The destination access keeps its predecessor and moves only the written
+    // word, so the forgery is a coherent re-derivation and not a second,
+    // independent disturbance of the same bus.
+    try expectTuple(honest_tuples.destinationConsumed(), forged_tuples.destinationConsumed());
+    try std.testing.expect(!std.mem.eql(
+        u8,
+        std.mem.sliceAsBytes(&honest_tuples.destinationEmitted()),
+        std.mem.sliceAsBytes(&forged_tuples.destinationEmitted()),
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// The production transaction
+// ---------------------------------------------------------------------------
+
+// Runtime: about 12 s. One complete proof of the forged witness plus the
+// verification that must refuse it.
+test "malicious prover: the stale register read proves and loses global closure at verification" {
+    var guest = try committed.Guest.init(std.testing.allocator, harness.SPEC);
+    defer guest.deinit();
+
+    // Installed before lookup ingestion, so the whole transaction — main
+    // trace, multiplicities, interaction trace, challenges — derives from the
+    // forged witness. Rejected at the last possible stage, by the verifier's
+    // global LogUp cancellation, because nothing earlier can see a row this
+    // self-consistent.
+    const values = harness.staleRead();
+    try harness.expectRejected(
+        &guest,
+        staleReadAttempt(&guest, &values),
+        .verification,
+        error.LogupSumNonZero,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Which relation domain fails to close
+// ---------------------------------------------------------------------------
+
+/// Per-domain closure of one production run: the committed sum of every
+/// component against the public boundary of the same relation.
+const DomainClosure = struct {
+    totals: [entry_mod.DOMAIN_COUNT]QM31,
+
+    fn of(diagnostic: *const prover_mod.RelationDiagnostic) DomainClosure {
+        var result = DomainClosure{ .totals = undefined };
+        for (0..entry_mod.DOMAIN_COUNT) |index| {
+            result.totals[index] = diagnostic.bundle.aggregate.domain_sums[index]
+                .add(diagnostic.bundle.public.domains[index]);
+        }
+        return result;
+    }
+};
+
+/// Re-run the same production transaction in `.relation_diagnostic` mode.
+///
+/// Identical up to Tree 2 — same witness, same mutation hook, same ingestion —
+/// and it stops before proof assembly, exposing the per-component and
+/// per-domain relation sums the proof reduces to a single scalar. The
+/// challenges come from a fresh channel by design (see
+/// `prover/interaction_trace.zig`), which is what makes the sums comparable
+/// across runs; this is an attribution instrument, and the rejection itself is
+/// pinned on the real `.prove` path above.
+fn diagnose(
+    guest: *const committed.Guest,
+    mutation: ?committed.Mutation,
+) !prover_mod.RelationDiagnostic {
+    var channel = riscv_cpu.CpuProverEngine.Channel{};
+    return orchestration.runRiscVWithEngineAndPublicDataUsingChannel(
+        riscv_cpu.CpuProverEngine,
+        .relation_diagnostic,
+        guest.allocator,
+        committed.PCS_CONFIG,
+        &guest.run.execution_trace,
+        &guest.run.state_chain_tracker,
+        &guest.run.rw_memory,
+        null,
+        guest.public.data,
+        &channel,
+        mutation,
+        null,
+    );
+}
+
+// Runtime: about 25 s. Two diagnostic runs of the fixture guest, each stopping
+// before proof assembly.
+test "malicious prover: only the memory-access relation fails to close over the stale read" {
+    var guest = try committed.Guest.init(std.testing.allocator, harness.SPEC);
+    defer guest.deinit();
+
+    // The instrument's own baseline. Without it, "only `memory_access` fails"
+    // would also be satisfied by an instrument that reports a non-zero
+    // `memory_access` sum on every run.
+    const honest = try diagnose(&guest, null);
+    try honest.bundle.validate();
+    const honest_closure = DomainClosure.of(&honest);
+    for (honest_closure.totals) |total| try std.testing.expect(total.isZero());
+
+    const values = harness.staleRead();
+    const forged = try diagnose(&guest, harness.override(STALE_READER, values.slice()));
+    const forged_closure = DomainClosure.of(&forged);
+    for (forged_closure.totals, 0..) |total, index| {
+        const domain: entry_mod.Domain = @enumFromInt(index);
+        if (domain == .memory_access) {
+            try std.testing.expect(!total.isZero());
+            continue;
+        }
+        if (!total.isZero()) {
+            std.debug.print(
+                "stale read disturbed the {s} relation as well\n",
+                .{@tagName(domain)},
+            );
+            return error.TestUnexpectedResult;
+        }
+    }
+
+    // The bundle's own consistency check reaches the same verdict by its own
+    // route: every component claim still matches its recomputation from the
+    // committed tuples — the forged witness is internally consistent — and the
+    // first thing that does not hold is one relation domain's balance.
+    try std.testing.expectError(
+        error.UnbalancedRelationDomain,
+        forged.bundle.validate(),
+    );
+}

--- a/src/tests/riscv/trace_test.zig
+++ b/src/tests/riscv/trace_test.zig
@@ -29,6 +29,13 @@ test {
         _ = @import("load_sign_soundness_test.zig");
         _ = @import("malicious_witness_test.zig");
         _ = @import("main_witness_rejection_test.zig");
+        // The production-path malicious-prover suite: the shared transaction
+        // harness and its four attack classes (issue #131).
+        _ = @import("malicious_prover_harness.zig");
+        _ = @import("malicious_prover_completion_test.zig");
+        _ = @import("malicious_prover_forged_output_test.zig");
+        _ = @import("malicious_prover_skipped_test.zig");
+        _ = @import("malicious_prover_stale_read_test.zig");
         _ = @import("mulh_soundness_test.zig");
         _ = @import("opcode_family_committed_soundness_test.zig");
         _ = @import("partial_store_soundness_test.zig");

--- a/src/tests/riscv/unit_test.zig
+++ b/src/tests/riscv/unit_test.zig
@@ -27,6 +27,36 @@ test {
     _ = @import("stwo_riscv_frontend").diagnostics.public_values;
 }
 
+test "sail_oracle: absence skips by default, fails under the gate switch, and never reads as disagreement" {
+    // Lives here rather than beside the code because `zig test` only collects
+    // tests from its root module, and every step reaches `sail_oracle.zig` as
+    // an imported dependency.
+    //
+    // Nothing here consults Sail: this is the enforcement flag's policy alone,
+    // which is the part a host without the pinned oracle can still prove.
+    const sail_oracle = runner.sail_oracle;
+    const Policy = sail_oracle.AbsencePolicy;
+
+    try std.testing.expectEqual(Policy.skip, Policy.fromEnvValue(null));
+    for ([_][]const u8{ "", "   ", "0", "false", "FALSE", "no", "Off", " off " }) |unset| {
+        try std.testing.expectEqual(Policy.skip, Policy.fromEnvValue(unset));
+    }
+    // Anything unrecognised requires the oracle: a gate switch must not be
+    // disarmed by a typo in the value a CI job passed it.
+    for ([_][]const u8{ "1", "true", "YES", "on", " 1 ", "ture" }) |set| {
+        try std.testing.expectEqual(Policy.fail, Policy.fromEnvValue(set));
+    }
+
+    // The distinct-error property the module header promises: enforcement
+    // reports the ABSENCE, and never borrows the disagreement error.
+    const Unavailable = sail_oracle.UnavailableError;
+    try std.testing.expectEqual(Unavailable.SkipZigTest, Policy.skip.err());
+    try std.testing.expectEqual(Unavailable.SailOracleUnavailable, Policy.fail.err());
+    const required: anyerror = Policy.fail.err();
+    try std.testing.expect(required != error.SkipZigTest);
+    try std.testing.expect(required != error.SailDisagreesWithRunner);
+}
+
 test "infra_trace: genMemoryColumns caps rows at the domain size" {
     const allocator = std.testing.allocator;
     var chain = StateChainTracker.init(allocator);


### PR DESCRIPTION
## Summary

Closes the open soundness item in `soundness/ROADMAP.md` for [#131](https://github.com/teddyjfpender/stwo-zig/issues/131): a deliberately malicious prover harness that enters the **real** proving transaction before commitment and proves rejection of four attack classes.

Stacked on `feat/architecture-hardening` (#132) so it can be reviewed and merged independently of that branch's package-boundary and CSP-benchmark work.

Nothing here is a post-hoc mutation of an honest proof. Witness forgeries are installed **before lookup ingestion**, so Tree 1, the lookup multiplicities and Tree 2 all derive from the same forged witness. Statement forgeries are the prover's **original** public statement, mixed into the transcript before any Fiat-Shamir challenge is drawn.

| attack | stage | error |
| --- | --- | --- |
| skipped instruction | `precommit_ingestion` | `InactiveRealRow` |
| stale register read | `verification` | `LogupSumNonZero` |
| forged public output | `verification` | `LogupSumNonZero` |
| altered completion | `admission` | `InvalidStatement` |

`attempt` classifies exactly four errors and lets every other one escape, so a broken fixture fails the test instead of masquerading as a rejection. `expectRejected` pins both the stage and the exact error.

**Stale read** is the load-bearing case, on the three-ADDI fixture from the issue's spike handoff (`x3 := 7; x3 := x3 + 1; x6 := x3 + 1`): the third row is rewritten to consume the older real `x3 = 7` at its first-write access clock with `x6 = 8` coherently recomputed. The row stays row-locally admissible, reaches a complete proof, and dies at verification — with `memory_access` pinned as the **only one of twelve relation domains** that fails to close.

**Altered completion** establishes "before transcript mixing" positively: at the point of rejection the channel is pristine with `n_draws == 0`, checked against a reference channel proven to move.

## Runner: `-Driscv-test-filter`

The exhaustive RISC-V gate is tens of minutes of end-to-end proving, and in its default `-Doptimize=Debug` the sample is dominated by Blake2s Merkle commitment. Focusing it previously meant hand-editing the `TestRoot` literals in `build_support/products/riscv_cpu.zig` — which is how a temporary `.filters = &.{"malicious prover"}` once reached `addExhaustiveTests` and silently reduced the whole adversarial gate to a handful of tests while still reporting green.

This adds a command-line filter, mirroring the existing `-Dcairo-test-filter` (including its forwarding through `graph/delegation.zig`, which builds the inner argv explicitly):

```sh
zig build test-riscv-release-exhaustive \
    -Driscv-test-filter="malicious prover" -Doptimize=ReleaseSafe
```

Measured on this branch: **31–68 s** filtered vs **~75 min** for the full Debug gate.

The flag **replaces** a step's pinned filters rather than adding to them — `filters` is an OR, so appending would broaden a scoped step instead of narrowing it. A step run under the flag is whatever the caller asked for, not its advertised scope: fine for iteration, never for a gate.

One hazard found while validating the flag and documented at the top of `riscv_test_filter.zig` rather than left as a trap: **a filter that matches nothing exits 0.** The runner reports success for an empty selection, so a typo is indistinguishable from a passing suite (verified with `-Driscv-test-filter=zzz-no-such-test`). Read the runtime, not just the exit code. That is the same silent-green shape the flag exists to prevent, moved rather than removed; enforcing a non-empty selection would need a run wrapper that counts executed tests.

The helper lives in its own `build_support/products/riscv_test_filter.zig` because `riscv_cpu.zig` was 496 lines against build-support's 500-line owner ceiling.

## Two things stated rather than smoothed over

**Acceptance criterion 1 needs a wording ruling.** It says the padded row is "rejected by the active-row placement constraint". That is exact **row-locally** — `expectOnlyConstraint` pins placement as the unique failing direct constraint — but **no end-to-end test would fail if that constraint were deleted**, because production refuses earlier at `source_ingest.zig:256`. We chose the issue's option (a) and did not relabel the criterion quietly. Proposed amendment:

> An active opcode row replaced by padding is rejected — row-locally by the active-row placement constraint as the unique failing direct constraint, and end-to-end at lookup-source ingestion with `error.InactiveRealRow`, which is strictly earlier.

Option (b) — a structurally shortened trace — was investigated and is **unreachable, structurally rather than budgetarily**: `is_active` and the committed `active()` are two readings of one row list (`runner/trace.zig:88-96`, `opcode_trace.zig:220-225`, `statement_geometry.describeOpcodeShards`), so omitting an instruction shortens the declared geometry instead of leaving a hole in it and the difference vanishes by construction. We built the shortened trace anyway: it dies at `InvalidRegisterAccessChain`, i.e. a genuine skip is an access-chain violation belonging to a different criterion. That result ships as a cheap row-local assertion with the honest rows as control.

**Criterion 6 (Sail agreement) was not exercised here.** The honest leg calls `Guest.proveAndVerify`, but the pinned Sail oracle is absent on our hosts so that leg skips. It rides on the pre-existing Sail infrastructure; it should be run once on a host with the oracle.

## Review follow-ups accepted, not fixed here

- The production transcript prefix is constructed in two places (drift risk if `proveStages` gains an opening event); it wants to be one shared helper.
- The completion file's argument would be stronger for noting that the halt tuple is also verifier-bound via `public_logup.memoryAccessSum`, making admission defence in depth rather than the whole story.

## Validation

- **`zig build test-riscv-release-exhaustive` green in both configurations**: the default `-Doptimize=Debug` (the CI reference, ~75 min) and `-Doptimize=ReleaseSafe` (~13 min, full suite including the access-determinacy sweep at 550,672 admissibility evaluations).
- Adversarial review of the four files together — vacuity walk ("if the AIR check this targets were deleted, would this test still fail?"), non-post-hoc audit, and an acceptance-criteria table.
- The pins are load-bearing, not decorative: deliberately flipping the skipped-instruction expectation to `prover_constraints`/`ConstraintsNotSatisfied` makes the suite fail with the mismatch printed.
- `zig fmt --check` and `python3 scripts/check_source_conformance.py` green.
- Pre-existing and untouched by this branch: `scripts/tests/test_cairo_claim_registry` fails in `setUpClass` on a pinned `stwo-cairo` revision mismatch (expects `82f21252`, working copy is at `fca831a4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update: the three flagged items are now closed

**1. Criterion 1 wording — amended in #131.** It now states both legs (row-locally the placement constraint is the unique failing direct constraint; end-to-end refused at ingestion with `InactiveRealRow`, strictly earlier), with a dated note recording why the original was structurally unreachable. Criterion 1 moves from *partial* to *satisfied as written*.

**2. `-Driscv-test-filter` matching nothing now fails the build.** The premise everyone starts with is wrong and worth stating: the compiler drops only *named* tests, so an unmatched filter still leaves the anonymous `test { _ = @import(...) }` aggregation blocks — the binary is never empty and a test count never reaches zero. A first implementation keyed on `test_count == 0` was silently a no-op. `EmptySelectionGuard` instead applies the compiler's own substring rule to the executed test names. Attached only when the flag is supplied, so unfiltered gates keep their steps, caching and runtime; filtered runs are side-effecting because a cache hit leaves the name table unpopulated and would fail a *correct* filter on its second run; absent metadata fails closed.

**3. Sail absence can now be refused, without redefining it.** The oracle module's contract is deliberate — `unavailable` stays a visible skip, because conflating absence with disagreement "is how a dead oracle starts to read as coverage". So enforcement is opt-in at the gate layer: `STWO_ZIG_REQUIRE_SAIL_ORACLE` turns an unavailable verdict into `error.SailOracleUnavailable`, distinct from the disagreement error. Unrecognised values enforce rather than silently disarm. All three `.unavailable` sites are covered, including one in `committed_forgery_harness.zig` that would otherwise have stayed silent.

### Verified locally

| behaviour | result |
| --- | --- |
| full unfiltered exhaustive gate (ReleaseSafe) | **green** |
| no-match filter | exits 1, `matched no test name` (was 0) |
| `"malicious prover"` filter | passes; Sail leg skips visibly |
| `STWO_ZIG_REQUIRE_SAIL_ORACLE=1` | fails, `SailOracleUnavailable, NOT a disagreement` |
| garbled value (`ture`) | fails **closed** |
| explicit `0` | still skips |

### Two things for the maintainer

- **Before this change, no job in this repo could prove the Sail criterion.** The only job with a provisioned oracle ran zero Zig tests; the only job running the suite had no oracle (`test-riscv-release-exhaustive` reaches CI via a compat alias into `release-gate`, which provisions no Sail, and the job naming "exhaustive" is hard-disabled with `if: ${{ false }}`). The requirement is now wired into the `differential` job — the only one with a verified oracle — so criterion 6 is provable there, on scope-match and nightly rather than on every PR. That job's 60-minute budget now also carries a cold ReleaseSafe Zig build; fallbacks are recorded in `conformance/riscv-sail-differential-gate.md`.
- **Pre-existing defect, recorded not fixed:** the two tests *inside* `sail_oracle.zig` execute in no build step at all — confirmed absent from every compiled binary's test-name table. That is the module's own doctrine turned on itself, and worse than a skip, since a skip at least prints. Making them live means adding two `python3`-spawning tests to a PR-blocking lane, which is a maintainer call. They carry a `WARNING`, and the new policy test was placed where it was verified by deliberate breakage to actually run.
