### PR TITLE
Metal residency 3.15: stored-domain eval arena (measured at parity; Option A stays default)

### DIFF
--- a/autoresearch/notes/2026-07-28-cairo-metal-residency-program/transcripts/session-16.md
+++ b/autoresearch/notes/2026-07-28-cairo-metal-residency-program/transcripts/session-16.md
@@ -1,0 +1,221 @@
+# Session 16 — increment 3.15, Library-2 consumption
+
+Implementation: Claude Opus 4.5. Orchestration: Claude Fable 5.
+Branch `autoresearch/metal-residency-l2`, head at start `f51e6bb9`.
+Raw data: `/private/tmp/i315/`.
+
+Reasoning first, then the raw numbers. The short version: the thing the
+increment was built to remove does not exist, and finding that out cost most of
+the budget's value and none of its correctness.
+
+---
+
+## 1. What I expected to be doing
+
+3.13 §8 ranked Library-2 consumption second and called it "highest value-per-risk
+of anything remaining", projecting stages of 170.99 / 439.53 / 110.96 ms —
+2.295x / 2.873x / 3.168x — on the strength of two things: 3.7 §3's statement that
+the product publishes columns at `2^trace_log` (so the arena must lift each one to
+`2^eval_log`), and 3.10 §3's measurement that stored-domain kernels are
+1.22-2.26x faster than eval-domain kernels reading the lifted copy.
+
+Both are load-bearing and only one of them is about the product.
+
+## 2. The build
+
+Straightforward, and the design decisions are in the note. Two are worth
+restating here because they are where I deviated from the brief and where I
+nearly introduced a bug.
+
+**I could not place columns at a fixed trace-domain stride.** The brief says
+"place trace-domain columns at planned offsets WITHOUT lifting", which reads as a
+stride of `2^trace_log`. A column's required extent is its own length, and
+column lengths are not uniform in principle — a preprocessed column may be
+committed at a different log size than the component's trace — and are not known
+at plan time, because `open` has no trace resolver and `resolve` runs per
+evaluation. A fixed trace-domain stride is therefore an out-of-bounds read
+waiting for the first component that reads a longer preprocessed column, and it
+would have been a *silent* one: the kernel would have read a neighbouring
+column's words and the proof would still have completed, just wrong.
+
+So the plan reserves `columns * 2^eval_log` as a capacity and `store` packs
+consecutively, publishing real offsets through `trace_offsets` — a block that was
+already rewritten on every evaluation in Option A, so runtime placement is free.
+The serial prefix pass checks `(eval_rows >> shift) << 1 == values.len`, which is
+exactly the statement that the largest index the reader can form lands inside the
+column. That check is the whole safety argument and it is one line.
+
+**The brief's admission rule cannot fire.** "Stored-domain mode engages when
+Library 2 authenticates AND every eligible component's sd-kernel resolves." Both
+libraries are minted from the same three program bundles, so both are missing the
+same rebound-constant straggler on arithmetic-2m and memory-7m (3.8 §1). Under
+the literal rule tier 1 would demote on two of three gate rows and the increment
+would be unmeasurable. I implemented the rule Option A already uses — unresolved
+component becomes declared host coverage, tier engages on at least one acceptance
+— and moved coverage equality from an asserted property to a verified one. §4 of
+the note verifies it: identical census on all seven workloads.
+
+## 3. The moment it went sideways
+
+First armed spot proof, all-opcodes, stored-domain: byte-exact
+`79ae76e1ac0c48b1`, 46/46 accepted, 121 dispatches, `cpu_fallbacks = 0`. That is
+the result I wanted and it arrived on the first try.
+
+Then the close log:
+
+```
+device composition (stored): stage 32.723 ms over 723 MiB (23.18 GB/s),
+  46 dispatches in 46 submissions, device 38.080 ms
+```
+
+723 MiB. Option A's all-opcodes lift volume is 723 MiB. If Option B were removing
+a 2x duplication this number had to be ~361.
+
+I ran the other arm off the same binary to be sure I was not comparing against a
+remembered figure:
+
+```
+device composition (lifted): stage 33.674 ms over 723 MiB (22.52 GB/s),
+  46 dispatches in 46 submissions, device 30.292 ms
+```
+
+Identical. Two readings were available: my stored accounting was wrong, or the
+columns were already eval-domain length. Rather than reason about it I made the
+product report the quantity directly — `store` now returns a `Volume` carrying
+staged bytes, the bytes Option A would have written, and the observed shift
+range, and the stage folds and logs it. One rebuild:
+
+```
+stored: eval-domain equivalent 723 MiB, shifts 1-1
+lifted: eval-domain equivalent 723 MiB, shifts 0-0
+```
+
+`shifts 1-1`. Every column, shift 1. `shift = eval_log - column_log + 1`, so
+`column_log == eval_log`: the committed columns are already at evaluation-domain
+length, `((p >> 1) << 1) + (p & 1) == p`, and the lift was already the identity.
+Confirmed on arithmetic-2m and memory-7m immediately after (`shifts 1-1`, same
+staged-equals-equivalent volumes at 1,482 and 4,317 MiB).
+
+The cause is one line: `pcs/tree_builders.zig:169` — "Each entry stores the
+*extended* column values and their log_size" — and `scheme_views.polynomials`
+hands those columns straight to the composition path. 3.7 §3 asserted the
+opposite, the arena's own module comment repeated it, 3.13 §6 priced it, and
+3.10's projection rested on it.
+
+**Why four increments of byte-exact verification did not catch it.** Every test
+that has ever exercised this ABI — 3.5's binding smoke, 3.6's fusion census,
+3.7's lift bridge, 3.10's Option-B anchors and price test — builds its **own**
+column store at trace-domain length and compares device against host over it.
+That is a coherent closed world and every result in it stands, including 3.10's
+1.22-2.26x. None of them ever asked what log size the *product* commits at. It is
+the same class of gap as 3.8 §1's "the metallib is compiled from the wrong
+bundle": a fixture that is self-consistent and unlike the product.
+
+## 4. The measurement, which I ran anyway
+
+Not because the answer was in doubt but because "parity" is a claim and needs the
+same evidence a win would. A-B-B-A, 3 blocks, 6 samples per arm, warmup per arm
+per workload, caches off both arms, same binaries, env-only pairing, loadavg
+1.21-3.92.
+
+Composition stage, stored over Option A: **1.0044x [0.9909, 1.0179]**,
+**0.9945x [0.9650, 1.0249]**, **1.0028x [0.9937, 1.0121]**. Three intervals, all
+containing 1.
+
+The decomposition is the part I would keep if I could keep one table. Staging
+1.0404x / 1.0294x / 1.0334x, intervals excluding 1 — a `@memcpy` beats the
+pair-duplication loop over identical volume. Device GPU 0.9919x / 0.9797x /
+0.9881x — the stored reader pays one load through the shift table and computes
+the identity with it. +1.0/+4.4/+1.1 ms and −0.4/−3.1/−0.4 ms. The stage is the
+sum and the sum is zero.
+
+That is 3.10's result, correctly transported: its stored kernels were fast
+because they read half the bytes, and on the product they read all of them.
+
+## 5. Disposition
+
+Default back to Option A, tier opt-in, one test pinning the default so a future
+flip has to touch the line where the reason is written. Everything stays: the
+mode is correct, general, byte-exact, and is what a column set committed at
+trace-domain length would need. Nothing about it is worth defaulting to at zero
+gain.
+
+## 6. Raw numbers
+
+### Gate, `/private/tmp/i315/gate.json` (36 timed samples)
+
+```
+composition stage (ms, mean of 6)
+  arithmetic-2m   Option-A 245.43   stored 244.37
+  memory-7m       Option-A 573.34   stored 576.48
+  all-opcodes     Option-A 128.15   stored 127.79
+
+prove (ms, mean of 6)
+  arithmetic-2m   Option-A 1542.87  stored 1538.36
+  memory-7m       Option-A 3692.45  stored 3692.25
+  all-opcodes     Option-A 1014.36  stored 1015.73
+
+staging pass (ms, mean of 6)
+  arithmetic-2m   Option-A 71.84    stored 69.07
+  memory-7m       Option-A 151.03   stored 146.67
+  all-opcodes     Option-A 32.65    stored 31.60
+
+device GPU (ms, mean of 6)
+  arithmetic-2m   Option-A 64.65    stored 65.18
+  memory-7m       Option-A 152.97   stored 156.10
+  all-opcodes     Option-A 29.56    stored 29.92
+
+admission (ms, range)
+  arithmetic-2m   Option-A 11.05-11.80   stored 10.76-11.37
+  memory-7m       Option-A 11.75-13.06   stored 11.43-12.79
+  all-opcodes     Option-A 12.56-12.73   stored 12.15-12.35
+
+digests, all 36 samples, singleton per workload per arm
+  arithmetic-2m 25e5719f4c578eb7   dispatches 102   fallbacks 0
+  memory-7m     e3317e55a5db5a42   dispatches 110   fallbacks 0
+  all-opcodes   79ae76e1ac0c48b1   dispatches 121   fallbacks 0
+
+staged / eval-domain-equivalent MiB, identical on both arms
+  arithmetic-2m 1482 / 1482      memory-7m 4317 / 4317     all-opcodes 723 / 723
+observed shift range
+  stored arm 1-1 on every sample of every workload
+```
+
+Library 2 cold pipeline cliff, first armed proof: `composition_device_admission`
+**141,307 ms** (prove 142,571 ms). Warm thereafter at 10.8-13.1 ms. Library 1's
+equivalent was 181,740 ms in 3.13 §3. Both libraries pay it once per host.
+poseidon-aggregator's first stored-domain proof paid a second cliff of the same
+kind at 73,142 ms, for the component set only that workload requests.
+
+### Seven-workload checklist, `/private/tmp/i315/verify.json`
+
+See note §4. Every digest equal to the campaign value on all three arms, all 21
+proofs `--verify` accepted by the Zig verifier, census identical between the two
+Metal tiers on every workload.
+
+### Fail-back, `/private/tmp/i315/f/`
+
+See note §5.
+
+## 7. What I would tell the next session
+
+Do 3.13's item 1. Instrument the composition residual before building anything
+else against that decomposition. This increment is the second lever in a row that
+was ranked and scheduled off `stage = lift + kernels + residual` where two of
+those three terms had never been checked against the product — 3.7's projection
+failed because the residual was assumed zero, and this one failed because the
+lift was assumed to be a duplication. The residual is 81.5-289.7 ms, it is the
+largest term on every workload, and nobody knows what is in it.
+
+Second: the staging copy is still 32.6-151.0 ms and is now the only term with a
+known mechanism. The columns are already the right length and already committed;
+the arena copies them because it owns its allocation. Aliasing rather than
+copying is the shape of the answer, and the campaign already aliases elsewhere
+(`commit_source_arena_aliases` is non-zero on every Metal proof here). It is
+harder than it sounds — it needs per-column contiguity and residency in
+`pcs/tree_builders.zig`, not in the composition stage — so scope it before
+promising it.
+
+Third, and cheapest: the `Volume` diagnostic exists now. Any future claim about
+what the product commits, at what length, can be read off a proof's stderr
+instead of inferred from a test fixture. Use it before pricing the next lever.

--- a/src/integrations/cairo_metal/composition_eval_arena.zig
+++ b/src/integrations/cairo_metal/composition_eval_arena.zig
@@ -42,10 +42,65 @@
 //! Every accepted component reuses the *same* buffer, sized to the largest
 //! plan, so the stage costs one resident allocation per proof rather than one
 //! per component.
+//!
+//! ## The stored-domain mode (increment 3.15, Option B)
+//!
+//! `Mode.stored` is the same arena with the lift deleted. Library 2's kernels
+//! (`stwo_zig_eval_sd_<hash>`) apply `((row >> shift) << 1) + (row & 1)`
+//! themselves, reading the column at the length the product already published
+//! it at, so staging becomes a `@memcpy` of exactly the committed words instead
+//! of a `2^eval_log`-word duplication. Two things change in the layout and
+//! nothing else does.
+//!
+//! 1. **A shift table.** One word per *global* column, holding the column's own
+//!    `ResolvedColumn.shift_amt`, placed at `args.base_params + n_base_params`
+//!    per `eval_abi.TraceAbi.shiftTableOffset`. `expressible` already refuses any
+//!    component with `n_base_params != 0`, so the table starts exactly at
+//!    `base_params` for every component this arena can plan — but the *offset*
+//!    is computed from the contract rather than assumed, so a future
+//!    parameterized program needs no change here.
+//! 2. **Columns are packed, not strided.** A column's required extent is exactly
+//!    its own length: with `shift = eval_log - column_log + 1`, the largest index
+//!    the reader can form is `((eval_rows - 1) >> shift) << 1 | 1`, i.e.
+//!    `2^column_log - 1`. Column lengths are therefore *not* uniform in general
+//!    (a preprocessed column may be committed at a different log size than the
+//!    component's trace), and they are not known until `resolve` runs — so the
+//!    plan reserves the only capacity that is always sufficient,
+//!    `columns * 2^eval_log`, and `store` packs the actual columns consecutively
+//!    into it, publishing the real offsets through `trace_offsets`. That block is
+//!    written per evaluation in both modes, so runtime placement costs nothing
+//!    and removes the one shape a fixed stride could not express.
+//!
+//! Reserving the eval-domain capacity means the *allocation* does not shrink.
+//! The **resident** footprint does, and that is the quantity that was costing
+//! 0.76-4.80 GB per proof: the column region is placed last in stored mode, so
+//! the pages past the packed prefix are never touched and are never faulted in.
 
 const std = @import("std");
 const composition = @import("stwo_cairo_frontend").witness.composition_bundle;
+const eval_program = @import("stwo_cairo_frontend").witness.eval_program;
 const WorkPool = @import("stwo_prover_impl").work_pool.WorkPool;
+const eval_abi = @import("eval_abi.zig");
+
+/// Which trace ABI the planned arena feeds. `lifted` is increment 3.8's
+/// Option-A layout, byte-for-byte unchanged; `stored` is Option B.
+pub const Mode = enum {
+    lifted,
+    stored,
+
+    pub fn abi(self: Mode) eval_abi.TraceAbi {
+        return switch (self) {
+            .lifted => .eval_domain,
+            .stored => .stored_domain,
+        };
+    }
+};
+
+/// Words reserved for a census slot no instruction ever reads. The reader can
+/// still *form* an index into it if a kernel were ever emitted that touched it,
+/// so the slot is given a real pair and a shift that pins the index to `{0,1}`
+/// rather than an offset that would address outside the region.
+const null_column_words: u32 = 2;
 
 pub const Error = error{
     InvalidCompositionComponent,
@@ -63,14 +118,25 @@ pub const byte_cap_env = "STWO_ZIG_COMPOSITION_EVAL_ARENA_BYTES";
 
 /// One component's resolved geometry and its offsets inside the shared arena.
 pub const Plan = struct {
+    mode: Mode,
     columns: u32,
     interactions: u32,
     eval_rows: u32,
+    eval_log_size: u32,
     trace_log_size: u32,
     denominator_count: u32,
     ext_param_count: u32,
     coefficient_count: u32,
     column_base: u32,
+    /// Words reserved for the whole column region. In `lifted` mode this is
+    /// exactly `columns * eval_rows` and every column occupies a fixed stride;
+    /// in `stored` mode it is the same bound used as a capacity, and the columns
+    /// packed inside it are shorter.
+    column_capacity: u64,
+    /// Offset of the runtime base-parameter block. Zero in `lifted` mode, where
+    /// no program in this bundle declares a base parameter and nothing reads it;
+    /// in `stored` mode it is the block whose tail is the per-column shift table.
+    base_params: u32,
     trace_offsets: u32,
     interaction_offsets: u32,
     ext_params: u32,
@@ -88,8 +154,17 @@ pub const Plan = struct {
         self.* = undefined;
     }
 
+    /// The fixed stride placement, valid in `lifted` mode only. Stored-domain
+    /// offsets are packed at staging time and published through `trace_offsets`.
     pub fn columnOffset(self: Plan, global: u32) u32 {
         return self.column_base + global * self.eval_rows;
+    }
+
+    /// Where this plan's shift table begins, given a part's own parameter count.
+    /// Routed through the ABI contract rather than open-coded so the two sides
+    /// of the layout cannot drift.
+    pub fn shiftTable(self: Plan, program: eval_program.Program) u32 {
+        return self.mode.abi().shiftTableOffset(self.base_params, program);
     }
 };
 
@@ -137,7 +212,17 @@ pub fn expressible(component: composition.Component) bool {
     return true;
 }
 
+/// The Option-A planner. Retained as the name every existing caller and test
+/// uses, and byte-for-byte the layout increment 3.8 shipped.
 pub fn plan(allocator: std.mem.Allocator, component: composition.Component) !Plan {
+    return planFor(allocator, component, .lifted);
+}
+
+pub fn planFor(
+    allocator: std.mem.Allocator,
+    component: composition.Component,
+    mode: Mode,
+) !Plan {
     if (!expressible(component)) return Error.InvalidCompositionComponent;
     const eval_log = component.evaluation_log_size;
     const trace_log = component.trace_log_size;
@@ -172,13 +257,31 @@ pub fn plan(allocator: std.mem.Allocator, component: composition.Component) !Pla
         return Error.InvalidCompositionComponent;
     coefficient_count = component.n_constraints;
 
+    // `columns * eval_rows` is the column region in both modes: a fixed stride
+    // in `lifted`, a sufficient capacity in `stored` (a column's extent is its
+    // own length, and no legal column exceeds `eval_rows`).
+    const column_capacity: u64 = @as(u64, columns) * eval_rows;
+
     var next: u64 = 0;
-    const column_base = next;
-    next += @as(u64, columns) * eval_rows;
+    // In `stored` mode the column region goes *last*, so every block the stage
+    // writes on every evaluation sits in the low pages and the untouched tail of
+    // the capacity is never faulted in. In `lifted` mode it stays first, because
+    // that layout is what increment 3.8 measured and 3.13 gated.
+    var column_base: u64 = 0;
+    if (mode == .lifted) {
+        column_base = next;
+        next += column_capacity;
+    }
     const trace_offsets = next;
     next += columns;
     const interaction_offsets = next;
     next += bases.len;
+    // The base-parameter block. Empty in `lifted` mode — no eligible program
+    // declares a base parameter and no eval-domain kernel reads the block — and
+    // in `stored` mode it is `n_base_params` (zero, enforced by `expressible`)
+    // program words followed by one shift word per global column.
+    const base_params = next;
+    if (mode == .stored) next += columns;
     const ext_params = next;
     next += 4 * @as(u64, ext_param_count);
     const random_coeffs = next;
@@ -190,19 +293,27 @@ pub fn plan(allocator: std.mem.Allocator, component: composition.Component) !Pla
         offset.* = next;
         next += eval_rows;
     }
+    if (mode == .stored) {
+        column_base = next;
+        next += column_capacity;
+    }
     // Every offset is a `u32` word index in the ABI, so a plan that cannot be
     // addressed is a planning refusal rather than a truncation.
     if (next > std.math.maxInt(u32)) return Error.EvalArenaTooLarge;
 
     return .{
+        .mode = mode,
         .columns = columns,
         .interactions = @intCast(bases.len),
         .eval_rows = eval_rows,
+        .eval_log_size = eval_log,
         .trace_log_size = trace_log,
         .denominator_count = denominator_count,
         .ext_param_count = ext_param_count,
         .coefficient_count = coefficient_count,
         .column_base = @intCast(column_base),
+        .column_capacity = column_capacity,
+        .base_params = @intCast(base_params),
         .trace_offsets = @intCast(trace_offsets),
         .interaction_offsets = @intCast(interaction_offsets),
         .ext_params = @intCast(ext_params),
@@ -344,6 +455,121 @@ pub fn lift(
     for (workers) |worker| if (worker.err) |err| return err;
 }
 
+const StoreWorker = struct {
+    words: []u32,
+    plan: *const Plan,
+    resolved: []const ResolvedScratch,
+    stride: usize,
+    start: usize,
+
+    fn run(self: *StoreWorker) void {
+        var column = self.start;
+        while (column < self.resolved.len) : (column += self.stride) {
+            // The offset was published into `trace_offsets` by the serial pass,
+            // so the workers share nothing and need no offsets array of their
+            // own — they read the same block the kernel will read.
+            const offset: usize = self.words[self.plan.trace_offsets + column];
+            const source = self.resolved[column].values;
+            if (source.len == 0) {
+                @memset(self.words[offset..][0..null_column_words], 0);
+                continue;
+            }
+            @memcpy(self.words[offset..][0..source.len], source);
+        }
+    }
+};
+
+/// Stages one component's columns into the arena **without lifting them**, and
+/// publishes the two blocks that placement produces: `trace_offsets` and the
+/// per-column shift table.
+///
+/// Returns the words actually written, which is the honest staging volume — the
+/// quantity Option A pays twice over.
+///
+/// The serial prefix pass is where correctness lives. For every column it checks
+/// the ABI's own extent identity, `(eval_rows >> shift) << 1 == values.len`: that
+/// is precisely the statement that the largest index Library 2's reader can form
+/// lands inside the committed column, so a column that passes it cannot be read
+/// out of bounds by any row of any part. A column that fails it is refused here,
+/// before a single word is written, and the caller answers with the host
+/// evaluation of that component.
+pub fn store(
+    words: []u32,
+    component_plan: Plan,
+    resolved: []const ResolvedScratch,
+    pool: ?*WorkPool,
+) !u64 {
+    if (component_plan.mode != .stored) return Error.EvalArenaColumnShape;
+    if (resolved.len != component_plan.columns) return Error.EvalArenaColumnShape;
+
+    const limit = component_plan.column_base + component_plan.column_capacity;
+    var cursor: u64 = component_plan.column_base;
+    var staged: u64 = 0;
+    for (resolved, 0..) |source, index| {
+        var shift: u32 = undefined;
+        var needed: u64 = undefined;
+        if (source.values.len == 0) {
+            // Never read. Pin the reader's index to `{0, 1}` inside the pair
+            // rather than leaving a shift that could address the whole arena.
+            shift = component_plan.eval_log_size;
+            needed = null_column_words;
+        } else {
+            if (source.shift_amt == 0) return Error.EvalArenaColumnShape;
+            if (source.shift_amt > component_plan.eval_log_size)
+                return Error.EvalArenaColumnShape;
+            const extent = (@as(u64, component_plan.eval_rows) >> source.shift_amt) << 1;
+            if (extent != source.values.len) return Error.EvalArenaColumnShape;
+            shift = source.shift_amt;
+            needed = source.values.len;
+        }
+        if (cursor + needed > limit) return Error.EvalArenaTooLarge;
+        words[component_plan.trace_offsets + index] = @intCast(cursor);
+        words[component_plan.base_params + index] = shift;
+        cursor += needed;
+        staged += needed;
+    }
+
+    const ready = pool orelse {
+        var worker = StoreWorker{
+            .words = words,
+            .plan = &component_plan,
+            .resolved = resolved,
+            .stride = 1,
+            .start = 0,
+        };
+        worker.run();
+        return staged * @sizeOf(u32);
+    };
+    const worker_count = @max(1, @min(ready.workerCount(), resolved.len));
+    if (worker_count == 1) {
+        var worker = StoreWorker{
+            .words = words,
+            .plan = &component_plan,
+            .resolved = resolved,
+            .stride = 1,
+            .start = 0,
+        };
+        worker.run();
+        return staged * @sizeOf(u32);
+    }
+    var buffer: [64]StoreWorker = undefined;
+    const workers = buffer[0..@min(worker_count, buffer.len)];
+    for (workers, 0..) |*worker, index| {
+        worker.* = .{
+            .words = words,
+            .plan = &component_plan,
+            .resolved = resolved,
+            .stride = workers.len,
+            .start = index,
+        };
+    }
+    var wait_group = std.Thread.WaitGroup{};
+    for (workers[1..]) |*worker| ready.spawnWg(&wait_group, StoreWorker.run, .{worker});
+    StoreWorker.run(&workers[0]);
+    wait_group.wait();
+    return staged * @sizeOf(u32);
+}
+
 test "the lifting map matches the product's own column reader" {
     try std.testing.expectEqual(@as(usize, 0), liftedIndex(0, 2));
     try std.testing.expectEqual(@as(usize, 1), liftedIndex(1, 2));
@@ -378,6 +604,114 @@ test "a mismatched destination is refused rather than asserted" {
         Error.EvalArenaColumnShape,
         liftColumn(destination[0..4], &source, 0),
     );
+}
+
+/// A hand-built two-column stored-domain plan. Building it directly rather than
+/// through `planFor` keeps this test about `store`'s placement contract; the
+/// planner's own layout is pinned by the layout test below it.
+fn storedFixture(bases: []u32, eval_log: u32, columns: u32) Plan {
+    const eval_rows = @as(u32, 1) << @intCast(eval_log);
+    return .{
+        .mode = .stored,
+        .columns = columns,
+        .interactions = @intCast(bases.len),
+        .eval_rows = eval_rows,
+        .eval_log_size = eval_log,
+        .trace_log_size = eval_log - 1,
+        .denominator_count = 2,
+        .ext_param_count = 0,
+        .coefficient_count = 1,
+        .column_base = 64,
+        .column_capacity = @as(u64, columns) * eval_rows,
+        .base_params = 16,
+        .trace_offsets = 0,
+        .interaction_offsets = 8,
+        .ext_params = 32,
+        .random_coeffs = 36,
+        .denom_inv = 40,
+        .coordinates = .{ 42, 44, 46, 48 },
+        .words = 64 + @as(u64, columns) * eval_rows,
+        .bases = bases,
+    };
+}
+
+test "stored staging packs columns and publishes their shifts" {
+    var bases = [_]u32{0};
+    const component_plan = storedFixture(&bases, 3, 2);
+    var words = [_]u32{0} ** 80;
+    // Both columns are committed at the trace log size, so both carry shift 2
+    // and four words: `(8 >> 2) << 1 == 4`.
+    const first = [_]u32{ 1, 2, 3, 4 };
+    const second = [_]u32{ 5, 6, 7, 8 };
+    const resolved = [_]ResolvedScratch{
+        .{ .values = &first, .shift_amt = 2 },
+        .{ .values = &second, .shift_amt = 2 },
+    };
+    const staged = try store(&words, component_plan, &resolved, null);
+    try std.testing.expectEqual(@as(u64, 8 * @sizeOf(u32)), staged);
+    // Packed consecutively from the region base, not strided by `eval_rows`.
+    try std.testing.expectEqual(@as(u32, 64), words[component_plan.trace_offsets]);
+    try std.testing.expectEqual(@as(u32, 68), words[component_plan.trace_offsets + 1]);
+    try std.testing.expectEqual(@as(u32, 2), words[component_plan.base_params]);
+    try std.testing.expectEqual(@as(u32, 2), words[component_plan.base_params + 1]);
+    try std.testing.expectEqualSlices(u32, &first, words[64..68]);
+    try std.testing.expectEqualSlices(u32, &second, words[68..72]);
+
+    // The reader's own map, run over every evaluation row against the words the
+    // staging just placed: this is the property the ABI rests on.
+    for (0..component_plan.eval_rows) |row| {
+        const index = ((row >> 2) << 1) + (row & 1);
+        const offset = words[component_plan.trace_offsets];
+        try std.testing.expectEqual(first[index], words[offset + index]);
+    }
+}
+
+test "a column whose length contradicts its shift is refused before any write" {
+    var bases = [_]u32{0};
+    const component_plan = storedFixture(&bases, 3, 1);
+    var words = [_]u32{0} ** 80;
+    // Shift 2 at `eval_rows = 8` demands a four-word column; this one is eight.
+    const wrong = [_]u32{ 1, 2, 3, 4, 5, 6, 7, 8 };
+    const resolved = [_]ResolvedScratch{.{ .values = &wrong, .shift_amt = 2 }};
+    try std.testing.expectError(
+        Error.EvalArenaColumnShape,
+        store(&words, component_plan, &resolved, null),
+    );
+    try std.testing.expectEqual(@as(u32, 0), words[64]);
+    // And the lifted planner's staging refuses to run against a stored plan.
+    try std.testing.expectError(
+        Error.EvalArenaColumnShape,
+        store(&words, storedLiftedFixture(&bases), &resolved, null),
+    );
+}
+
+fn storedLiftedFixture(bases: []u32) Plan {
+    var lifted = storedFixture(bases, 3, 1);
+    lifted.mode = .lifted;
+    return lifted;
+}
+
+test "an unread census slot gets a real pair and an index-pinning shift" {
+    var bases = [_]u32{0};
+    const component_plan = storedFixture(&bases, 3, 2);
+    var words = [_]u32{0} ** 80;
+    const present = [_]u32{ 1, 2, 3, 4 };
+    const resolved = [_]ResolvedScratch{
+        .{},
+        .{ .values = &present, .shift_amt = 2 },
+    };
+    const staged = try store(&words, component_plan, &resolved, null);
+    try std.testing.expectEqual(@as(u64, 6 * @sizeOf(u32)), staged);
+    try std.testing.expectEqual(
+        component_plan.eval_log_size,
+        words[component_plan.base_params],
+    );
+    // Every row of the unread slot addresses inside its own pair.
+    for (0..component_plan.eval_rows) |row| {
+        const index = ((row >> component_plan.eval_log_size) << 1) + (row & 1);
+        try std.testing.expect(index < null_column_words);
+    }
+    try std.testing.expectEqual(@as(u32, 66), words[component_plan.trace_offsets + 1]);
 }
 
 test "the arena byte cap is read from the process and defaults closed" {

--- a/src/integrations/cairo_metal/composition_eval_arena.zig
+++ b/src/integrations/cairo_metal/composition_eval_arena.zig
@@ -493,18 +493,41 @@ const StoreWorker = struct {
 /// out of bounds by any row of any part. A column that fails it is refused here,
 /// before a single word is written, and the caller answers with the host
 /// evaluation of that component.
+/// What one component's staging actually moved, and at what shifts.
+///
+/// `lifted_bytes` is the volume the Option-A path would have written for the
+/// same component. Reporting the two side by side is the only way to price the
+/// ABI change honestly: the saving is a property of the *committed* column log
+/// sizes, which no test that builds its own column store can observe.
+pub const Volume = struct {
+    stored_bytes: u64 = 0,
+    lifted_bytes: u64 = 0,
+    shift_min: u32 = std.math.maxInt(u32),
+    shift_max: u32 = 0,
+
+    pub fn fold(self: *Volume, other: Volume) void {
+        self.stored_bytes += other.stored_bytes;
+        self.lifted_bytes += other.lifted_bytes;
+        self.shift_min = @min(self.shift_min, other.shift_min);
+        self.shift_max = @max(self.shift_max, other.shift_max);
+    }
+};
+
 pub fn store(
     words: []u32,
     component_plan: Plan,
     resolved: []const ResolvedScratch,
     pool: ?*WorkPool,
-) !u64 {
+) !Volume {
     if (component_plan.mode != .stored) return Error.EvalArenaColumnShape;
     if (resolved.len != component_plan.columns) return Error.EvalArenaColumnShape;
 
     const limit = component_plan.column_base + component_plan.column_capacity;
     var cursor: u64 = component_plan.column_base;
-    var staged: u64 = 0;
+    var volume = Volume{
+        .lifted_bytes = @as(u64, component_plan.columns) *
+            component_plan.eval_rows * @sizeOf(u32),
+    };
     for (resolved, 0..) |source, index| {
         var shift: u32 = undefined;
         var needed: u64 = undefined;
@@ -526,7 +549,11 @@ pub fn store(
         words[component_plan.trace_offsets + index] = @intCast(cursor);
         words[component_plan.base_params + index] = shift;
         cursor += needed;
-        staged += needed;
+        volume.stored_bytes += needed * @sizeOf(u32);
+        if (source.values.len != 0) {
+            volume.shift_min = @min(volume.shift_min, shift);
+            volume.shift_max = @max(volume.shift_max, shift);
+        }
     }
 
     const ready = pool orelse {
@@ -538,7 +565,7 @@ pub fn store(
             .start = 0,
         };
         worker.run();
-        return staged * @sizeOf(u32);
+        return volume;
     };
     const worker_count = @max(1, @min(ready.workerCount(), resolved.len));
     if (worker_count == 1) {
@@ -550,7 +577,7 @@ pub fn store(
             .start = 0,
         };
         worker.run();
-        return staged * @sizeOf(u32);
+        return volume;
     }
     var buffer: [64]StoreWorker = undefined;
     const workers = buffer[0..@min(worker_count, buffer.len)];
@@ -567,7 +594,7 @@ pub fn store(
     for (workers[1..]) |*worker| ready.spawnWg(&wait_group, StoreWorker.run, .{worker});
     StoreWorker.run(&workers[0]);
     wait_group.wait();
-    return staged * @sizeOf(u32);
+    return volume;
 }
 
 test "the lifting map matches the product's own column reader" {
@@ -647,8 +674,13 @@ test "stored staging packs columns and publishes their shifts" {
         .{ .values = &first, .shift_amt = 2 },
         .{ .values = &second, .shift_amt = 2 },
     };
-    const staged = try store(&words, component_plan, &resolved, null);
-    try std.testing.expectEqual(@as(u64, 8 * @sizeOf(u32)), staged);
+    const volume = try store(&words, component_plan, &resolved, null);
+    try std.testing.expectEqual(@as(u64, 8 * @sizeOf(u32)), volume.stored_bytes);
+    // Two four-word columns against a two-column eval-domain plan: the ABI
+    // change is worth exactly the ratio of these two numbers on this fixture.
+    try std.testing.expectEqual(@as(u64, 16 * @sizeOf(u32)), volume.lifted_bytes);
+    try std.testing.expectEqual(@as(u32, 2), volume.shift_min);
+    try std.testing.expectEqual(@as(u32, 2), volume.shift_max);
     // Packed consecutively from the region base, not strided by `eval_rows`.
     try std.testing.expectEqual(@as(u32, 64), words[component_plan.trace_offsets]);
     try std.testing.expectEqual(@as(u32, 68), words[component_plan.trace_offsets + 1]);
@@ -700,8 +732,8 @@ test "an unread census slot gets a real pair and an index-pinning shift" {
         .{},
         .{ .values = &present, .shift_amt = 2 },
     };
-    const staged = try store(&words, component_plan, &resolved, null);
-    try std.testing.expectEqual(@as(u64, 6 * @sizeOf(u32)), staged);
+    const volume = try store(&words, component_plan, &resolved, null);
+    try std.testing.expectEqual(@as(u64, 6 * @sizeOf(u32)), volume.stored_bytes);
     try std.testing.expectEqual(
         component_plan.eval_log_size,
         words[component_plan.base_params],

--- a/src/integrations/cairo_metal/composition_eval_arena.zig
+++ b/src/integrations/cairo_metal/composition_eval_arena.zig
@@ -10,19 +10,23 @@
 //! ```
 //!
 //! with `row` running over the **evaluation** domain, so an arena column must be
-//! `2^eval_log` words long. The product publishes columns at `2^trace_log`
-//! (`pcs/scheme_views.polynomials`), which is why the host evaluator is handed
-//! `shift_amt = evaluation_log_size - column.log_size + 1`. **The eval arena is
-//! therefore not placement — it is placement plus a lift**, and the lift is the
-//! staging pass: writing the lifted copy into the arena is the same bytes as
+//! `2^eval_log` words long. The host evaluator is handed
+//! `shift_amt = evaluation_log_size - column.log_size + 1` for the same reason,
+//! and the lifting map is `component_prover.Poly.at`'s own: evaluation position
+//! `p` reads index `((p >> s) << 1) + (p & 1)`. Writing that map's image into the
+//! arena is the staging pass, and it is the same bytes
 //! `src/tests/metal/composition_lift_bridge_test.zig` verified byte-exact on a
 //! 1-part and a 5-part component of the authenticated bundle.
 //!
-//! The lifting map is `component_prover.Poly.at`'s own: evaluation position `p`
-//! reads trace index `((p >> s) << 1) + (p & 1)` with `s` the column's shift.
-//! That is each adjacent pair emitted `2^(s-1)` times — a streaming 8-byte
-//! granule duplication, not a gather, which is why it runs at 89.84 GB/s
-//! single-threaded ReleaseFast and parallelises per column with no sharing.
+//! **Increment 3.15 measured `s` on the product path and it is 1 on every column
+//! of every portfolio workload**, so that map is the identity and the staging
+//! pass is a copy, not a duplication. Increment 3.7 §3 stated — and this comment
+//! used to repeat — that "the product publishes columns at `2^trace_log`". It
+//! does not: `pcs/scheme_views.polynomials` hands back the committed tree
+//! columns, and `pcs/tree_builders.zig:169` stores the **extended** values in
+//! them. The host's `shift_amt` machinery is correct and general, and on this
+//! product it is exercised only at its identity. The consequence for Option B is
+//! recorded under `Mode` below, and it is the whole finding of 3.15.
 //!
 //! ## Layout
 //!
@@ -72,9 +76,17 @@
 //!    and removes the one shape a fixed stride could not express.
 //!
 //! Reserving the eval-domain capacity means the *allocation* does not shrink.
-//! The **resident** footprint does, and that is the quantity that was costing
-//! 0.76-4.80 GB per proof: the column region is placed last in stored mode, so
-//! the pages past the packed prefix are never touched and are never faulted in.
+//! The **resident** footprint shrinks by whatever the packing leaves untouched,
+//! because the column region is placed last in stored mode and the pages past
+//! the packed prefix are never faulted in.
+//!
+//! **On this product that saving is zero, measured.** Every observed shift is 1,
+//! so the packed prefix is the whole capacity and the stored arena holds exactly
+//! the words the lifted one held. The mode is correct, byte-exact and general —
+//! a column committed at a shorter log size *would* be packed short and *would*
+//! be read correctly by Library 2 — but the portfolio does not contain one, and
+//! the honest statement of what Option B buys here is "one indirection through a
+//! shift table, in exchange for the same bytes". See the `Volume` diagnostic.
 
 const std = @import("std");
 const composition = @import("stwo_cairo_frontend").witness.composition_bundle;

--- a/src/integrations/cairo_metal/composition_stage.zig
+++ b/src/integrations/cairo_metal/composition_stage.zig
@@ -175,7 +175,11 @@ const Session = struct {
     entries: []?Entry,
     resolved: []eval_arena.ResolvedScratch = &.{},
     lift_ns: u64 = 0,
-    lifted_bytes: u64 = 0,
+    /// Staged volume, and what Option A would have written for the same
+    /// columns. Equal by construction on the `lifted` path; the gap on the
+    /// `stored` path is the ABI change's whole staging benefit, and it is a
+    /// property of the *committed* column log sizes rather than of the plan.
+    volume: eval_arena.Volume = .{},
     dispatches: u64 = 0,
     /// Blocking submissions actually made. One per evaluated component, against
     /// the `dispatches` above which stay one per part; the gap between the two
@@ -527,12 +531,16 @@ fn closeAdapter(context: *anyopaque) void {
         const seconds = @as(f64, @floatFromInt(self.lift_ns)) / std.time.ns_per_s;
         std.log.info(
             "device composition ({t}): stage {d:.3} ms over {d} MiB ({d:.2} GB/s), " ++
+                "eval-domain equivalent {d} MiB, shifts {d}-{d}, " ++
                 "{d} dispatches in {d} submissions, device {d:.3} ms",
             .{
                 self.mode,
                 @as(f64, @floatFromInt(self.lift_ns)) / std.time.ns_per_ms,
-                self.lifted_bytes >> 20,
-                @as(f64, @floatFromInt(self.lifted_bytes)) / seconds / 1.0e9,
+                self.volume.stored_bytes >> 20,
+                @as(f64, @floatFromInt(self.volume.stored_bytes)) / seconds / 1.0e9,
+                self.volume.lifted_bytes >> 20,
+                self.volume.shift_min,
+                self.volume.shift_max,
                 self.dispatches,
                 self.submissions,
                 self.device_gpu_ms,
@@ -598,7 +606,13 @@ fn evaluate(self: *Session, request: *const device_stage.Request) !void {
                 prover.work_pool.getGlobalPool(),
             );
             self.lift_ns += timer.read();
-            self.lifted_bytes += @as(u64, plan.columns) * plan.eval_rows * @sizeOf(u32);
+            const written = @as(u64, plan.columns) * plan.eval_rows * @sizeOf(u32);
+            self.volume.fold(.{
+                .stored_bytes = written,
+                .lifted_bytes = written,
+                .shift_min = 0,
+                .shift_max = 0,
+            });
             for (0..plan.columns) |column|
                 self.words[plan.trace_offsets + column] = plan.columnOffset(@intCast(column));
         },
@@ -606,12 +620,12 @@ fn evaluate(self: *Session, request: *const device_stage.Request) !void {
         // publishes `trace_offsets` and the shift table itself because both are
         // products of the packing it just did.
         .stored => {
-            self.lifted_bytes += try eval_arena.store(
+            self.volume.fold(try eval_arena.store(
                 self.words,
                 plan,
                 self.resolved[0..plan.columns],
                 prover.work_pool.getGlobalPool(),
-            );
+            ));
             self.lift_ns += timer.read();
         },
     }

--- a/src/integrations/cairo_metal/composition_stage.zig
+++ b/src/integrations/cairo_metal/composition_stage.zig
@@ -111,6 +111,22 @@ pub const metallib_env = "STWO_ZIG_COMPOSITION_METALLIB";
 /// artifact did.
 pub const metallib_leaf = "air_template_composition_eval_domain.metallib";
 
+/// Set to `0` to pin the stage to the Option-A (lifted, Library 1) path.
+///
+/// Increment 3.15's default is stored-domain **preferred**: when the hook is
+/// armed the stage tries Library 2 first and only falls to Option A if that tier
+/// declines. The switch exists so the two paths are an env-only pairing off one
+/// build, which is what made 3.13's gate clean, and so a deployment that
+/// distrusts the new tier can pin the measured one without a rebuild.
+pub const stored_domain_env = "STWO_ZIG_COMPOSITION_STORED_DOMAIN";
+/// Overrides the *stored-domain* library path, independently of `metallib_env`.
+/// Two libraries, two overrides: the corrupt-Library-2 fail-back test has to be
+/// able to poison tier 1 without touching the tier it must fall back to.
+pub const stored_metallib_env = "STWO_ZIG_COMPOSITION_STORED_METALLIB";
+/// The Option-B stored-domain library (increment 3.10's ABI, minted alongside
+/// Library 1 from the same three AIR template program bundles).
+pub const stored_metallib_leaf = "air_template_composition_stored_domain.metallib";
+
 const Config = struct {
     /// A directory to look for the metallib in, derived from an asset path the
     /// product already resolves. Never owned.
@@ -145,6 +161,7 @@ const Entry = struct {
 };
 
 const Session = struct {
+    mode: eval_arena.Mode,
     allocator: std.mem.Allocator,
     /// Borrowed. The bundle outlives the prove call it was opened for, and this
     /// is what makes a request's component identity recoverable without the
@@ -179,6 +196,45 @@ fn openAdapter(
     };
 }
 
+/// Why a tier did not take the stage. One value per tier boundary, so the
+/// increment-3.8 decline accounting says *which* path refused rather than only
+/// that the stage did — the two tiers fail for different reasons and a
+/// stored-domain refusal that silently reads as an Option-A refusal would hide
+/// exactly the regression this increment could introduce.
+const Decline = enum {
+    /// The tier is switched off by the process.
+    disabled,
+    /// The library did not authenticate, or its path did not resolve.
+    library,
+    /// No component could be planned, or every plan was over the byte cap.
+    arena,
+    /// The library authenticated but resolved no component's kernels.
+    kernels,
+};
+
+fn declineName(mode: eval_arena.Mode, reason: Decline) []const u8 {
+    return switch (mode) {
+        .stored => switch (reason) {
+            .disabled => "stored_domain_disabled",
+            .library => "stored_domain_library",
+            .arena => "stored_domain_arena",
+            .kernels => "stored_domain_kernels",
+        },
+        .lifted => switch (reason) {
+            .disabled => "eval_domain_disabled",
+            .library => "eval_domain_library",
+            .arena => "eval_domain_arena",
+            .kernels => "eval_domain_kernels",
+        },
+    };
+}
+
+/// True unless the process pinned the stage to Option A.
+fn storedDomainPreferred() bool {
+    const text = std.posix.getenv(stored_domain_env) orelse return true;
+    return !std.mem.eql(u8, text, "0");
+}
+
 fn open(
     settings: Config,
     allocator: std.mem.Allocator,
@@ -188,16 +244,58 @@ fn open(
     if (!std.mem.eql(u8, armed, "1")) return null;
     if (components.len == 0) return null;
 
-    const path = try resolveMetallib(allocator, settings);
+    // Tier 1: the stored-domain path. It is *tried*, not asserted: a decline
+    // here is not a stage decline, it is a demotion to the tier increment 3.13
+    // gated. Option A stays whole underneath, and the host path stays whole
+    // underneath that.
+    if (storedDomainPreferred()) {
+        if (attempt(settings, allocator, components, .stored)) |opened| {
+            if (opened) |session| return session;
+        } else |err| {
+            std.log.err("stored-domain composition tier declined: {t}", .{err});
+        }
+    } else {
+        std.log.info(
+            "device composition tier declined: {s}",
+            .{declineName(.stored, .disabled)},
+        );
+    }
+    return attempt(settings, allocator, components, .lifted);
+}
+
+fn attempt(
+    settings: Config,
+    allocator: std.mem.Allocator,
+    components: []const composition.Component,
+    mode: eval_arena.Mode,
+) anyerror!?device_stage.Session {
+    const path = resolveMetallib(allocator, settings, mode) catch |err| {
+        std.log.err(
+            "device composition tier declined: {s} ({t})",
+            .{ declineName(mode, .library), err },
+        );
+        return err;
+    };
     defer allocator.free(path);
-    // Integrity before load, and a rejection is terminal for this path.
-    const admission = try composition_aot.authenticate(
+    // Integrity before load, and a rejection is terminal for this tier.
+    const admission = composition_aot.authenticate(
         path,
         try composition_aot.policyFromProcess(allocator),
-    );
+    ) catch |err| {
+        std.log.err(
+            "device composition tier declined: {s} ({t})",
+            .{ declineName(mode, .library), err },
+        );
+        return err;
+    };
     std.log.info(
-        "device composition metallib admitted: {s} ({s}, {d} bytes)",
-        .{ admission.label orelse "pinned", &admission.measurement.hex(), admission.measurement.length },
+        "device composition metallib admitted: {s} ({s}, {d} bytes, {t} arena)",
+        .{
+            admission.label orelse "pinned",
+            &admission.measurement.hex(),
+            admission.measurement.length,
+            mode,
+        },
     );
 
     var lease = try shared_runtime.acquireExisting();
@@ -220,7 +318,7 @@ fn open(
     var max_columns: u32 = 0;
     for (components, entries) |component, *entry| {
         if (!eval_arena.expressible(component)) continue;
-        var component_plan = eval_arena.plan(allocator, component) catch continue;
+        var component_plan = eval_arena.planFor(allocator, component, mode) catch continue;
         var plan_owned = true;
         defer if (plan_owned) component_plan.deinit(allocator);
         const bytes = component_plan.words * @sizeOf(u32);
@@ -231,7 +329,13 @@ fn open(
         peak_words = @max(peak_words, component_plan.words);
         max_columns = @max(max_columns, component_plan.columns);
     }
-    if (planned == 0) return null;
+    if (planned == 0) {
+        std.log.err(
+            "device composition tier declined: {s}",
+            .{declineName(mode, .arena)},
+        );
+        return null;
+    }
 
     var library = try lease.runtime.loadEvalLibrary(path);
     var library_owned = true;
@@ -245,12 +349,19 @@ fn open(
         const plans = allocator.alloc(metal.EvalPlan, component.parts.len) catch continue;
         var resolved: usize = 0;
         for (component.parts, plans) |part, *plan| {
-            const name = codegen.kernelName(allocator, part.program.header.semantic_hash) catch break;
+            // The name carries the ABI infix, so a library of the other ABI
+            // cannot resolve here: a mismatch is a missing-function decline
+            // rather than a silently wrong column read.
+            const name = codegen.kernelNameFor(
+                allocator,
+                part.program.header.semantic_hash,
+                mode.abi(),
+            ) catch break;
             defer allocator.free(name);
             plan.* = lease.runtime.prepareEvalFromLibrary(
                 library,
                 name,
-                layoutFor(ready.plan, part.rc_base, part.program.header.domain_log_size),
+                layoutFor(ready.plan, part.rc_base, part.program),
             ) catch break;
             resolved += 1;
         }
@@ -277,7 +388,13 @@ fn open(
         accepted_flag.* = true;
         accepted += 1;
     }
-    if (accepted == 0) return null;
+    if (accepted == 0) {
+        std.log.err(
+            "device composition tier declined: {s}",
+            .{declineName(mode, .kernels)},
+        );
+        return null;
+    }
 
     var arena = try lease.runtime.allocateResidentBuffer(peak_words * @sizeOf(u32));
     var arena_owned = true;
@@ -290,6 +407,7 @@ fn open(
     const session = try allocator.create(Session);
     errdefer allocator.destroy(session);
     session.* = .{
+        .mode = mode,
         .allocator = allocator,
         .components = components,
         .lease = lease,
@@ -304,8 +422,9 @@ fn open(
     arena_owned = false;
 
     std.log.info(
-        "device composition stage open: {d}/{d} components accepted, arena {d} MiB",
-        .{ accepted, components.len, (peak_words * @sizeOf(u32)) >> 20 },
+        "device composition stage open: {t} arena, {d}/{d} components accepted " ++
+            "({d} planned), arena {d} MiB",
+        .{ mode, accepted, components.len, planned, (peak_words * @sizeOf(u32)) >> 20 },
     );
     return .{
         .context = session,
@@ -315,11 +434,21 @@ fn open(
     };
 }
 
-fn layoutFor(plan: eval_arena.Plan, rc_base: u32, domain_log_size: u32) metal.EvalLayout {
+fn layoutFor(
+    plan: eval_arena.Plan,
+    rc_base: u32,
+    program: frontend.witness.eval_program.Program,
+) metal.EvalLayout {
+    const domain_log_size = program.header.domain_log_size;
     return .{
         .trace_offsets = plan.trace_offsets,
         .interaction_offsets = plan.interaction_offsets,
-        .base_params = 0,
+        // Option A leaves this at zero: the block is empty and unread. Option B
+        // points it at the block whose tail — `+ n_base_params`, the constant the
+        // kernel bakes in — is this component's shift table. `plan.shiftTable`
+        // is the same computation from the other side and the layout test below
+        // holds them equal.
+        .base_params = plan.base_params,
         .ext_params = plan.ext_params,
         .random_coeffs = plan.random_coeffs,
         .denom_inv = plan.denom_inv,
@@ -338,31 +467,58 @@ fn byteCap() u64 {
         eval_arena.default_byte_cap;
 }
 
-fn resolveMetallib(allocator: std.mem.Allocator, settings: Config) ![]u8 {
-    if (std.posix.getenv(metallib_env)) |override|
+fn leafFor(mode: eval_arena.Mode) []const u8 {
+    return switch (mode) {
+        .lifted => metallib_leaf,
+        .stored => stored_metallib_leaf,
+    };
+}
+
+fn overrideFor(mode: eval_arena.Mode) ?[]const u8 {
+    return switch (mode) {
+        .lifted => std.posix.getenv(metallib_env),
+        .stored => std.posix.getenv(stored_metallib_env),
+    };
+}
+
+fn defaultPathFor(mode: eval_arena.Mode) []const u8 {
+    return switch (mode) {
+        .lifted => default_metallib_path,
+        .stored => default_stored_metallib_path,
+    };
+}
+
+fn resolveMetallib(
+    allocator: std.mem.Allocator,
+    settings: Config,
+    mode: eval_arena.Mode,
+) ![]u8 {
+    if (overrideFor(mode)) |override|
         return allocator.dupe(u8, override);
+    const fallback = defaultPathFor(mode);
     if (settings.search_root) |asset| {
-        // The eval-domain metallib sits *beside* the AIR template library it was
-        // minted from — both are `vectors/cairo/official/` — where the superseded
-        // SN2 artifact sat one directory above it. So this is the asset's own
+        // Both metallibs sit *beside* the AIR template library they were minted
+        // from — all of `vectors/cairo/official/` — where the superseded SN2
+        // artifact sat one directory above. So this is the asset's own
         // directory, not its parent.
         if (std.fs.path.dirname(asset)) |leaf_dir| {
-            const candidate = try std.fs.path.join(allocator, &.{ leaf_dir, metallib_leaf });
+            const candidate = try std.fs.path.join(allocator, &.{ leaf_dir, leafFor(mode) });
             errdefer allocator.free(candidate);
             std.fs.cwd().access(candidate, .{}) catch {
                 allocator.free(candidate);
-                return allocator.dupe(u8, default_metallib_path);
+                return allocator.dupe(u8, fallback);
             };
             return candidate;
         }
     }
-    return allocator.dupe(u8, default_metallib_path);
+    return allocator.dupe(u8, fallback);
 }
 
-/// The in-tree location, used when no asset path was resolved or the sibling
+/// The in-tree locations, used when no asset path was resolved or the sibling
 /// lookup missed. Relative, because every proving path runs with the repository
 /// root as its working directory.
 const default_metallib_path = "vectors/cairo/official/" ++ metallib_leaf;
+const default_stored_metallib_path = "vectors/cairo/official/" ++ stored_metallib_leaf;
 
 fn closeAdapter(context: *anyopaque) void {
     const self: *Session = @ptrCast(@alignCast(context));
@@ -370,9 +526,10 @@ fn closeAdapter(context: *anyopaque) void {
     if (self.lift_ns != 0) {
         const seconds = @as(f64, @floatFromInt(self.lift_ns)) / std.time.ns_per_s;
         std.log.info(
-            "device composition: lift {d:.3} ms over {d} MiB ({d:.2} GB/s), " ++
+            "device composition ({t}): stage {d:.3} ms over {d} MiB ({d:.2} GB/s), " ++
                 "{d} dispatches in {d} submissions, device {d:.3} ms",
             .{
+                self.mode,
                 @as(f64, @floatFromInt(self.lift_ns)) / std.time.ns_per_ms,
                 self.lifted_bytes >> 20,
                 @as(f64, @floatFromInt(self.lifted_bytes)) / seconds / 1.0e9,
@@ -430,19 +587,37 @@ fn evaluate(self: *Session, request: *const device_stage.Request) !void {
     }
 
     var timer = try std.time.Timer.start();
-    try eval_arena.lift(
-        self.words,
-        plan,
-        self.resolved[0..plan.columns],
-        prover.work_pool.getGlobalPool(),
-    );
-    self.lift_ns += timer.read();
-    self.lifted_bytes += @as(u64, plan.columns) * plan.eval_rows * @sizeOf(u32);
+    switch (plan.mode) {
+        // Option A. The lift *is* the staging pass, and it writes twice the
+        // words it reads.
+        .lifted => {
+            try eval_arena.lift(
+                self.words,
+                plan,
+                self.resolved[0..plan.columns],
+                prover.work_pool.getGlobalPool(),
+            );
+            self.lift_ns += timer.read();
+            self.lifted_bytes += @as(u64, plan.columns) * plan.eval_rows * @sizeOf(u32);
+            for (0..plan.columns) |column|
+                self.words[plan.trace_offsets + column] = plan.columnOffset(@intCast(column));
+        },
+        // Option B. The staging pass copies exactly the committed words, and it
+        // publishes `trace_offsets` and the shift table itself because both are
+        // products of the packing it just did.
+        .stored => {
+            self.lifted_bytes += try eval_arena.store(
+                self.words,
+                plan,
+                self.resolved[0..plan.columns],
+                prover.work_pool.getGlobalPool(),
+            );
+            self.lift_ns += timer.read();
+        },
+    }
 
-    // Offsets, parameters, coefficients and denominators. Small blocks, written
-    // after the lift so a lift refusal costs nothing else.
-    for (0..plan.columns) |column|
-        self.words[plan.trace_offsets + column] = plan.columnOffset(@intCast(column));
+    // Parameters, coefficients and denominators. Small blocks, written after
+    // staging so a staging refusal costs nothing else.
     for (plan.bases, 0..) |base, slot|
         self.words[plan.interaction_offsets + slot] = base;
     for (0..plan.ext_param_count) |slot| {
@@ -522,6 +697,101 @@ test "the enable switch and the path override are named, not guessed" {
     );
 }
 
+test "the stored-domain tier is named apart from the eval-domain tier" {
+    try std.testing.expectEqualStrings(
+        "STWO_ZIG_COMPOSITION_STORED_DOMAIN",
+        stored_domain_env,
+    );
+    try std.testing.expectEqualStrings(
+        "STWO_ZIG_COMPOSITION_STORED_METALLIB",
+        stored_metallib_env,
+    );
+    // Two libraries, two leaves, two overrides. Sharing any of the three would
+    // make the fail-back test poison the tier it is supposed to fall back to.
+    try std.testing.expect(!std.mem.eql(u8, metallib_leaf, stored_metallib_leaf));
+    try std.testing.expect(!std.mem.eql(u8, metallib_env, stored_metallib_env));
+    try std.testing.expect(!std.mem.eql(
+        u8,
+        default_metallib_path,
+        default_stored_metallib_path,
+    ));
+    try std.testing.expectEqualStrings(stored_metallib_leaf, leafFor(.stored));
+    try std.testing.expectEqualStrings(metallib_leaf, leafFor(.lifted));
+}
+
+test "every tier boundary has its own decline reason" {
+    // The point of the accounting is that no two boundaries share a name: a
+    // stored-domain refusal read as an Option-A refusal is the one failure mode
+    // that would hide a coverage regression behind an unchanged digest.
+    var seen: [8][]const u8 = undefined;
+    var count: usize = 0;
+    for ([_]eval_arena.Mode{ .stored, .lifted }) |mode| {
+        for ([_]Decline{ .disabled, .library, .arena, .kernels }) |reason| {
+            const name = declineName(mode, reason);
+            for (seen[0..count]) |prior|
+                try std.testing.expect(!std.mem.eql(u8, prior, name));
+            seen[count] = name;
+            count += 1;
+        }
+    }
+    try std.testing.expectEqual(@as(usize, 8), count);
+}
+
+test "the stored-domain layout points base_params at the shift table" {
+    // The two sides of increment 3.10's layout contract, held equal: the host
+    // writes shifts at `plan.base_params` and binds `EvalLayout.base_params` to
+    // the same word, and the kernel reads them at `base_params + n_base_params`.
+    // `expressible` refuses any component with a non-zero `n_base_params`, so
+    // the two agree today; the assertion is here so that stops being silent if
+    // increment 3.10 part B ever lands.
+    var bases = [_]u32{0};
+    const stored = eval_arena.Plan{
+        .mode = .stored,
+        .columns = 3,
+        .interactions = 1,
+        .eval_rows = 8,
+        .eval_log_size = 3,
+        .trace_log_size = 2,
+        .denominator_count = 2,
+        .ext_param_count = 0,
+        .coefficient_count = 1,
+        .column_base = 64,
+        .column_capacity = 24,
+        .base_params = 16,
+        .trace_offsets = 0,
+        .interaction_offsets = 8,
+        .ext_params = 32,
+        .random_coeffs = 36,
+        .denom_inv = 40,
+        .coordinates = .{ 42, 44, 46, 48 },
+        .words = 88,
+        .bases = &bases,
+    };
+    const program = frontend.witness.eval_program.Program{
+        .header = .{
+            .semantic_hash = 0,
+            .n_base_params = 0,
+            .n_ext_params = 0,
+            .n_interactions = 1,
+            .n_constraints = 1,
+            .domain_log_size = 2,
+        },
+        .base_insts = &.{},
+        .ext_insts = &.{},
+        .constraints = &.{},
+    };
+    try std.testing.expectEqual(stored.base_params, stored.shiftTable(program));
+    try std.testing.expectEqual(
+        stored.base_params,
+        layoutFor(stored, 0, program).base_params,
+    );
+
+    var lifted = stored;
+    lifted.mode = .lifted;
+    lifted.base_params = 0;
+    try std.testing.expectEqual(@as(u32, 0), layoutFor(lifted, 0, program).base_params);
+}
+
 test "the default metallib path is the eval-domain entry in the approved manifest" {
     // The path the product resolves and the manifest entry that admits it must
     // not drift apart: a rename on one side has to fail here rather than at a
@@ -533,4 +803,18 @@ test "the default metallib path is the eval-domain entry in the approved manifes
     }
     try std.testing.expect(found);
     try std.testing.expect(std.mem.endsWith(u8, default_metallib_path, metallib_leaf));
+}
+
+test "the stored-domain path is the stored-domain entry in the approved manifest" {
+    var found = false;
+    for (composition_aot.approved_metallibs) |approved| {
+        if (std.mem.eql(u8, approved.label, "air_template_composition_stored_domain_v1"))
+            found = true;
+    }
+    try std.testing.expect(found);
+    try std.testing.expect(std.mem.endsWith(
+        u8,
+        default_stored_metallib_path,
+        stored_metallib_leaf,
+    ));
 }

--- a/src/integrations/cairo_metal/composition_stage.zig
+++ b/src/integrations/cairo_metal/composition_stage.zig
@@ -111,13 +111,21 @@ pub const metallib_env = "STWO_ZIG_COMPOSITION_METALLIB";
 /// artifact did.
 pub const metallib_leaf = "air_template_composition_eval_domain.metallib";
 
-/// Set to `0` to pin the stage to the Option-A (lifted, Library 1) path.
+/// Set to `1` to prefer the stored-domain (Library 2) tier over Option A.
 ///
-/// Increment 3.15's default is stored-domain **preferred**: when the hook is
-/// armed the stage tries Library 2 first and only falls to Option A if that tier
-/// declines. The switch exists so the two paths are an env-only pairing off one
-/// build, which is what made 3.13's gate clean, and so a deployment that
-/// distrusts the new tier can pin the measured one without a rebuild.
+/// **The default is off, and increment 3.15 turned it off on measurement rather
+/// than on caution.** The tier is byte-exact on all seven portfolio workloads
+/// and resolves the same component census Option A does, but it buys nothing:
+/// every column the product commits is already at evaluation-domain length
+/// (`composition_eval_arena`'s `Volume` diagnostic reports `shifts 1-1` on every
+/// workload), so Library 2's reader computes the identity map, reads the same
+/// words through one extra indirection, and the staging pass it was built to
+/// shrink was never a duplication. Paired A-B-B-A puts the composition stage at
+/// parity within noise. Preferring it by default would trade a measured path for
+/// an unmeasured one at zero gain.
+///
+/// It stays reachable, and armed it is an env-only pairing off one build, which
+/// is what a future column set committed at trace-domain length would need.
 pub const stored_domain_env = "STWO_ZIG_COMPOSITION_STORED_DOMAIN";
 /// Overrides the *stored-domain* library path, independently of `metallib_env`.
 /// Two libraries, two overrides: the corrupt-Library-2 fail-back test has to be
@@ -233,10 +241,10 @@ fn declineName(mode: eval_arena.Mode, reason: Decline) []const u8 {
     };
 }
 
-/// True unless the process pinned the stage to Option A.
+/// True only when the process asked for the stored-domain tier.
 fn storedDomainPreferred() bool {
-    const text = std.posix.getenv(stored_domain_env) orelse return true;
-    return !std.mem.eql(u8, text, "0");
+    const text = std.posix.getenv(stored_domain_env) orelse return false;
+    return std.mem.eql(u8, text, "1");
 }
 
 fn open(
@@ -709,6 +717,12 @@ test "the enable switch and the path override are named, not guessed" {
         "vectors/cairo/official/air_template_composition_eval_domain.metallib",
         default_metallib_path,
     );
+}
+
+test "the stored-domain tier is opt-in, and 3.13's Option-A default is intact" {
+    // 3.15 measured the tier at parity and left the measured path in charge.
+    // A default flip has to change this line, which is where the reason lives.
+    try std.testing.expect(!storedDomainPreferred());
 }
 
 test "the stored-domain tier is named apart from the eval-domain tier" {


### PR DESCRIPTION
## Increment 3.15: Library-2 (stored-domain) consumption — measured at parity, Option A left in charge

Resumption of the Metal residency program toward the ≥1.6× bar. This increment taught the eval arena a **stored-domain mode** (trace-domain columns placed unlifted, per-column shift table in the parameter block per the 3.10 layout contract, `stwo_zig_eval_sd_*` kernel resolution against the digest-admitted Library 2, three-tier fallback stored→lifted→host).

**Honest headline: the stored-domain tier measured at parity with Option A in the product path** — the 1.22–2.26× kernel advantage from the 3.10 JIT pricing did not survive contact with in-situ staging — so the selection deliberately leaves **Option A (lifted, Library 1) as the default**, with the stored-domain tier landed, admitted, and env-selectable for future work.

Commits:
- `bcd70481` — the arena stored-domain mode
- `847a7a59` — staging pricing, stored vs eval-domain
- `90ead7d5` — measurement + the parity verdict, Option A default
- transcript `session-16.md` (checkpoint commit — session ended at wind-down; the agent's final note section and full seven-workload verification table should be reviewed against the transcript before merge)

**Review status: draft.** Byte-exactness and the three-commit evidence are in the transcript; the binding 3.14 seven-workload checklist may be incomplete for this head — run it before merging (`test-cairo-cpu-product test-cairo-frontend test-cairo-metal-product package-workspace metal-check` + the seven-row digest set).

Program state after this increment: Metal remains 1.013× faster than Rust portfolio-wide; the remaining levers to 1.6× are the PoW device kernel (110–145 ms/proof — mint spec to follow on a fresh issue), Phase-4 witness residency (pedersen acceptance row), and the quarantined Phase-2 interaction residency pending coordination with main's resident-LogUp line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
