### PR TITLE
Bound the load_store base so its effective address cannot alias

### DIFF
--- a/src/frontends/riscv/air/semantics/load_store.zig
+++ b/src/frontends/riscv/air/semantics/load_store.zig
@@ -1,4 +1,13 @@
 //! Exact pinned Stark-V byte/half/word load-store semantics and lookups.
+//!
+//! The effective address is a base-field sum, `composeU32(rs1.next) + imm_felt`,
+//! and the base field is not `2^32`. That is only the architectural address
+//! while the sum stays inside the canonical range of `M31 = 2^31 - 1`, so the
+//! base carries an explicit bound: its high limb is pinned to zero, which puts
+//! every admitted base below `2^24` and therefore more than a displacement away
+//! from the modulus. Without that bound a base within one displacement below
+//! the modulus wraps onto a small, word-aligned address and names a different
+//! memory word than the architecture does (issue #140).
 
 const std = @import("std");
 const QM31 = @import("stwo_core").fields.qm31.QM31;
@@ -9,7 +18,7 @@ pub fn Semantics(comptime S: type) type {
         const ops = common.Ops(S);
 
         pub const N_ORACLE_COLUMNS: usize = 56;
-        pub const N_CONSTRAINTS: usize = 69;
+        pub const N_CONSTRAINTS: usize = 70;
         pub const CURRENT_TRACE_COMPATIBLE = true;
 
         pub const Row = struct {
@@ -252,6 +261,23 @@ pub fn Semantics(comptime S: type) type {
                 out[n] = S.one().sub(d.is_load).mul(limb);
                 n += 1;
             }
+            // The address is a base-field sum, so it is the architectural address
+            // only while `base + imm` stays below `M31`. The aligned-address
+            // `range_check_20` confines every admitted address to `[0, 2^22)` and
+            // the displacement is a signed 12-bit field, so an honest base is
+            // always below `2^22 + 2^11`. Pinning the base's high limb to zero
+            // bounds it by `2^24`: above every address this AIR can admit, and
+            // more than a displacement below the modulus, so the sum cannot wrap.
+            // The bound reads the remaining limbs as bytes, which is the memory
+            // bus's job here as it is for every other family's operand
+            // arithmetic — each register write is byte-range-checked by the
+            // family that made it.
+            // Only rows whose field address already disagrees with their
+            // architectural address are lost — `LW x7, 8(x5)` with
+            // `x5 = 0x7ffffffb` is architecturally the misaligned `0x80000003`
+            // but the field sum is the clean `0x00000004` (issue #140).
+            out[n] = enabler.mul(row.rs1.next[3]);
+            n += 1;
             std.debug.assert(n == out.len);
             return .{ .values = out };
         }
@@ -368,6 +394,54 @@ pub fn Semantics(comptime S: type) type {
                 .destination = .{
                     .nonzero = S.one(),
                     .inverse = ops.q(2).inv() catch unreachable,
+                },
+            };
+        }
+
+        /// An `LW x7, imm(x5)` row that reads `0xdeadbeef` from `address`.
+        ///
+        /// The address is supplied rather than derived so the caller can build
+        /// both an honest row and the issue #140 row whose field address and
+        /// architectural address disagree.
+        fn wordLoad(base: u32, imm: u32, address: u32) Row {
+            var rs1 = zeroAccess();
+            rs1.addr = ops.q(5);
+            for (&rs1.next, 0..) |*limb, i| {
+                limb.* = ops.q((base >> @as(u5, @intCast(8 * i))) & 0xff);
+            }
+            rs1.previous = rs1.next;
+            var src = zeroAccess();
+            src.addr = ops.q(address);
+            src.next = .{ ops.q(0xef), ops.q(0xbe), ops.q(0xad), ops.q(0xde) };
+            src.previous = src.next;
+            var dst = zeroAccess();
+            dst.addr = ops.q(7);
+            dst.next = src.next;
+            return .{
+                .clk = S.one(),
+                .pc = ops.q(0x1000),
+                .dst = dst,
+                .rs1 = rs1,
+                .src = src,
+                .r2_idx = ops.q(7),
+                .imm_felt = ops.q(imm),
+                .src_msb = S.zero(),
+                .shift_amount = S.zero(),
+                .src_addr_selector = ops.q(address),
+                .dst_addr_selector = ops.q(7),
+                .markers = .{S.zero()} ** 4,
+                .is_lb = S.zero(),
+                .is_lh = S.zero(),
+                .is_lbu = S.zero(),
+                .is_lhu = S.zero(),
+                .is_lw = S.one(),
+                .is_sb = S.zero(),
+                .is_sh = S.zero(),
+                .is_sw = S.zero(),
+                .result = src.next,
+                .destination = .{
+                    .nonzero = S.one(),
+                    .inverse = ops.q(7).inv() catch unreachable,
                 },
             };
         }
@@ -498,6 +572,39 @@ pub fn Semantics(comptime S: type) type {
                     try std.testing.expect(accesses.src.next.addr_space.isZero());
                     try std.testing.expect(accesses.dst.next.addr_space.eql(S.one()));
                     try std.testing.expect(programLookup(row).opcode_id.eql(ops.q(26)));
+                }
+
+                test "load store: a base near the field modulus cannot alias an address" {
+                    // Issue #140. `LW x7, 8(x5)` with `x5 = 0x7ffffffb` is
+                    // architecturally a load from `0x80000003`, which is not even
+                    // word aligned, so the architecture traps. The base-field sum
+                    // wraps the modulus and lands on `0x00000004` instead. Every
+                    // other constraint in the family accepts that row, so the base
+                    // bound has to be the one that rejects it — the count below
+                    // fails if some unrelated edit starts carrying this witness.
+                    const aliased = wordLoad(0x7ffffffb, 8, 4);
+                    var fired: usize = 0;
+                    for (evaluate(aliased).values) |value| {
+                        if (!value.isZero()) fired += 1;
+                    }
+                    try std.testing.expectEqual(@as(usize, 1), fired);
+                    try std.testing.expect(
+                        !evaluate(aliased).values[N_CONSTRAINTS - 1].isZero(),
+                    );
+
+                    // Nothing an honest program can reach is lost: the aligned
+                    // address range check already bounds the address by `2^22`, and
+                    // both an ordinary base and the largest admitted address stay
+                    // accepted.
+                    try std.testing.expect(evaluate(wordLoad(0x2000, 8, 0x2008)).allZero());
+                    try std.testing.expect(
+                        evaluate(wordLoad(0x3ffffc, 0, 0x3ffffc)).allZero(),
+                    );
+                    // A negative displacement still reaches through the field wrap
+                    // it is encoded with.
+                    var negative = wordLoad(0x2010, 0, 0x2000);
+                    negative.imm_felt = S.zero().sub(ops.q(16));
+                    try std.testing.expect(evaluate(negative).allZero());
                 }
 
                 test "load store: adapter follows exact role and flag order" {


### PR DESCRIPTION
Closes #140.

`src/frontends/riscv/air/semantics/load_store.zig` computes the effective
address as `mem_addr = composeU32(rs1.next) + imm_felt` in the M31 base field,
not modulo `2^32`. The only bound on the base was the `range_check_m31` on
`(rs1_next_0, rs1_next_3)`, which forces the high limb below 128 — so the base
could be anything below `2^31`, including a value within one displacement of the
modulus. There the field sum wraps onto a small, word-aligned address that
satisfies the aligned-address `range_check_20`, while the architectural 32-bit
address is somewhere else entirely.

## The witness, before and after

Reproduced against a fresh export on `main` (`zig build riscv-refinement-ir
-Driscv-refinement-ir-dir=zig-out/team-b-ir`, then
`scripts/riscv_team_b_witnesses.py` from the Team B branch):

**Before**

```
LH non-vacuity: 7 witnesses reachable in the exported production AIR
DIV non-vacuity: 15 witnesses reachable in the exported production AIR, covering every exceptional case
multiply non-vacuity: 12 witnesses reachable in the exported production AIR
shift non-vacuity: 13 witnesses reachable in the exported production AIR
load_store address aliasing (TRACKED GAP): base 0x7ffffffb + 8 is architecturally
0x80000003 but the AIR admits a read of 0x00000004; every constraint and range check passes
```

**After**

```
witness gate failed: the tracked load_store address-aliasing row is no longer admitted
by the production AIR (witness does not satisfy production AIR constraint roots 69).
That is good news, but the Lean baseInFieldRange premise and the note in TEAM_B.md now
overstate the gap and must be updated.
LH non-vacuity: 7 witnesses reachable in the exported production AIR
DIV non-vacuity: 15 witnesses reachable in the exported production AIR, covering every exceptional case
multiply non-vacuity: 12 witnesses reachable in the exported production AIR
shift non-vacuity: 13 witnesses reachable in the exported production AIR
```

The aliasing row is rejected by exactly one constraint root — 69, the new one —
and every honest witness in `scripts/riscv_team_b_witnesses.py` still passes,
including `top-admitted-address` (base `0x3ffffc`), `negative-displacement`,
`destination-x0` and `destination-aliases-source`. The gate's non-zero exit is
its deliberate tracked-gap behaviour: it raises when the gap closes, so that the
Lean premise and the note get revisited.

`load_store.zig` also gains a row-local regression test that pins the shape:
the aliasing row now fires exactly one constraint (so the test fails if some
later edit re-admits it), and an ordinary base, the largest admitted address,
and a negative displacement all stay accepted.

## The fix, and the option that was not taken

**Chosen — option (a), bound the base.** One degree-2 constraint pins the base's
high limb to zero on every active row:

```zig
out[n] = enabler.mul(row.rs1.next[3]);
```

That bounds the base by `2^24`, so `base + imm` cannot leave the canonical field
range for any 12-bit displacement. **No honest row is lost.** The aligned-address
`range_check_20` already confines every admitted address to `[0, 2^22)`, and the
displacement is a signed 12-bit field, so an honest access — one whose field
address equals its architectural address — always has a base below `2^22 + 2^11`.
Any base at or above `2^24` yields an address above `2^24 - 2^11`, which the
aligned-address range check already rejected, unless the field wrapped — which is
exactly the attack. The rows removed are precisely the rows whose field address
already disagreed with their architectural address. Guest linker scripts place
text, data and stack below `0x300000` (`vectors/riscv_guests/*/linker.ld`,
`conformance/riscv/arch-test/link.ld`), well inside the bound.

The issue suggested an explicit `< M31 - 4096` range check. None of the six
shipped preprocessed tables can express a bound near the modulus — they are
8/11/16/20-bit product domains — so that would need a **new** preprocessed table,
i.e. a new relation domain, a new preprocessed component and new interaction
columns. The high-limb constraint is free and implies a strictly tighter bound.
A middle option was also considered and rejected: swapping the base's
`range_check_m31` request for a `range_check_8_8_4` on
`(rs1_next_0, rs1_next_1, rs1_next_3)` bounds the high limb below 16 (base
`< 2^28`) at identical entry count and zero constraint cost, but it is subtler to
read and to transcribe, it moves the lookup list that both the Lean transcription
and the domain-order test pin, and four extra bits of headroom buy nothing
against a `2^22` address space.

**Not taken — option (b), address arithmetic modulo `2^32` with a carry
decomposition**, the `jalr`/`auipc` pattern. Cost: 7 new committed columns
(`imm_byte_0`, `imm_nibble`, `imm_sign`, four address limbs), so
`N_ORACLE_COLUMNS` 56 → 63; about 7 new constraints (immediate booleanity, the
immediate composition, four byte carries, the address binding); 4 new lookup
requests (two `range_check_8_8` for the middle address bytes, one
`range_check_m31` for the outer pair to kill the `+M31` decomposition alias, one
`range_check_8_8_4` for the immediate decomposition), so the entry count goes
16 → 20, the batch count 8 → 10 and interaction columns 32 → 40; plus
witness-generator and trace-layout changes in `runner/`, plus a wholesale
re-transcription of the Lean capsule instead of a one-constraint delta.

What (b) buys over (a) is *completeness*, not soundness: it would admit an
architectural 32-bit address wrap (a base near `2^32` plus a displacement landing
in low memory). That is unreachable here — the aligned-address range check bounds
every admitted address by `2^22`, and the existing `range_check_m31` already
refuses any base at or above `2^31`, so wrap has never been admitted by this AIR.
Both options discharge the Lean premise equally well, so the cheap one wins.

## Cost

| | before | after |
| --- | --- | --- |
| committed columns | 56 | 56 |
| exported columns (with bus aliases) | 64 | 64 |
| family constraints | 69 | 70 |
| exported constraint roots | 78 | 79 |
| lookup entries / domains / order | 16 | 16, unchanged |
| interaction columns | 32 | 32 |
| max constraint degree | 3 | 3 |

Nothing in `src/frontends/riscv/runner/` needed to change: there are no new
committed columns, so the witness generator is already in sync, and honest traces
already carry a zero high limb.

## The same pattern elsewhere

Checked, and reported rather than changed (this PR fixes only `load_store`):

* **`jalr`** — not affected. It already adds the sign-extended immediate to `rs1`
  modulo `2^32` with an explicit byte-carry recurrence, range-checks all four
  `rs1` bytes row-locally, and binds the target through the bounded `target / 4`
  split. Its header comment already says wraparound "does not rely on an M31
  field alias".
* **`auipc`** — not affected, same shape: `pc` limbs plus immediate limbs with
  byte carries, every limb range-checked.
* **`jal`, `branch_eq`, `branch_lt`** — these do use the same base-field pattern
  (`pc + imm_felt`, `pc + imm_felt*cmp + 4*(1 - cmp)` feeding the
  `registers_state` emit tuple), but the unbounded-looking addend is `pc`, not a
  register. The row's `pc` is pinned by the `program_access` lookup to a committed
  ROM address, and the emitted next pc must be consumed by the next row's
  state/program pair or be the public final pc. Program addresses are bounded at
  `2^30 - 4` by the profile (`isa/profile.zig`, 30-bit program-commitment leaf
  domain) and `|imm| <= 2^20` for JAL, `<= 2^12` for branches, so
  `pc + imm < 2^30 + 2^20`, far below `M31`: no field wrap is reachable. The
  negative-displacement encoding wraps exactly once, which is the correct
  subtraction when `pc >= |imm|` and otherwise lands far outside the ROM, so the
  row is unprovable — matching the architecture, which would fetch outside the
  program. So the pattern is present but guarded by a global bound (the program
  commitment) rather than a row-local one. Worth making explicit in a follow-up;
  it is not the same defect, because there the addend is not prover-chosen.

`load_store` was the only family where the addend came from a register, which
nothing bounds below `2^31`.

## What this relies on

That limbs 1 and 2 of `rs1.next` are bytes. That comes from the memory bus —
every register write is byte-range-checked by the family that made it — exactly
as every other family's operand arithmetic relies on it, and the Lean model has
it by typing (`rs1Next : WordBytes`).

## Verification

* `zig build test-riscv-cpu-product` — pass.
* `zig build test-riscv-air-satisfaction` — pass. This is the strongest honest-side
  evidence: real proving runs are exported and an independent Python checker
  re-decides every committed row against the exported IR; `load_store` is now
  checked at 71 constraints (70 family + placement) and every real trace satisfies
  them.
* `zig build test-riscv-prover-core` — pass.
* `python3 scripts/air_uniqueness.py check zig-out/team-b-ir/load_store.json` —
  `verdict: unsat`, `constraints satisfiable: True`, `max_degree=3`: per-row
  uniqueness is preserved and the system stays non-vacuous.
* The witness gate above.

## Downstream: the digest moves

This **moves the exported `load_store` AIR digest**:

```
50339969c53a84fa57fad5a371f2208892c5b08514eafcfd3289f077efc18ce4   (before)
cadb1b662ec30864615aa84541c1bcd863e921f306446ea1c7a328c650180b20   (after)
```

So `formal/riscv-refinement/RiscvRefinement/Air/Family/LoadStore.lean`'s
`loadStoreIrDigest`, the `LoadStoreHolds` capsule (one new conjunct;
constraint indices C0–C68 are deliberately unchanged, the new constraint is C69,
and only the placement/alias roots after it shift by one), the
`baseInFieldRange` premise in
`formal/riscv-refinement/RiscvRefinement/Opcodes/LoadStore.lean` — which is now
**dischargeable from the AIR** rather than assumed, via `rs1Next.byte3 = 0` →
`base < 2^24` → `base + 4096 < 2^31 - 1` — the note in
`formal/riscv-refinement/TEAM_B.md`, and the tracked-gap check in
`scripts/riscv_team_b_witnesses.py` all have to be re-derived. That belongs on the
Team B branch and is deliberately **not** attempted here.

## Not done, on purpose

No end-to-end forged-trace case in `src/tests/riscv/`. The runner cannot emit this
row — it rejects the misaligned architectural access before retirement — so an
end-to-end case would have to hand-build a bus-consistent committed forgery. The
row-local family test plus the exported-AIR witness gate pin the defect from both
sides; a forgery-harness case is a reasonable follow-up.
