### PR TITLE
W1: cairo_cpu + cairo_metal boards, cairo_proof_v1 parser (TRACKS §3, §8)

### DIFF
--- a/autoresearch/MANIFEST.json
+++ b/autoresearch/MANIFEST.json
@@ -644,6 +644,172 @@
           }
         }
       },
+      "cairo_cpu": {
+        "enabled": true,
+        "promotion_eligible": false,
+        "promotion_blocked_reason": "TRACKS §7: cairo_cpu records evidence but cannot promote until per-(board, class) A/A dispersion and anchors are measured on the designated Apple M5 Max judge host and frozen into harness.anchor_* plus a cairo calibration freeze for board cairo_cpu. No Cairo calibration exists yet, so promotion fails closed; the gate opens only after that M5 calibration is committed.",
+        "board": "cairo_cpu",
+        "build_step": "zig build stwo-cairo-cpu -Doptimize=ReleaseFast",
+        "binary": "zig-out/bin/stwo-cairo-cpu",
+        "report_schema": "cairo_proof_v1",
+        "correctness_oracle": {
+          "authority": "official-stwo-cairo-verifier",
+          "repository": "https://github.com/starkware-libs/stwo-cairo",
+          "commit": "82f21252a68ec006d73e299f5bf1ce6d4db0ee78",
+          "stwo_repository": "https://github.com/starkware-libs/stwo",
+          "stwo_commit": "7b211edde786775016ef3eecb837a6240d8fe792",
+          "adapter": "tools/stwo-cairo-official-verifier-rs",
+          "build_command": "cargo build --locked --release --manifest-path tools/stwo-cairo-official-verifier-rs/Cargo.toml",
+          "final_validator": true
+        },
+        "acceptance_corpus": {
+          "note": "TRACKS §3.3 acceptance corpus: the pinned zksecurity/zkvm-benchmarks program matrix with expected cycle rules. Acceptance only — never a scored basket.",
+          "path": "vectors/cairo/cairo_program_matrix.json",
+          "sha256": "4a639d0b3254be24bdc106d22dc07fa76afdb9e9251ae319d60060b8300e876a"
+        },
+        "gates_policy": {
+          "warmups": 1,
+          "samples_per_round": 1,
+          "min_rounds": 3,
+          "max_rounds": 5,
+          "wall_clock_cap_seconds": {
+            "small": 900,
+            "wide": 3600
+          },
+          "note": "The Cairo product CLI proves exactly one statement per process, so one sample is one cold process; the runner owns the warmup/sample loop. Warmups must stay at or above one because the mandatory phase profile is recorded on a discarded warmup so scored samples run uninstrumented."
+        },
+        "mechanism_telemetry": {
+          "fail_closed": true,
+          "required_fields": [
+            "product_identity_sha256",
+            "protocol_manifest_sha256",
+            "profile",
+            "input_sha256",
+            "proof_format",
+            "proof_bytes",
+            "proof_sha256",
+            "stwo_cairo_revision",
+            "stwo_revision",
+            "mean_execute_seconds",
+            "mean_prove_seconds",
+            "mean_verify_seconds",
+            "mean_cold_process_seconds",
+            "phase_seconds"
+          ]
+        },
+        "workload_provisioning": {
+          "note": "TRACKS §3.3 campaign portfolio entries whose prover inputs are host-local and far above the repository fixture budget. They are declared here so the basket's incompleteness is loud, never silent; generation commands live in autoresearch/schema/cairo-proof-v1.md. Entries here are not runnable workloads and are never scored.",
+          "documentation": "autoresearch/schema/cairo-proof-v1.md",
+          "pending": {
+            "cairo_poseidon_aggregator": {
+              "vm_steps": 6892,
+              "committed_cells": 48299328,
+              "reason": "prover input is host-local; regeneration needs the pinned Cairo VM adapter and the campaign aggregator program, neither of which is committed"
+            },
+            "cairo_pedersen_aggregator": {
+              "vm_steps": 5872,
+              "committed_cells": 48037024,
+              "reason": "prover input is host-local; regeneration needs the pinned Cairo VM adapter and the campaign aggregator program, neither of which is committed"
+            },
+            "cairo_fibonacci_100k": {
+              "vm_steps": 700022,
+              "committed_cells": 112959872,
+              "reason": "prover input is host-local; 700k VM steps exceed the repository fixture budget"
+            },
+            "cairo_factorial_100k": {
+              "vm_steps": 600015,
+              "committed_cells": 123184848,
+              "reason": "prover input is host-local; 600k VM steps exceed the repository fixture budget"
+            },
+            "cairo_arithmetic_2m": {
+              "vm_steps": 2200019,
+              "committed_cells": 216639776,
+              "reason": "prover input is host-local; 2.2M VM steps exceed the repository fixture budget"
+            },
+            "cairo_memory_7m": {
+              "vm_steps": 7367979,
+              "committed_cells": 604162096,
+              "reason": "prover input is host-local; 7.37M VM steps exceed the repository fixture budget and the workload needs roughly 17-18 GiB resident memory"
+            }
+          }
+        },
+        "workloads": {
+          "cairo_all_opcodes": {
+            "class": "small",
+            "args": "prove --prover-input vectors/cairo/official/all_opcodes.prover_input.json --params vectors/cairo/official/all_opcodes.params.json --proof-format json --verify",
+            "native_unit": "committed cells"
+          },
+          "cairo_all_builtins": {
+            "class": "wide",
+            "args": "prove --prover-input vectors/cairo/official/all_builtins.prover_input.json --params vectors/cairo/official/all_builtins.params.json --proof-format json --verify",
+            "native_unit": "committed cells"
+          }
+        }
+      },
+      "cairo_metal": {
+        "enabled": false,
+        "promotion_eligible": false,
+        "disabled_reason": "cairo_metal is staged only: TRACKS §2 records the Cairo + Metal product as parity_gated, not released. The product descriptor in build_support/products/cairo_metal.zig still carries state .parity_gated behind its test-cairo-metal-product and test-cairo-metal-oracle release gates, no Metal-lane Cairo calibration exists on the designated judge host, and the generalized per-board Metal calibration (TRACKS §7) is not yet built. The group stays dark and fails closed.",
+        "promotion_blocked_reason": "TRACKS §7: no cairo_metal calibration exists on the designated Apple M5 Max judge host, and the product is parity_gated rather than released.",
+        "board": "cairo_metal",
+        "build_step": "zig build stwo-cairo-metal -Doptimize=ReleaseFast",
+        "binary": "zig-out/bin/stwo-cairo-metal",
+        "report_schema": "cairo_proof_v1",
+        "correctness_oracle": {
+          "authority": "official-stwo-cairo-verifier",
+          "repository": "https://github.com/starkware-libs/stwo-cairo",
+          "commit": "82f21252a68ec006d73e299f5bf1ce6d4db0ee78",
+          "stwo_repository": "https://github.com/starkware-libs/stwo",
+          "stwo_commit": "7b211edde786775016ef3eecb837a6240d8fe792",
+          "adapter": "tools/stwo-cairo-official-verifier-rs",
+          "build_command": "cargo build --locked --release --manifest-path tools/stwo-cairo-official-verifier-rs/Cargo.toml",
+          "final_validator": true
+        },
+        "gates_policy": {
+          "warmups": 1,
+          "samples_per_round": 1,
+          "min_rounds": 3,
+          "max_rounds": 5,
+          "wall_clock_cap_seconds": {
+            "small": 900,
+            "wide": 3600
+          },
+          "note": "Mirrors cairo_cpu: one proof per cold process, phase profile recorded on a discarded warmup."
+        },
+        "mechanism_telemetry": {
+          "fail_closed": true,
+          "required_fields": [
+            "product_identity_sha256",
+            "protocol_manifest_sha256",
+            "profile",
+            "input_sha256",
+            "proof_format",
+            "proof_bytes",
+            "proof_sha256",
+            "stwo_cairo_revision",
+            "stwo_revision",
+            "mean_execute_seconds",
+            "mean_prove_seconds",
+            "mean_verify_seconds",
+            "mean_cold_process_seconds",
+            "phase_seconds",
+            "metal_dispatches",
+            "cpu_fallbacks"
+          ]
+        },
+        "workloads": {
+          "mcairo_all_opcodes": {
+            "class": "small",
+            "args": "prove --prover-input vectors/cairo/official/all_opcodes.prover_input.json --params vectors/cairo/official/all_opcodes.params.json --proof-format json --verify",
+            "native_unit": "committed cells"
+          },
+          "mcairo_all_builtins": {
+            "class": "wide",
+            "args": "prove --prover-input vectors/cairo/official/all_builtins.prover_input.json --params vectors/cairo/official/all_builtins.params.json --proof-format json --verify",
+            "native_unit": "committed cells"
+          }
+        }
+      },
       "pr6_supremacy": {
         "enabled": false,
         "promotion_eligible": false,

--- a/autoresearch/cli/stwo_perf/ledger.py
+++ b/autoresearch/cli/stwo_perf/ledger.py
@@ -41,9 +41,17 @@ EVIDENCE_KINDS = ("promotion", "span_audit", "direct_audit")
 OUTCOMES = ("promoted", "neutral", "rejected")
 
 # Scoring boards (schema/scoring.md). Kernel results never enter the ledger.
+#
+# APPEND ONLY. Removing a name silently drops its history from the site feed
+# (TRACKS §6), so retired boards keep their entry forever. Campaign v3 (TRACKS
+# §2, §3.4, §8) appends the wave-1 Cairo tracks plus the pr6_supremacy
+# objective board, which must be registered here before it can ever write a
+# row — objective boards that are absent from BOARDS are the current gap
+# TRACKS §3.4 names explicitly.
 BOARDS = (
     "core_cpu", "core_hybrid", "core_metal", "core_cuda",
     "heavy_native", "heavy_cairo", "stream", "riscv",
+    "cairo_cpu", "cairo_metal", "pr6_supremacy",
 )
 
 _FLOAT_COLS = {"judged_r", "ci_low", "ci_high", "prove_ms", "native_mhz", "peak_rss_mib"}

--- a/autoresearch/cli/stwo_perf/manifest.py
+++ b/autoresearch/cli/stwo_perf/manifest.py
@@ -14,6 +14,11 @@ REPORT_SCHEMA_VERSIONS = {
     "native_cuda_product_v6": 6,
     "pr6_supremacy_v1": 1,
     "riscv_proof_v2": 2,
+    # Harness envelope version for the Cairo frontend products. It is NOT the
+    # product report's own schema_version (that is pinned separately in
+    # runner.CAIRO_PRODUCT_REPORT_SCHEMA_VERSION); see
+    # autoresearch/schema/cairo-proof-v1.md.
+    "cairo_proof_v1": 1,
 }
 
 GROUP_GATES_POLICY_LIMITS = {
@@ -66,6 +71,47 @@ RISCV_RESOURCE_TELEMETRY = {
         "cycles",
     ],
 }
+CAIRO_MECHANISM_FIELDS = frozenset({
+    "product_identity_sha256",
+    "protocol_manifest_sha256",
+    "profile",
+    "input_sha256",
+    "proof_format",
+    "proof_bytes",
+    "proof_sha256",
+    "stwo_cairo_revision",
+    "stwo_revision",
+    "mean_execute_seconds",
+    "mean_prove_seconds",
+    "mean_verify_seconds",
+    "mean_cold_process_seconds",
+    "phase_seconds",
+    "metal_dispatches",
+    "cpu_fallbacks",
+})
+# Semantics, not implementation: these must be byte-identical across the A and
+# B arms of a paired Cairo round and across rounds. Identity and protocol
+# digests are deliberately excluded because they bind the arm's own source.
+CAIRO_STABLE_MECHANISM_FIELDS = frozenset({
+    "profile",
+    "input_sha256",
+    "proof_format",
+    "proof_bytes",
+    "proof_sha256",
+    "stwo_cairo_revision",
+    "stwo_revision",
+})
+# TRACKS §3.2: the named phase cutpoints every Cairo track must publish.
+CAIRO_PHASE_NAMES = (
+    "execute",
+    "witness",
+    "commit",
+    "interaction",
+    "composition",
+    "fri",
+    "serialize",
+    "verify",
+)
 PR6_MECHANISM_TELEMETRY = {
     "fail_closed": True,
     "required_fields": [
@@ -137,6 +183,9 @@ class WorkloadGroup:
     correctness_oracle: dict = field(default_factory=dict)
     mechanism_telemetry: dict = field(default_factory=dict)
     resource_telemetry: dict = field(default_factory=dict)
+    promotion_blocked_reason: str | None = None
+    acceptance_corpus: dict = field(default_factory=dict)
+    workload_provisioning: dict = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -227,6 +276,9 @@ class Manifest:
                 correctness_oracle=dict(spec.get("correctness_oracle", {})),
                 mechanism_telemetry=dict(spec.get("mechanism_telemetry", {})),
                 resource_telemetry=dict(spec.get("resource_telemetry", {})),
+                promotion_blocked_reason=spec.get("promotion_blocked_reason"),
+                acceptance_corpus=dict(spec.get("acceptance_corpus", {})),
+                workload_provisioning=dict(spec.get("workload_provisioning", {})),
             ))
         return out
 
@@ -385,6 +437,7 @@ def load(root: Path | None = None) -> Manifest:
     except json.JSONDecodeError as exc:
         raise ManifestError(f"invalid MANIFEST.json: {exc}") from exc
     _validate(raw)
+    _validate_acceptance_corpora(repo, raw)
     groups = raw["workload_registry"]["groups"]
     if "cuda" in groups:
         try:
@@ -484,6 +537,12 @@ def _validate(raw: dict) -> None:
         _validate_group_resource_telemetry(
             gid, report_schema, spec.get("resource_telemetry", {})
         )
+        _validate_group_acceptance_corpus(gid, spec.get("acceptance_corpus", {}))
+        _validate_group_workload_provisioning(
+            gid, spec.get("workload_provisioning", {}), spec.get("workloads", {})
+        )
+        if report_schema == "cairo_proof_v1":
+            _validate_cairo_group(gid, spec)
         if not isinstance(spec["workloads"], dict) or not spec["workloads"]:
             raise ManifestError(f"workload group {gid}: workloads must be a non-empty object")
         for wid, w in spec["workloads"].items():
@@ -556,6 +615,9 @@ def _validate_group_mechanism_telemetry(
                 "Metal dispatch/synchronization/fallback counters"
             )
         return
+    if report_schema == "cairo_proof_v1":
+        _validate_cairo_mechanism_telemetry(gid, telemetry)
+        return
     if report_schema != "riscv_proof_v2":
         return
     if set(telemetry) != {"fail_closed", "required_fields"}:
@@ -585,6 +647,225 @@ def _validate_group_mechanism_telemetry(
             f"workload group {gid}: mechanism telemetry omits stable field(s): "
             + ", ".join(missing)
         )
+
+
+def _validate_cairo_mechanism_telemetry(gid: str, telemetry: object) -> None:
+    """TRACKS §3.2: Cairo phase and identity telemetry is mandatory, fail-closed."""
+    if not isinstance(telemetry, dict) or set(telemetry) != {
+        "fail_closed", "required_fields",
+    }:
+        raise ManifestError(
+            f"workload group {gid}: Cairo mechanism_telemetry requires exactly "
+            "fail_closed and required_fields"
+        )
+    if telemetry["fail_closed"] is not True:
+        raise ManifestError(
+            f"workload group {gid}: Cairo mechanism telemetry must fail closed"
+        )
+    fields = telemetry["required_fields"]
+    if (not isinstance(fields, list) or not fields or
+            any(not isinstance(name, str) for name in fields) or
+            len(fields) != len(set(fields))):
+        raise ManifestError(
+            f"workload group {gid}: mechanism required_fields must be a unique "
+            "non-empty list"
+        )
+    unknown = sorted(set(fields) - CAIRO_MECHANISM_FIELDS)
+    if unknown:
+        raise ManifestError(
+            f"workload group {gid}: unsupported mechanism field(s): "
+            + ", ".join(unknown)
+        )
+    missing = sorted(CAIRO_STABLE_MECHANISM_FIELDS - set(fields))
+    if missing:
+        raise ManifestError(
+            f"workload group {gid}: mechanism telemetry omits stable field(s): "
+            + ", ".join(missing)
+        )
+    if "phase_seconds" not in fields:
+        raise ManifestError(
+            f"workload group {gid}: Cairo mechanism telemetry must require "
+            "phase_seconds; TRACKS §3.2 makes the named phase cutpoints mandatory"
+        )
+
+
+def _validate_cairo_group(gid: str, spec: dict) -> None:
+    """Cairo tracks are oracle-pinned and never promotion eligible in wave 1."""
+    if spec.get("promotion_eligible"):
+        raise ManifestError(
+            f"workload group {gid}: no Cairo board may be promotion eligible "
+            "before its judge-host calibration is frozen (TRACKS §7)"
+        )
+    if not str(spec.get("promotion_blocked_reason") or "").strip():
+        raise ManifestError(
+            f"workload group {gid} cannot promote and states no "
+            "promotion_blocked_reason; a silently unpromotable Cairo board is "
+            "not allowed"
+        )
+    oracle = spec.get("correctness_oracle")
+    required = (
+        "authority", "repository", "commit", "stwo_repository", "stwo_commit",
+        "adapter", "build_command", "final_validator",
+    )
+    if not isinstance(oracle, dict) or any(key not in oracle for key in required):
+        raise ManifestError(
+            f"workload group {gid}: Cairo correctness_oracle must pin "
+            + ", ".join(required)
+        )
+    if oracle["authority"] != "official-stwo-cairo-verifier":
+        raise ManifestError(
+            f"workload group {gid}: the only admissible Cairo authority is the "
+            "official stwo-cairo verifier"
+        )
+    if oracle["final_validator"] is not True:
+        raise ManifestError(
+            f"workload group {gid}: the Cairo oracle must be the final validator"
+        )
+    for key, repository in (
+        ("repository", "https://github.com/starkware-libs/stwo-cairo"),
+        ("stwo_repository", "https://github.com/starkware-libs/stwo"),
+    ):
+        if oracle[key] != repository:
+            raise ManifestError(
+                f"workload group {gid}: Cairo oracle {key} must be {repository}"
+            )
+    for key in ("commit", "stwo_commit"):
+        value = oracle[key]
+        if (not isinstance(value, str) or len(value) != 40
+                or any(char not in "0123456789abcdef" for char in value)):
+            raise ManifestError(
+                f"workload group {gid}: Cairo oracle {key} must be a full "
+                "lowercase Git commit"
+            )
+    adapter = oracle["adapter"]
+    if (not isinstance(adapter, str)
+            or adapter != "tools/stwo-cairo-official-verifier-rs"):
+        raise ManifestError(
+            f"workload group {gid}: the Cairo oracle adapter must be the pinned "
+            "in-repository official verifier package"
+        )
+
+
+def _validate_group_acceptance_corpus(gid: str, corpus: object) -> None:
+    if not isinstance(corpus, dict):
+        raise ManifestError(f"workload group {gid}: acceptance_corpus must be an object")
+    if not corpus:
+        return
+    allowed = {"path", "sha256", "note"}
+    if set(corpus) - allowed or not {"path", "sha256"} <= set(corpus):
+        raise ManifestError(
+            f"workload group {gid}: acceptance_corpus requires path and sha256 "
+            "(note optional)"
+        )
+    path = corpus["path"]
+    if (
+        not isinstance(path, str) or not path.startswith("vectors/")
+        or Path(path).is_absolute() or ".." in Path(path).parts
+    ):
+        raise ManifestError(
+            f"workload group {gid}: acceptance_corpus.path must be a repository "
+            "vectors path"
+        )
+    digest = corpus["sha256"]
+    if (
+        not isinstance(digest, str) or len(digest) != 64
+        or any(char not in "0123456789abcdef" for char in digest)
+    ):
+        raise ManifestError(
+            f"workload group {gid}: acceptance_corpus.sha256 must be canonical "
+            "lowercase SHA-256 hex"
+        )
+    if "note" in corpus and (
+        not isinstance(corpus["note"], str) or not corpus["note"].strip()
+    ):
+        raise ManifestError(
+            f"workload group {gid}: acceptance_corpus.note must be non-empty"
+        )
+
+
+def _validate_group_workload_provisioning(
+    gid: str, provisioning: object, workloads: object,
+) -> None:
+    """Declared-but-unprovisioned basket entries stay loud and never runnable."""
+    if not isinstance(provisioning, dict):
+        raise ManifestError(
+            f"workload group {gid}: workload_provisioning must be an object"
+        )
+    if not provisioning:
+        return
+    if set(provisioning) != {"note", "documentation", "pending"}:
+        raise ManifestError(
+            f"workload group {gid}: workload_provisioning requires exactly note, "
+            "documentation, and pending"
+        )
+    for key in ("note", "documentation"):
+        if not isinstance(provisioning[key], str) or not provisioning[key].strip():
+            raise ManifestError(
+                f"workload group {gid}: workload_provisioning.{key} must be non-empty"
+            )
+    pending = provisioning["pending"]
+    if not isinstance(pending, dict) or not pending:
+        raise ManifestError(
+            f"workload group {gid}: workload_provisioning.pending must be a "
+            "non-empty object"
+        )
+    declared = set(workloads) if isinstance(workloads, dict) else set()
+    for wid, entry in pending.items():
+        if wid in declared:
+            raise ManifestError(
+                f"workload group {gid}: {wid} is both a runnable workload and a "
+                "pending provisioning entry"
+            )
+        if not isinstance(entry, dict) or set(entry) != {
+            "vm_steps", "committed_cells", "reason",
+        }:
+            raise ManifestError(
+                f"workload group {gid}: pending workload {wid} requires exactly "
+                "vm_steps, committed_cells, and reason"
+            )
+        for key in ("vm_steps", "committed_cells"):
+            value = entry[key]
+            if type(value) is not int or value <= 0:
+                raise ManifestError(
+                    f"workload group {gid}: pending workload {wid}.{key} must be "
+                    "a positive integer"
+                )
+        if not isinstance(entry["reason"], str) or not entry["reason"].strip():
+            raise ManifestError(
+                f"workload group {gid}: pending workload {wid} has no reason"
+            )
+
+
+def _validate_acceptance_corpora(repo: Path, raw: dict) -> None:
+    """Bind every declared acceptance corpus to its committed bytes.
+
+    Harness-only fixture trees (the synthetic `autoresearch/`-only repositories
+    several tests and tools build) carry no `vectors/`; there is nothing to
+    bind and nothing to drift. Whenever the vectors tree IS present the binding
+    is mandatory: a missing or altered corpus fails the load.
+    """
+    import hashlib
+
+    if not (repo / "vectors").is_dir():
+        return
+    for gid, spec in raw["workload_registry"]["groups"].items():
+        corpus = spec.get("acceptance_corpus") or {}
+        if not corpus:
+            continue
+        path = repo / corpus["path"]
+        try:
+            payload = path.read_bytes()
+        except OSError as exc:
+            raise ManifestError(
+                f"workload group {gid}: acceptance corpus {corpus['path']} is "
+                f"not readable: {exc}"
+            ) from exc
+        actual = hashlib.sha256(payload).hexdigest()
+        if actual != corpus["sha256"]:
+            raise ManifestError(
+                f"workload group {gid}: acceptance corpus {corpus['path']} digest "
+                f"drifted (manifest {corpus['sha256']}, file {actual})"
+            )
 
 
 def _validate_classes(classes: object) -> None:

--- a/autoresearch/cli/stwo_perf/runner.py
+++ b/autoresearch/cli/stwo_perf/runner.py
@@ -81,6 +81,110 @@ _NATIVE_RESOURCE_KEYS = {
 }
 
 
+# --- Cairo (cairo_proof_v1) ------------------------------------------------
+#
+# `cairo_proof_v1` is the harness envelope, not the product's own report
+# version: the focused Cairo CLIs emit a `schema_version: 2` proving report on
+# stdout and an optional `schema_version: 1` stage profile. See
+# autoresearch/schema/cairo-proof-v1.md.
+CAIRO_PRODUCT_REPORT_SCHEMA_VERSION = 2
+CAIRO_STAGE_PROFILE_SCHEMA_VERSION = 1
+CAIRO_PROOF_FORMATS = frozenset({"json", "binary", "cairo-serde"})
+CAIRO_IMPLEMENTATION_REPOSITORY = "https://github.com/teddyjfpender/stwo-zig"
+CAIRO_COMMANDS = frozenset({"prove", "run-and-prove"})
+
+_CAIRO_REPORT_KEYS = {
+    "schema_version", "product", "frontend", "backend", "backend_evidence",
+    "preprocessed_cache", "profile", "execution", "input", "proof", "timing",
+    "verification",
+}
+_CAIRO_PRODUCT_KEYS = {
+    "schema_version", "name", "frontend", "backend", "role",
+    "protocol_features", "protocol_manifest_sha256", "identity_sha256",
+    "source", "zig_version", "target", "optimize", "runtime", "upstream",
+}
+_CAIRO_SOURCE_KEYS = {
+    "repository", "commit", "tree", "dirty", "dirty_content_sha256",
+}
+_CAIRO_TARGET_KEYS = {"arch", "os", "abi", "cpu_model", "cpu_features_sha256"}
+_CAIRO_RUNTIME_KEYS = {"manifest", "sdk", "aot"}
+_CAIRO_UPSTREAM_KEYS = {
+    "stwo_cairo_revision", "stwo_revision", "cairo_language_version",
+    "cairo_vm_version",
+}
+_CAIRO_BACKEND_EVIDENCE_KEYS = {
+    "execution", "classification", "metal_dispatches", "cpu_fallbacks",
+    "runtime_initializations", "runtime_shutdowns",
+    "commit_source_arena_aliases", "commit_source_arena_memcpys",
+    "commit_source_uploads",
+}
+_CAIRO_PREPROCESSED_CACHE_KEYS = {
+    "enabled", "budget_bytes", "hits", "misses", "stores", "evictions",
+    "loaded_bytes", "stored_bytes", "evicted_bytes", "directory_bytes",
+    "eviction_ns",
+}
+_CAIRO_EXECUTION_KEYS = {
+    "program_type", "program_sha256", "arguments_sha256", "adapter_sha256",
+    "wall_ns",
+}
+
+# TRACKS §3.2 named cutpoints -> the stage-profile ROOT ids that compose them.
+# `execute` and `verify` come from the report's own timing block; `serialize`
+# is a documented instrumentation gap (the CLI writes and hashes the proof
+# outside the recorder). Unknown roots fail closed so a product change forces a
+# harness update instead of silently dropping proving time.
+CAIRO_PHASE_STAGES: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
+    "witness": (
+        (
+            "preprocessed_plan",
+            "preprocessed_table_build",
+            "base_trace_build",
+            "air_template_instantiation",
+        ),
+        (),
+    ),
+    "commit": (
+        ("preprocessed_materialize_and_commit", "main_trace_commit"),
+        (),
+    ),
+    "interaction": (
+        ("interaction_trace_build", "interaction_trace_commit"),
+        (),
+    ),
+    "composition": (
+        (
+            "draw_random_coeff",
+            "composition_trace_extract",
+            "composition_evaluation",
+            "composition_interpolate_and_split",
+            "composition_commit",
+        ),
+        (
+            # Metal-lane device-composition admission markers.
+            "composition_device_admission",
+            "composition_device_declined",
+            "composition_device_components",
+            "composition_device_host_components",
+            "composition_device_fallbacks",
+        ),
+    ),
+    "fri": (
+        (
+            "oods_point_and_mask_points",
+            "sampled_value_evaluation",
+            "sampled_value_channel_mix",
+            "fri_quotient_build_and_commit",
+            "proof_of_work",
+            "fri_decommit",
+            "trace_decommit",
+            "constraint_check_and_assembly",
+        ),
+        (),
+    ),
+}
+CAIRO_UNINSTRUMENTED_PHASES = ("serialize",)
+
+
 def _workload_resource_profile(workload: Workload) -> str:
     tokens = shlex.split(workload.args)
     positions = [index for index, token in enumerate(tokens) if token == "--resource-profile"]
@@ -441,6 +545,25 @@ def bench_once(
             f"build it first ({group.build_step}); refusing to fabricate measurements"
         )
     out_dir.mkdir(parents=True, exist_ok=True)
+    if group.report_schema == "cairo_proof_v1":
+        # The Cairo CLIs prove one statement per process, so the harness owns
+        # the warmup/sample loop and reads a cold-process boundary per sample.
+        cairo_timeout = (
+            timeout_seconds
+            if timeout_seconds is not None
+            else manifest.workload_class(workload.workload_class).command_timeout_seconds
+        )
+        if cairo_timeout <= 0:
+            raise RunError(f"{workload.workload_id}: no command time budget remains")
+        try:
+            return _bench_cairo(
+                arm_root, group, workload, warmups, samples, out_dir,
+                tag, float(cairo_timeout), deadline_monotonic,
+            )
+        except (OSError, KeyError, TypeError, ValueError) as exc:
+            raise RunError(
+                f"{workload.workload_id}: malformed {group.report_schema} report: {exc}"
+            ) from exc
     proof_path = None
     product_report_path = None
     if group.report_schema == "riscv_proof_v2":
@@ -1031,6 +1154,481 @@ def _parse_riscv_resources(
         "instructions": delta["instructions"],
         "cycles": delta["cycles"],
     }
+
+
+def _exact_object(value: object, keys: set[str], label: str) -> dict:
+    if not isinstance(value, dict) or set(value) != keys:
+        missing = sorted(keys - set(value)) if isinstance(value, dict) else sorted(keys)
+        unknown = sorted(set(value) - keys) if isinstance(value, dict) else []
+        raise ValueError(
+            f"{label} fields differ: missing={missing} unknown={unknown}"
+        )
+    return value
+
+
+def _nonempty_text(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return value
+
+
+def _cairo_command(workload: Workload) -> tuple[str, str, bool]:
+    """(command, requested proof format, verification requested) from args."""
+    tokens = shlex.split(workload.args)
+    if not tokens or tokens[0] not in CAIRO_COMMANDS:
+        raise ValueError(
+            "Cairo workload args must start with prove or run-and-prove"
+        )
+    proof_format = "json"
+    positions = [i for i, token in enumerate(tokens) if token == "--proof-format"]
+    if positions:
+        if len(positions) != 1 or positions[0] + 1 >= len(tokens):
+            raise ValueError("Cairo workload has a malformed --proof-format")
+        proof_format = tokens[positions[0] + 1]
+    if proof_format not in CAIRO_PROOF_FORMATS:
+        raise ValueError(f"unsupported Cairo proof format {proof_format!r}")
+    for reserved in ("--proof", "--stage-profile-out", "--report-out"):
+        if reserved in tokens:
+            raise ValueError(
+                f"Cairo workload args must not carry {reserved}; the runner owns "
+                "the output paths"
+            )
+    return tokens[0], proof_format, "--verify" in tokens
+
+
+def _parse_cairo_report(
+    report: dict,
+    group: WorkloadGroup,
+    workload: Workload,
+    proof_path: Path,
+) -> dict:
+    """Fail-closed validation of ONE Cairo product proving report.
+
+    Everything the report claims is either checked against the manifest (the
+    pinned official oracle revisions, the declared binary, the requested proof
+    format) or against the retained artifact on disk. Nothing is inferred and
+    nothing missing is defaulted.
+    """
+    command, requested_format, verify_requested = _cairo_command(workload)
+    if not verify_requested:
+        raise ValueError(
+            "a scored Cairo workload must request --verify; unverified proofs "
+            "never enter a boundary measurement"
+        )
+    _exact_object(report, _CAIRO_REPORT_KEYS, "report")
+    actual = report["schema_version"]
+    if type(actual) is not int or actual != CAIRO_PRODUCT_REPORT_SCHEMA_VERSION:
+        raise RunError(
+            f"{workload.workload_id}: group {group.group_id} expected "
+            f"{group.report_schema} (product schema_version="
+            f"{CAIRO_PRODUCT_REPORT_SCHEMA_VERSION}), got schema_version={actual!r}"
+        )
+    if report["frontend"] != "cairo":
+        raise ValueError("report.frontend must equal 'cairo'")
+    backend = _nonempty_text(report["backend"], "report.backend")
+
+    product = _exact_object(report["product"], _CAIRO_PRODUCT_KEYS, "report.product")
+    if product["schema_version"] != CAIRO_PRODUCT_REPORT_SCHEMA_VERSION:
+        raise ValueError("report.product.schema_version is not the pinned version")
+    expected_name = Path(group.binary).name
+    if product["name"] != expected_name:
+        raise ValueError(
+            f"report.product.name {product['name']!r} is not the group's declared "
+            f"binary {expected_name!r}"
+        )
+    if product["frontend"] != "cairo" or product["backend"] != backend:
+        raise ValueError("report.product frontend/backend disagree with the report")
+    if product["role"] != "cli":
+        raise ValueError("report.product.role must equal 'cli'")
+    if product["optimize"] != "ReleaseFast":
+        raise ValueError("a measured Cairo product must be built ReleaseFast")
+    _nonempty_text(product["protocol_features"], "report.product.protocol_features")
+    _nonempty_text(product["zig_version"], "report.product.zig_version")
+    protocol_manifest_sha256 = _sha256_hex(
+        product["protocol_manifest_sha256"], "report.product.protocol_manifest_sha256",
+    )
+    identity_sha256 = _sha256_hex(
+        product["identity_sha256"], "report.product.identity_sha256",
+    )
+    source = _exact_object(
+        product["source"], _CAIRO_SOURCE_KEYS, "report.product.source",
+    )
+    if source["repository"] != CAIRO_IMPLEMENTATION_REPOSITORY:
+        raise ValueError("report.product.source.repository is not this implementation")
+    _commit_hex(source["commit"], "report.product.source.commit")
+    _commit_hex(source["tree"], "report.product.source.tree")
+    if type(source["dirty"]) is not bool:
+        raise ValueError("report.product.source.dirty must be a boolean")
+    if source["dirty"]:
+        _sha256_hex(
+            source["dirty_content_sha256"],
+            "report.product.source.dirty_content_sha256",
+        )
+    elif source["dirty_content_sha256"] is not None:
+        raise ValueError("a clean Cairo source must have null dirty_content_sha256")
+    target = _exact_object(
+        product["target"], _CAIRO_TARGET_KEYS, "report.product.target",
+    )
+    for key in ("arch", "os", "abi", "cpu_model"):
+        _nonempty_text(target[key], f"report.product.target.{key}")
+    _sha256_hex(target["cpu_features_sha256"], "report.product.target.cpu_features_sha256")
+    runtime = _exact_object(
+        product["runtime"], _CAIRO_RUNTIME_KEYS, "report.product.runtime",
+    )
+    for key in sorted(_CAIRO_RUNTIME_KEYS):
+        _nonempty_text(runtime[key], f"report.product.runtime.{key}")
+    upstream = _exact_object(
+        product["upstream"], _CAIRO_UPSTREAM_KEYS, "report.product.upstream",
+    )
+    oracle = group.correctness_oracle
+    if oracle.get("final_validator") is not True:
+        raise RunError(
+            f"{workload.workload_id}: group {group.group_id} has no final-validator "
+            "Cairo correctness oracle"
+        )
+    if upstream["stwo_cairo_revision"] != oracle.get("commit"):
+        raise ValueError(
+            "report.product.upstream.stwo_cairo_revision is not the manifest-pinned "
+            "official stwo-cairo commit"
+        )
+    if upstream["stwo_revision"] != oracle.get("stwo_commit"):
+        raise ValueError(
+            "report.product.upstream.stwo_revision is not the manifest-pinned "
+            "official stwo commit"
+        )
+    for key in ("cairo_language_version", "cairo_vm_version"):
+        _nonempty_text(upstream[key], f"report.product.upstream.{key}")
+
+    evidence = _exact_object(
+        report["backend_evidence"], _CAIRO_BACKEND_EVIDENCE_KEYS,
+        "report.backend_evidence",
+    )
+    _nonempty_text(evidence["execution"], "report.backend_evidence.execution")
+    _nonempty_text(evidence["classification"], "report.backend_evidence.classification")
+    for key in sorted(_CAIRO_BACKEND_EVIDENCE_KEYS - {"execution", "classification"}):
+        _nonnegative_integer(evidence[key], f"report.backend_evidence.{key}")
+    if evidence["cpu_fallbacks"] != 0:
+        raise ValueError(
+            "report.backend_evidence.cpu_fallbacks must be zero; a lane that fell "
+            "back is not the declared product"
+        )
+
+    cache = _exact_object(
+        report["preprocessed_cache"], _CAIRO_PREPROCESSED_CACHE_KEYS,
+        "report.preprocessed_cache",
+    )
+    if type(cache["enabled"]) is not bool:
+        raise ValueError("report.preprocessed_cache.enabled must be a boolean")
+    for key in sorted(_CAIRO_PREPROCESSED_CACHE_KEYS - {"enabled"}):
+        _nonnegative_integer(cache[key], f"report.preprocessed_cache.{key}")
+
+    profile = _nonempty_text(report["profile"], "report.profile")
+    input_sha256 = _sha256_hex(
+        _exact_object(report["input"], {"sha256"}, "report.input")["sha256"],
+        "report.input.sha256",
+    )
+    proof = _exact_object(
+        report["proof"], {"format", "bytes", "sha256"}, "report.proof",
+    )
+    if proof["format"] != requested_format:
+        raise ValueError(
+            f"report.proof.format {proof['format']!r} is not the requested "
+            f"{requested_format!r}"
+        )
+    proof_bytes = _nonnegative_integer(proof["bytes"], "report.proof.bytes", positive=True)
+    proof_sha256 = _sha256_hex(proof["sha256"], "report.proof.sha256")
+
+    timing = _exact_object(
+        report["timing"], {"execute_ns", "prove_ns", "verify_ns"}, "report.timing",
+    )
+    execute_ns = _nonnegative_integer(timing["execute_ns"], "report.timing.execute_ns")
+    prove_ns = _nonnegative_integer(
+        timing["prove_ns"], "report.timing.prove_ns", positive=True,
+    )
+    verify_ns = _nonnegative_integer(
+        timing["verify_ns"], "report.timing.verify_ns", positive=True,
+    )
+    verification = _exact_object(
+        report["verification"], {"requested", "zig"}, "report.verification",
+    )
+    if verification["requested"] is not True or verification["zig"] is not True:
+        raise ValueError(
+            "report.verification must record a requested and completed in-process "
+            "verification"
+        )
+
+    execution = report["execution"]
+    if command == "prove":
+        if execution is not None:
+            raise ValueError("a prove report must have null execution")
+        if execute_ns != 0:
+            raise ValueError("a prove report must have zero execute_ns")
+    else:
+        execution = _exact_object(
+            execution, _CAIRO_EXECUTION_KEYS, "report.execution",
+        )
+        _nonempty_text(execution["program_type"], "report.execution.program_type")
+        _sha256_hex(execution["program_sha256"], "report.execution.program_sha256")
+        if execution["arguments_sha256"] is not None:
+            _sha256_hex(
+                execution["arguments_sha256"], "report.execution.arguments_sha256",
+            )
+        _sha256_hex(execution["adapter_sha256"], "report.execution.adapter_sha256")
+        wall_ns = _nonnegative_integer(
+            execution["wall_ns"], "report.execution.wall_ns", positive=True,
+        )
+        if wall_ns != execute_ns:
+            raise ValueError("report.execution.wall_ns disagrees with timing.execute_ns")
+
+    if not proof_path.is_file():
+        raise ValueError("the Cairo product did not retain the requested proof")
+    artifact = proof_path.read_bytes()
+    if len(artifact) != proof_bytes:
+        raise ValueError("report.proof.bytes does not match the retained proof")
+    if hashlib.sha256(artifact).hexdigest() != proof_sha256:
+        raise ValueError("report.proof.sha256 does not match the retained proof")
+
+    return {
+        "product_identity_sha256": identity_sha256,
+        "protocol_manifest_sha256": protocol_manifest_sha256,
+        "profile": profile,
+        "input_sha256": input_sha256,
+        "proof_format": proof["format"],
+        "proof_bytes": proof_bytes,
+        "proof_sha256": proof_sha256,
+        "stwo_cairo_revision": upstream["stwo_cairo_revision"],
+        "stwo_revision": upstream["stwo_revision"],
+        "metal_dispatches": evidence["metal_dispatches"],
+        "cpu_fallbacks": evidence["cpu_fallbacks"],
+        "execute_seconds": execute_ns / 1_000_000_000.0,
+        "prove_seconds": prove_ns / 1_000_000_000.0,
+        "verify_seconds": verify_ns / 1_000_000_000.0,
+        "implementation_commit": source["commit"],
+    }
+
+
+def _parse_cairo_stage_profile(profile: dict, workload: Workload) -> dict:
+    """TRACKS §3.2 named cutpoints from one `--stage-profile-out` snapshot."""
+    _exact_object(
+        profile, {"schema_version", "runtime", "example", "stages"},
+        "stage profile",
+    )
+    if profile["schema_version"] != CAIRO_STAGE_PROFILE_SCHEMA_VERSION:
+        raise ValueError(
+            "stage profile schema_version is not "
+            f"{CAIRO_STAGE_PROFILE_SCHEMA_VERSION}"
+        )
+    if profile["example"] != "cairo":
+        raise ValueError("stage profile is not a Cairo profile")
+    _nonempty_text(profile["runtime"], "stage profile runtime")
+    stages = profile["stages"]
+    if not isinstance(stages, list) or not stages:
+        raise ValueError("stage profile has no stages")
+
+    owner = {}
+    for phase, (required, optional) in CAIRO_PHASE_STAGES.items():
+        for stage_id in required + optional:
+            owner[stage_id] = phase
+    seconds = {phase: 0.0 for phase in CAIRO_PHASE_STAGES}
+    observed: set[str] = set()
+    for index, node in enumerate(stages):
+        if not isinstance(node, dict) or not {"id", "label", "seconds"} <= set(node):
+            raise ValueError(f"stage profile root {index} is not a stage node")
+        if set(node) - {"id", "label", "seconds", "children"}:
+            raise ValueError(f"stage profile root {index} has unknown fields")
+        stage_id = _nonempty_text(node["id"], f"stage profile root {index} id")
+        phase = owner.get(stage_id)
+        if phase is None:
+            raise ValueError(
+                f"{workload.workload_id}: unclassified Cairo stage root "
+                f"{stage_id!r}; the phase cutpoint table must be updated before "
+                "this product can be measured"
+            )
+        seconds[phase] += _finite_number(node["seconds"], f"stage {stage_id} seconds")
+        observed.add(stage_id)
+    for phase, (required, _optional) in CAIRO_PHASE_STAGES.items():
+        missing = sorted(set(required) - observed)
+        if missing:
+            raise ValueError(
+                f"{workload.workload_id}: Cairo phase {phase} is missing mandatory "
+                "cutpoint stage(s): " + ", ".join(missing)
+            )
+    return seconds
+
+
+def _bench_cairo(
+    arm_root: Path,
+    group: WorkloadGroup,
+    workload: Workload,
+    warmups: int,
+    samples: int,
+    out_dir: Path,
+    tag: str,
+    timeout: float,
+    deadline_monotonic: float | None,
+) -> ArmResult:
+    """One arm of one Cairo round: warmups + samples cold CLI processes.
+
+    The focused Cairo CLIs prove exactly one statement per process, so the
+    harness owns the warmup/sample loop and one sample is one cold process. The
+    mandatory phase profile is recorded on the FIRST discarded warmup so scored
+    samples run uninstrumented.
+    """
+    if warmups < 1:
+        raise RunError(
+            f"{workload.workload_id}: Cairo measurement needs at least one warmup; "
+            "the mandatory phase profile is recorded on a discarded warmup"
+        )
+    if samples < 1:
+        raise RunError(f"{workload.workload_id}: Cairo measurement needs a sample")
+    binary = arm_root / group.binary
+    args = _format_workload_args(arm_root, group, workload, warmups, samples)
+    run_kwargs = (
+        {"deadline_monotonic": deadline_monotonic}
+        if deadline_monotonic is not None else {}
+    )
+    stage_seconds: dict | None = None
+    measured: list[dict] = []
+    reports: list[dict] = []
+    for index in range(warmups + samples):
+        scored = index >= warmups
+        proof_path = (
+            out_dir / f"{workload.workload_id}.{tag}.i{index}.proof"
+        ).resolve()
+        proof_path.unlink(missing_ok=True)
+        extra = f" --proof {shlex.quote(str(proof_path))}"
+        stage_path = None
+        if index == warmups - 1:
+            stage_path = (
+                out_dir / f"{workload.workload_id}.{tag}.stages.json"
+            ).resolve()
+            stage_path.unlink(missing_ok=True)
+            extra += f" --stage-profile-out {shlex.quote(str(stage_path))}"
+        started = time.monotonic()
+        stdout = _run(
+            f"{binary} {args}{extra}", arm_root, timeout=float(timeout), **run_kwargs,
+        )
+        cold_seconds = time.monotonic() - started
+        try:
+            report = _load_json_object(stdout, "Cairo product report")
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise RunError(
+                f"{workload.workload_id}: Cairo product emitted non-JSON output "
+                f"(first 200 chars: {stdout[:200]!r})"
+            ) from exc
+        parsed = _parse_cairo_report(report, group, workload, proof_path)
+        if stage_path is not None:
+            stage_seconds = _parse_cairo_stage_profile(
+                _load_json_object(
+                    stage_path.read_text(encoding="utf-8"), "Cairo stage profile",
+                ),
+                workload,
+            )
+        if scored:
+            parsed["cold_process_seconds"] = cold_seconds
+            measured.append(parsed)
+            reports.append(report)
+        else:
+            proof_path.unlink(missing_ok=True)
+    if stage_seconds is None:
+        raise RunError(
+            f"{workload.workload_id}: no Cairo phase profile was recorded"
+        )
+
+    for field_name in (
+        "profile", "input_sha256", "proof_format", "proof_bytes", "proof_sha256",
+        "stwo_cairo_revision", "stwo_revision", "product_identity_sha256",
+        "protocol_manifest_sha256",
+    ):
+        values = {sample[field_name] for sample in measured}
+        if len(values) != 1:
+            raise RunError(
+                f"{workload.workload_id}: {field_name} changed between measured "
+                f"Cairo samples ({sorted(values)})"
+            )
+    phase_seconds = {
+        "execute": statistics.mean(s["execute_seconds"] for s in measured),
+        "witness": stage_seconds["witness"],
+        "commit": stage_seconds["commit"],
+        "interaction": stage_seconds["interaction"],
+        "composition": stage_seconds["composition"],
+        "fri": stage_seconds["fri"],
+        # Documented gap: proof encode/write/hash is outside the recorder.
+        "serialize": None,
+        "verify": statistics.mean(s["verify_seconds"] for s in measured),
+    }
+    available = {
+        "product_identity_sha256": measured[0]["product_identity_sha256"],
+        "protocol_manifest_sha256": measured[0]["protocol_manifest_sha256"],
+        "profile": measured[0]["profile"],
+        "input_sha256": measured[0]["input_sha256"],
+        "proof_format": measured[0]["proof_format"],
+        "proof_bytes": measured[0]["proof_bytes"],
+        "proof_sha256": measured[0]["proof_sha256"],
+        "stwo_cairo_revision": measured[0]["stwo_cairo_revision"],
+        "stwo_revision": measured[0]["stwo_revision"],
+        "metal_dispatches": measured[0]["metal_dispatches"],
+        "cpu_fallbacks": measured[0]["cpu_fallbacks"],
+        "mean_execute_seconds": phase_seconds["execute"],
+        "mean_prove_seconds": statistics.mean(s["prove_seconds"] for s in measured),
+        "mean_verify_seconds": phase_seconds["verify"],
+        "mean_cold_process_seconds": statistics.mean(
+            s["cold_process_seconds"] for s in measured
+        ),
+        "phase_seconds": phase_seconds,
+    }
+    required_fields = group.mechanism_telemetry.get("required_fields", [])
+    if group.mechanism_telemetry.get("fail_closed") is not True or not required_fields:
+        raise RunError(
+            f"{workload.workload_id}: group {group.group_id} declares no "
+            "fail-closed Cairo mechanism telemetry"
+        )
+    missing = sorted(set(required_fields) - set(available))
+    if missing:
+        raise RunError(
+            f"{workload.workload_id}: Cairo mechanism telemetry cannot supply "
+            + ", ".join(missing)
+        )
+    mechanism = {name: available[name] for name in required_fields}
+
+    out_path = out_dir / f"{workload.workload_id}.{tag}.json"
+    out_path.write_text(json.dumps({
+        "schema": group.report_schema,
+        "workload": workload.workload_id,
+        "group": group.group_id,
+        "board": group.board,
+        "warmups": warmups,
+        "samples": samples,
+        "measurement_boundary": "cold_process",
+        "phase_profile_source": {
+            "invocation_index": warmups - 1,
+            "scored": False,
+            "note": "The stage profile is recorded on the last discarded warmup "
+                    "so scored samples run uninstrumented; phase seconds are "
+                    "diagnostic telemetry and are never scored (TRACKS §3.2).",
+        },
+        "phase_seconds": phase_seconds,
+        "mechanism": mechanism,
+        "measured_samples": measured,
+        "product_reports": reports,
+    }, indent=1))
+    return ArmResult(
+        # prove_ms is diagnostic telemetry on a v3 track (TRACKS §3.1).
+        prove_ms=statistics.median(s["prove_seconds"] for s in measured) * 1000.0,
+        proof_verified=len(measured),
+        byte_identical=len({s["proof_sha256"] for s in measured}) == 1,
+        peak_rss_mib=None,
+        report_path=str(out_path),
+        proof_digest=measured[0]["proof_sha256"],
+        proof_bytes=measured[0]["proof_bytes"],
+        # The scored boundary: before process creation -> after exit, with
+        # independent in-process verification inside it (TRACKS §3.1).
+        request_ms=statistics.median(
+            s["cold_process_seconds"] for s in measured
+        ) * 1000.0,
+        mechanism=mechanism,
+        resources_complete=False,
+    )
 
 
 def paired_rounds(

--- a/autoresearch/schema/cairo-proof-v1.md
+++ b/autoresearch/schema/cairo-proof-v1.md
@@ -1,0 +1,323 @@
+# Cairo proof benchmark report v1
+
+`cairo_proof_v1` is the fail-closed report contract consumed by the `cairo_cpu`
+and `cairo_metal` workload groups (TRACKS §2, §8 wave 1). It is a **harness
+envelope name, not a product report version**: the focused Cairo CLIs
+(`stwo-cairo-cpu`, `stwo-cairo-metal`) already emit a `schema_version: 2`
+proving report and a `schema_version: 1` stage profile, and this document pins
+exactly how the harness reads them. Nothing in this schema was invented for the
+harness; every field below is emitted today by
+`src/products/cairo/shared/application.zig` and
+`src/prover_api/stage_profile.zig`.
+
+| identity | value |
+|---|---|
+| manifest `report_schema` | `cairo_proof_v1` |
+| `manifest.REPORT_SCHEMA_VERSIONS["cairo_proof_v1"]` | `1` (envelope) |
+| product report `schema_version` | `2` (`runner.CAIRO_PRODUCT_REPORT_SCHEMA_VERSION`) |
+| stage profile `schema_version` | `1` (`runner.CAIRO_STAGE_PROFILE_SCHEMA_VERSION`) |
+| parser | `runner._parse_cairo_report`, `runner._parse_cairo_stage_profile` |
+| arm driver | `runner._bench_cairo`, dispatched from `runner.bench_once` |
+
+## How one arm is measured
+
+The Cairo CLIs prove exactly **one statement per process**. There is no
+`--warmups`, no `--samples`, and no `--repeat`. The harness therefore owns the
+loop: `_bench_cairo` runs `warmups + samples` cold processes, discards the
+warmups, and measures each scored sample as one complete cold process. One
+sample is one cold process by construction.
+
+The `{warmups}` / `{samples}` registry placeholders are consequently **absent
+from Cairo workload `args`** — there is no CLI flag to bind them to, and
+inventing one would mean editing the product. Sampling is expressed only in the
+group's `gates_policy`.
+
+The mandatory phase profile is recorded on the **last discarded warmup**
+(`--stage-profile-out`), so scored samples run uninstrumented and the profile's
+cache/residency state is the closest available match to the first scored
+sample. The envelope records this explicitly in `phase_profile_source`; phase
+seconds are diagnostic telemetry and are never scored (TRACKS §3.2).
+
+`--proof`, `--stage-profile-out`, and `--report-out` are owned by the runner
+and are rejected if a manifest workload tries to set them. The report is read
+from stdout (the CLI writes it to stdout exactly when `--report-out` is
+omitted).
+
+## Scored boundary (TRACKS §3.1)
+
+| boundary | source | field |
+|---|---|---|
+| cold process | harness-measured subprocess wall time | `ArmResult.request_ms` (median), `mean_cold_process_seconds` |
+| prove island | `report.timing.prove_ns` | `ArmResult.prove_ms` (median) — **diagnostic only** |
+
+`prove_ms` is demoted to telemetry on every v3 track. The **scored** Cairo
+boundary is the cold-process boundary: before process creation → after exit,
+with the product's own independent verification (`--verify`, checked as
+`verification.requested && verification.zig`) inside it. That is a strict
+superset of PR6's verified-request boundary, so this track is never laxer than
+PR6 (TRACKS §3.1); see [Gaps](#gaps-in-the-current-product-cli) for why the
+tighter in-process request span does not exist yet.
+
+## Product report (`schema_version: 2`)
+
+Exact field set; any missing or unknown field fails closed.
+
+```
+schema_version          u32, must equal 2
+product                 object (below)
+frontend                "cairo"
+backend                 non-empty string, equals product.backend
+backend_evidence        object (below)
+preprocessed_cache      object (below)
+profile                 non-empty string (proving-profile name)
+execution               null for `prove`; object for `run-and-prove` (below)
+input.sha256            canonical lowercase SHA-256 of the prover input
+proof.format            "json" | "binary" | "cairo-serde"; must equal the
+                        format requested by the workload args
+proof.bytes             positive integer; must equal the retained artifact size
+proof.sha256            canonical SHA-256; must equal the retained artifact hash
+timing.execute_ns       non-negative integer (0 for `prove`)
+timing.prove_ns         positive integer
+timing.verify_ns        positive integer
+verification.requested  must be true
+verification.zig        must be true
+```
+
+`product`:
+
+```
+schema_version              u32, 2
+name                        must equal basename(group.binary)
+frontend                    "cairo"
+backend                     equals report.backend
+role                        "cli"
+protocol_features           non-empty string
+protocol_manifest_sha256    canonical SHA-256
+identity_sha256             canonical SHA-256
+source.repository           https://github.com/teddyjfpender/stwo-zig
+source.commit               full lowercase Git commit
+source.tree                 full lowercase Git tree
+source.dirty                boolean
+source.dirty_content_sha256 SHA-256 when dirty, else null
+zig_version                 non-empty string
+target.arch/os/abi/cpu_model        non-empty strings
+target.cpu_features_sha256          canonical SHA-256
+optimize                    must equal "ReleaseFast"
+runtime.manifest/sdk/aot            non-empty strings
+upstream.stwo_cairo_revision        must equal correctness_oracle.commit
+upstream.stwo_revision              must equal correctness_oracle.stwo_commit
+upstream.cairo_language_version     non-empty string
+upstream.cairo_vm_version           non-empty string
+```
+
+The two `upstream` checks are the oracle binding: a measured Cairo product must
+be built against exactly the official Stwo-Cairo pair the manifest pins as the
+final validator, or the sample is refused.
+
+`backend_evidence`:
+
+```
+execution                     non-empty string ("cpu-simd", ...)
+classification                non-empty string ("host-only", ...)
+metal_dispatches              non-negative integer
+cpu_fallbacks                 non-negative integer; MUST be 0
+runtime_initializations       non-negative integer
+runtime_shutdowns             non-negative integer
+commit_source_arena_aliases   non-negative integer
+commit_source_arena_memcpys   non-negative integer
+commit_source_uploads         non-negative integer
+```
+
+`preprocessed_cache` (availability accounting only; never reaches a key, a
+transcript, or a proof byte): `enabled` (bool) plus non-negative integers
+`budget_bytes`, `hits`, `misses`, `stores`, `evictions`, `loaded_bytes`,
+`stored_bytes`, `evicted_bytes`, `directory_bytes`, `eviction_ns`.
+
+`execution` (only for `run-and-prove`): `program_type`, `program_sha256`,
+`arguments_sha256` (nullable), `adapter_sha256`, `wall_ns`; `wall_ns` must equal
+`timing.execute_ns`.
+
+## Named phase cutpoints (TRACKS §3.2)
+
+The stage profile is a hierarchical tree; the harness classifies its **roots**
+into the eight named cutpoints. An unclassified root fails closed, so a product
+that adds a stage forces a harness update instead of silently dropping proving
+time. A missing mandatory root also fails closed.
+
+| cutpoint | source |
+|---|---|
+| `execute` | `report.timing.execute_ns` |
+| `witness` | `preprocessed_plan`, `preprocessed_table_build`, `base_trace_build`, `air_template_instantiation` |
+| `commit` | `preprocessed_materialize_and_commit`, `main_trace_commit` |
+| `interaction` | `interaction_trace_build`, `interaction_trace_commit` |
+| `composition` | `draw_random_coeff`, `composition_trace_extract`, `composition_evaluation`, `composition_interpolate_and_split`, `composition_commit` (+ optional Metal roots `composition_device_admission`, `composition_device_declined`, `composition_device_components`, `composition_device_host_components`, `composition_device_fallbacks`) |
+| `fri` | `oods_point_and_mask_points`, `sampled_value_evaluation`, `sampled_value_channel_mix`, `fri_quotient_build_and_commit`, `proof_of_work`, `fri_decommit`, `trace_decommit`, `constraint_check_and_assembly` |
+| `serialize` | **not instrumented — emitted as `null`** |
+| `verify` | `report.timing.verify_ns` |
+
+## Mechanism telemetry
+
+`mechanism_telemetry.required_fields` is manifest data, validated against
+`manifest.CAIRO_MECHANISM_FIELDS`. The subset in
+`manifest.CAIRO_STABLE_MECHANISM_FIELDS` is semantics rather than
+implementation and must be identical across measured samples (and, once the
+paired comparison is wired, across the A and B arms):
+
+- stable: `profile`, `input_sha256`, `proof_format`, `proof_bytes`,
+  `proof_sha256`, `stwo_cairo_revision`, `stwo_revision`
+- identity: `product_identity_sha256`, `protocol_manifest_sha256`
+- timing: `mean_execute_seconds`, `mean_prove_seconds`, `mean_verify_seconds`,
+  `mean_cold_process_seconds`
+- phases: `phase_seconds` (mandatory)
+- Metal lane: `metal_dispatches`, `cpu_fallbacks`
+
+## Retained evidence
+
+`_bench_cairo` writes one envelope per arm per round at
+`<out_dir>/<workload>.<tag>.json`:
+
+```
+schema                  "cairo_proof_v1"
+workload / group / board
+warmups / samples
+measurement_boundary    "cold_process"
+phase_profile_source    {invocation_index, scored: false, note}
+phase_seconds           the eight named cutpoints
+mechanism               exactly the manifest-declared required fields
+measured_samples        one normalized record per scored sample
+product_reports         the raw product reports, verbatim
+```
+
+Warmup proofs are deleted; measured-sample proofs are retained next to the
+envelope so the official verifier can be pointed at them.
+
+## Workload basket
+
+Committed, runnable (TRACKS §3.3):
+
+| workload | class | fixture | committed cells | note |
+|---|---|---|---|---|
+| `cairo_all_opcodes` | small | `vectors/cairo/official/all_opcodes.prover_input.json` (177 KiB) | 97,420,320 | campaign portfolio entry 1 |
+| `cairo_all_builtins` | wide | `vectors/cairo/official/all_builtins.prover_input.json` (900 KiB) | — | builtin-saturating killer workload |
+
+Both use official security parameters through their committed
+`*.params.json` profiles (`all_opcodes` → `official-live-cairo-canonical-small`,
+`all_builtins` → `official-live-cairo-canonical`). No functional-mode scoring
+exists on Cairo.
+
+Every Cairo class is a **standard** resource class. The Cairo CLIs have no
+`--resource-profile` flag, so `xlarge`/`huge`/`extreme` (which the manifest
+requires to pass `--resource-profile`) cannot be used until the product gains
+that flag.
+
+The acceptance corpus is `vectors/cairo/cairo_program_matrix.json` (pinned
+`zksecurity/zkvm-benchmarks` @ `6d9d1e5e5a8086e6b3a52b03017421159f65ee6e`),
+wired as `acceptance_corpus` with a `sha256` that `manifest.load()` verifies
+against the committed bytes on every load. It is acceptance material, never a
+scored basket.
+
+### Large-fixture provisioning
+
+Six of the seven campaign-portfolio workloads have prover inputs that are
+host-local and far above any sane repository fixture budget (`memory-7m` alone
+is 7,367,979 VM steps and needs roughly 17–18 GiB resident memory to prove).
+They are declared in `workload_registry.groups.cairo_cpu.workload_provisioning.pending`
+so their absence is loud, and they are not runnable workloads.
+
+Regenerating one on a provisioning host:
+
+```sh
+# 1. Build the pinned official Cairo VM adapter (it is the only admissible
+#    execution sidecar; its identity is checked by the product at run time).
+cargo build --locked --release \
+  --manifest-path tools/stwo-cairo-vm-adapter-rs/Cargo.toml
+
+# 2. Execute the compiled Cairo program into an official ProverInput.
+STWO_CAIRO_VM_ADAPTER=$PWD/target/release/stwo-cairo-vm-adapter \
+  ./target/release/stwo-cairo-vm-adapter run \
+    --program /path/to/<workload>.compiled.json \
+    --program-type json \
+    --arguments /path/to/<workload>.arguments.json \
+    --prover-input-out /path/to/<workload>.prover_input.json
+
+# 3. Prove and verify it with the released product to confirm the fixture.
+zig build stwo-cairo-cpu -Doptimize=ReleaseFast
+./zig-out/bin/stwo-cairo-cpu prove \
+  --prover-input /path/to/<workload>.prover_input.json \
+  --params vectors/cairo/official/all_builtins.params.json \
+  --proof /path/to/<workload>.proof.json \
+  --stage-profile-out /path/to/<workload>.stages.json \
+  --verify
+
+# 4. Confirm with the pinned official Rust verifier before trusting it.
+cargo run --locked --release \
+  --manifest-path tools/stwo-cairo-official-verifier-rs/Cargo.toml -- verify \
+  --proof /absolute/path/<workload>.proof.json \
+  --channel blake2s --proof-format json \
+  --result /absolute/path/<workload>.verdict.json
+```
+
+A fixture only enters the manifest with an adjacent provenance record naming
+the compiled program, its digest, the adapter identity, and the pinned
+Stwo-Cairo revision — the shape already used by
+`vectors/cairo/programs/official_corpus.provenance.json`.
+
+## Correctness oracle
+
+Both Cairo groups pin the official Stwo-Cairo verifier as `final_validator`:
+
+```
+authority        official-stwo-cairo-verifier
+repository       https://github.com/starkware-libs/stwo-cairo
+commit           82f21252a68ec006d73e299f5bf1ce6d4db0ee78
+stwo_repository  https://github.com/starkware-libs/stwo
+stwo_commit      7b211edde786775016ef3eecb837a6240d8fe792
+adapter          tools/stwo-cairo-official-verifier-rs
+build_command    cargo build --locked --release \
+                   --manifest-path tools/stwo-cairo-official-verifier-rs/Cargo.toml
+```
+
+Those revisions are the ones declared by
+`tools/stwo-cairo-official-verifier-rs/Cargo.toml`
+(`[package.metadata.official-verifier]`), bound to full commits by its
+`Cargo.lock`, and recorded in the Cairo Lane of `conformance/upstream.md`. Zig
+scalar, SIMD, Metal, trace-oracle, or Zig-verifier agreement never overrides an
+official-verifier rejection.
+
+## Promotion
+
+Neither Cairo board is promotion eligible. `cairo_cpu` runs and records
+evidence with `promotion_eligible: false` and a `promotion_blocked_reason`;
+`manifest._validate_cairo_group` refuses any Cairo group that sets
+`promotion_eligible: true`, and `_validate` refuses any live group that is
+unpromotable without stating why. The gate opens only after per-(board, class)
+A/A dispersion and anchors are measured on the designated Apple M5 Max judge
+host and frozen (TRACKS §7).
+
+## Gaps in the current product CLI
+
+These are real, and none of them is papered over:
+
+1. **No request-scoped span.** `timing.prove_ns` starts *after* the prover
+   input, witness programs, feed topology, fixed tables, relation templates,
+   and AIR template library are read, and stops before the proof is encoded and
+   written. The product emits no timestamp pair covering read → verify, so the
+   harness scores the strictly wider cold-process boundary instead. Closing
+   this needs a `timing.request_ns` in
+   `src/products/cairo/shared/application.zig` (product ownership, not harness).
+2. **No `serialize` cutpoint.** Proof encoding, compression, writing, and
+   hashing all happen outside the stage recorder. `phase_seconds.serialize` is
+   `null`.
+3. **No resource telemetry.** The Cairo report carries no RSS, energy,
+   instruction, or cycle counters, so `peak_rss_mib`, `energy_j`,
+   `instructions`, and `cycles` are `None` and `resources_complete` is `false`.
+   `all_builtins` measured ~16.7 GiB peak footprint out of band; a Cairo
+   equivalent of the RISC-V `resources` block would make G4/G5 resource gates
+   usable on this track.
+4. **No CPU-seconds.** TRACKS §3.2 asks for dual time units per cell (wall and
+   CPU). The product reports wall time only.
+5. **No `--resource-profile`.** Large resource classes are unreachable until
+   the CLI accepts one.
+6. **No holdout generator.** With two committed workloads there is no pool to
+   jitter; TRACKS §3.3 wants the seeded pool extended to this group once the
+   portfolio fixtures are provisioned.

--- a/autoresearch/tests/fixtures/cairo/cairo_product_report_v2.json
+++ b/autoresearch/tests/fixtures/cairo/cairo_product_report_v2.json
@@ -1,0 +1,85 @@
+{
+ "schema_version": 2,
+ "product": {
+  "schema_version": 2,
+  "name": "stwo-cairo-cpu",
+  "frontend": "cairo",
+  "backend": "cpu",
+  "role": "cli",
+  "protocol_features": "stwo-cairo-v1.2.2+cairo-executable-v1+cairo-lang-2.20.0+cairo-vm-3.2.0+official-vm-adapter-v2+official-json-v1+cairo-serde-v1+bincode-v1+bzip2-1.0.8+live-geometry-v1+air-template-library-v1+lifted-pcs-v2+blake2s+authenticated-witness-cpu-aot-v1",
+  "protocol_manifest_sha256": "120493a3b6a8b328224badb949a836ad821e76494a4e80f6fe281db34b2965fc",
+  "identity_sha256": "dad506603b5ce6500d74d28212959b3882c6cbf6696faf50a2f6061a262863cf",
+  "source": {
+   "repository": "https://github.com/teddyjfpender/stwo-zig",
+   "commit": "07ac6885263e9ce0109047d65565bc8587131d89",
+   "tree": "344f95ffbd1d0298380209a0fe615c7386048188",
+   "dirty": false,
+   "dirty_content_sha256": null
+  },
+  "zig_version": "0.15.2",
+  "target": {
+   "arch": "aarch64",
+   "os": "macos",
+   "abi": "none",
+   "cpu_model": "apple_m4",
+   "cpu_features_sha256": "859c5cadfcabd95e14b648a6c1dad1e42a0e8c6657abe2d935c19c104848975b"
+  },
+  "optimize": "ReleaseFast",
+  "runtime": {
+   "manifest": "none",
+   "sdk": "none",
+   "aot": "none"
+  },
+  "upstream": {
+   "stwo_cairo_revision": "82f21252a68ec006d73e299f5bf1ce6d4db0ee78",
+   "stwo_revision": "7b211edde786775016ef3eecb837a6240d8fe792",
+   "cairo_language_version": "2.20.0",
+   "cairo_vm_version": "3.2.0"
+  }
+ },
+ "frontend": "cairo",
+ "backend": "cpu",
+ "backend_evidence": {
+  "execution": "cpu-simd",
+  "classification": "host-only",
+  "metal_dispatches": 0,
+  "cpu_fallbacks": 0,
+  "runtime_initializations": 0,
+  "runtime_shutdowns": 0,
+  "commit_source_arena_aliases": 0,
+  "commit_source_arena_memcpys": 0,
+  "commit_source_uploads": 0
+ },
+ "preprocessed_cache": {
+  "enabled": true,
+  "budget_bytes": 2147483648,
+  "hits": 0,
+  "misses": 2,
+  "stores": 2,
+  "evictions": 0,
+  "loaded_bytes": 0,
+  "stored_bytes": 136315104,
+  "evicted_bytes": 0,
+  "directory_bytes": 136315104,
+  "eviction_ns": 44333
+ },
+ "profile": "official-live-cairo-canonical-small",
+ "execution": null,
+ "input": {
+  "sha256": "7f94bd5dcf32e7dd69a8a47f42d41830b4fdd3b75846ef9f7694f3164117fcd6"
+ },
+ "proof": {
+  "format": "json",
+  "bytes": 3006412,
+  "sha256": "79ae76e1ac0c48b1e3b06810ddb1fed8aabe5dfb10d028e879105b79716cb310"
+ },
+ "timing": {
+  "execute_ns": 0,
+  "prove_ns": 1758413875,
+  "verify_ns": 7667334
+ },
+ "verification": {
+  "requested": true,
+  "zig": true
+ }
+}

--- a/autoresearch/tests/fixtures/cairo/cairo_stage_profile_v1.json
+++ b/autoresearch/tests/fixtures/cairo/cairo_stage_profile_v1.json
@@ -1,0 +1,112 @@
+{
+ "schema_version": 1,
+ "runtime": "cpu",
+ "example": "cairo",
+ "stages": [
+  {
+   "id": "preprocessed_plan",
+   "label": "Preprocessed plan",
+   "seconds": 7e-05
+  },
+  {
+   "id": "preprocessed_table_build",
+   "label": "Preprocessed table build",
+   "seconds": 0.137283
+  },
+  {
+   "id": "base_trace_build",
+   "label": "Base trace build",
+   "seconds": 0.020883
+  },
+  {
+   "id": "air_template_instantiation",
+   "label": "AIR template instantiation",
+   "seconds": 0.000198
+  },
+  {
+   "id": "preprocessed_materialize_and_commit",
+   "label": "Preprocessed materialize and commit",
+   "seconds": 0.1992
+  },
+  {
+   "id": "main_trace_commit",
+   "label": "Main trace commit",
+   "seconds": 0.204005
+  },
+  {
+   "id": "interaction_trace_build",
+   "label": "Interaction trace build",
+   "seconds": 0.142084
+  },
+  {
+   "id": "interaction_trace_commit",
+   "label": "Interaction trace commit",
+   "seconds": 0.298161
+  },
+  {
+   "id": "draw_random_coeff",
+   "label": "Draw random coefficient",
+   "seconds": 0
+  },
+  {
+   "id": "composition_trace_extract",
+   "label": "Composition trace extract",
+   "seconds": 1.7e-05
+  },
+  {
+   "id": "composition_evaluation",
+   "label": "Composition evaluation",
+   "seconds": 0.291588
+  },
+  {
+   "id": "composition_interpolate_and_split",
+   "label": "Composition interpolate and split",
+   "seconds": 0.007813
+  },
+  {
+   "id": "composition_commit",
+   "label": "Composition commit",
+   "seconds": 0.067749
+  },
+  {
+   "id": "oods_point_and_mask_points",
+   "label": "OODS point and mask points",
+   "seconds": 0.000155
+  },
+  {
+   "id": "sampled_value_evaluation",
+   "label": "Sampled-value evaluation",
+   "seconds": 0.037828
+  },
+  {
+   "id": "sampled_value_channel_mix",
+   "label": "Sampled-value channel mix",
+   "seconds": 0.000105
+  },
+  {
+   "id": "fri_quotient_build_and_commit",
+   "label": "FRI quotient build + commit (lazy)",
+   "seconds": 0.18838
+  },
+  {
+   "id": "proof_of_work",
+   "label": "Proof of work",
+   "seconds": 0.086572
+  },
+  {
+   "id": "fri_decommit",
+   "label": "FRI decommit",
+   "seconds": 0.004704
+  },
+  {
+   "id": "trace_decommit",
+   "label": "Trace decommit",
+   "seconds": 0.001474
+  },
+  {
+   "id": "constraint_check_and_assembly",
+   "label": "Constraint check and assembly",
+   "seconds": 0.000707
+  }
+ ]
+}

--- a/autoresearch/tests/test_cairo_boards.py
+++ b/autoresearch/tests/test_cairo_boards.py
@@ -1,0 +1,707 @@
+"""Wave-1 Cairo tracks: manifest groups, cairo_proof_v1 parser, ledger boards.
+
+Contract: autoresearch/TRACKS.md §2 (track taxonomy), §3.1-3.3 (dual boundary,
+named phase cutpoints, workload baskets), §3.4 (objective boards must be
+registered in ledger.BOARDS), §7 (calibration gates promotion), §8 (wave 1).
+"""
+
+import copy
+import hashlib
+import json
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "cli"))
+from stwo_perf import ledger, manifest as manifest_mod, runner
+from stwo_perf.manifest import Manifest, ManifestError
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "cairo"
+
+PINNED_STWO_CAIRO = "82f21252a68ec006d73e299f5bf1ce6d4db0ee78"
+PINNED_STWO = "7b211edde786775016ef3eecb837a6240d8fe792"
+
+CAIRO_ARGS = (
+    "prove --prover-input vectors/cairo/official/all_opcodes.prover_input.json "
+    "--params vectors/cairo/official/all_opcodes.params.json "
+    "--proof-format json --verify"
+)
+
+FAKE_PRODUCT = '''#!/usr/bin/env python3
+import hashlib
+import json
+import sys
+
+REPORT = json.loads(REPORT_JSON)
+PROFILE = json.loads(PROFILE_JSON)
+
+args = sys.argv[1:]
+proof_path = args[args.index("--proof") + 1]
+payload = PROOF_PAYLOAD
+with open(proof_path, "wb") as handle:
+    handle.write(payload)
+REPORT["proof"]["bytes"] = len(payload)
+REPORT["proof"]["sha256"] = hashlib.sha256(payload).hexdigest()
+if "--stage-profile-out" in args:
+    with open(args[args.index("--stage-profile-out") + 1], "w") as handle:
+        json.dump(PROFILE, handle)
+MUTATE
+print(json.dumps(REPORT))
+'''
+
+
+def load_report() -> dict:
+    return json.loads((FIXTURES / "cairo_product_report_v2.json").read_text())
+
+
+def load_profile() -> dict:
+    return json.loads((FIXTURES / "cairo_stage_profile_v1.json").read_text())
+
+
+def cairo_group_spec(**overrides) -> dict:
+    spec = {
+        "enabled": True,
+        "promotion_eligible": False,
+        "promotion_blocked_reason": "no judge-host calibration yet",
+        "board": "cairo_cpu",
+        "build_step": "true",
+        "binary": "bin/stwo-cairo-cpu",
+        "report_schema": "cairo_proof_v1",
+        "correctness_oracle": {
+            "authority": "official-stwo-cairo-verifier",
+            "repository": "https://github.com/starkware-libs/stwo-cairo",
+            "commit": PINNED_STWO_CAIRO,
+            "stwo_repository": "https://github.com/starkware-libs/stwo",
+            "stwo_commit": PINNED_STWO,
+            "adapter": "tools/stwo-cairo-official-verifier-rs",
+            "build_command": "cargo build --locked --release",
+            "final_validator": True,
+        },
+        "gates_policy": {
+            "warmups": 1,
+            "samples_per_round": 1,
+            "min_rounds": 3,
+            "max_rounds": 3,
+        },
+        "mechanism_telemetry": {
+            "fail_closed": True,
+            "required_fields": [
+                "product_identity_sha256", "protocol_manifest_sha256", "profile",
+                "input_sha256", "proof_format", "proof_bytes", "proof_sha256",
+                "stwo_cairo_revision", "stwo_revision", "mean_execute_seconds",
+                "mean_prove_seconds", "mean_verify_seconds",
+                "mean_cold_process_seconds", "phase_seconds",
+            ],
+        },
+        "workloads": {
+            "cairo_all_opcodes": {
+                "class": "small",
+                "args": CAIRO_ARGS,
+                "native_unit": "committed cells",
+            },
+        },
+    }
+    spec.update(overrides)
+    return spec
+
+
+def raw_manifest(**overrides) -> dict:
+    return {
+        "manifest_version": 2,
+        "harness": {"anchor_commit": None},
+        "editable_paths": [],
+        "locked_paths": [],
+        "gates_policy": {
+            "ci_level": 0.95,
+            "theta_floor": 0.01,
+            "dispersion_multiplier": 2.0,
+            "warmups": 1,
+            "samples_per_round": 1,
+            "min_rounds": 3,
+            "max_rounds": 3,
+            "search_health": {
+                "trailing_window": 4,
+                "gradient_snr_threshold": 2.0,
+                "auto_boost_rounds": 2,
+                "maximum_rounds": 8,
+            },
+            "wall_clock_cap_seconds": {"small": 120},
+        },
+        "qualification_policy": {
+            "required_checks": ["allowed_diff"],
+            "max_active_per_user": 1,
+        },
+        "workload_registry": {
+            "classes": {
+                "small": {
+                    "scored": True,
+                    "resource": {
+                        "profile": "standard",
+                        "command_timeout_seconds": 120,
+                        "wall_clock_cap_seconds": 120,
+                    },
+                    "sampling": {
+                        "warmups": 1,
+                        "samples_per_round": 1,
+                        "min_rounds": 3,
+                        "max_rounds": 3,
+                    },
+                },
+            },
+            "groups": {"cairo_cpu": cairo_group_spec(**overrides)},
+        },
+    }
+
+
+class CairoManifestGroupTest(unittest.TestCase):
+    """The committed MANIFEST.json actually declares the wave-1 Cairo tracks."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.m = manifest_mod.load(REPO_ROOT)
+
+    def test_cairo_cpu_is_live_and_never_promotion_eligible(self):
+        group = self.m.group_for_board("cairo_cpu")
+        self.assertEqual(group.group_id, "cairo_cpu")
+        self.assertTrue(group.enabled)
+        self.assertFalse(group.promotion_eligible)
+        self.assertIn("calibration", (group.promotion_blocked_reason or "").lower())
+        self.assertEqual(
+            group.build_step, "zig build stwo-cairo-cpu -Doptimize=ReleaseFast",
+        )
+        self.assertEqual(group.binary, "zig-out/bin/stwo-cairo-cpu")
+        self.assertEqual(group.report_schema, "cairo_proof_v1")
+
+    def test_cairo_metal_is_staged_dark_like_the_cuda_group(self):
+        group = self.m.group_for_board("cairo_metal")
+        self.assertFalse(group.enabled)
+        self.assertFalse(group.promotion_eligible)
+        self.assertIn("parity_gated", group.disabled_reason)
+        self.assertEqual(
+            group.build_step, "zig build stwo-cairo-metal -Doptimize=ReleaseFast",
+        )
+        self.assertEqual(group.binary, "zig-out/bin/stwo-cairo-metal")
+        self.assertEqual(group.report_schema, "cairo_proof_v1")
+
+    def test_both_cairo_groups_pin_the_official_verifier_as_final_validator(self):
+        cargo = (
+            REPO_ROOT / "tools" / "stwo-cairo-official-verifier-rs" / "Cargo.toml"
+        ).read_text()
+        self.assertIn(f'stwo-cairo-revision = "{PINNED_STWO_CAIRO}"', cargo)
+        self.assertIn(f'stwo-revision = "{PINNED_STWO}"', cargo)
+        for board in ("cairo_cpu", "cairo_metal"):
+            oracle = self.m.group_for_board(board).correctness_oracle
+            self.assertEqual(oracle["authority"], "official-stwo-cairo-verifier")
+            self.assertEqual(oracle["commit"], PINNED_STWO_CAIRO)
+            self.assertEqual(oracle["stwo_commit"], PINNED_STWO)
+            self.assertEqual(
+                oracle["adapter"], "tools/stwo-cairo-official-verifier-rs",
+            )
+            self.assertIs(oracle["final_validator"], True)
+
+    def test_cairo_workloads_use_committed_fixtures_and_standard_classes(self):
+        for board in ("cairo_cpu", "cairo_metal"):
+            group = self.m.group_for_board(board)
+            self.assertTrue(group.workloads)
+            for workload in group.workloads:
+                self.assertIn(workload.workload_class, ("small", "wide"))
+                command, proof_format, verify = runner._cairo_command(workload)
+                self.assertEqual(command, "prove")
+                self.assertEqual(proof_format, "json")
+                self.assertTrue(verify)
+                fixture = workload.args.split("--prover-input ")[1].split(" ")[0]
+                params = workload.args.split("--params ")[1].split(" ")[0]
+                self.assertTrue((REPO_ROOT / fixture).is_file(), fixture)
+                self.assertTrue((REPO_ROOT / params).is_file(), params)
+
+    def test_acceptance_corpus_is_wired_and_digest_bound(self):
+        corpus = self.m.group_for_board("cairo_cpu").acceptance_corpus
+        self.assertEqual(corpus["path"], "vectors/cairo/cairo_program_matrix.json")
+        payload = (REPO_ROOT / corpus["path"]).read_bytes()
+        self.assertEqual(hashlib.sha256(payload).hexdigest(), corpus["sha256"])
+        matrix = json.loads(payload)
+        self.assertEqual(matrix["kind"], "cairo_acceptance_corpus")
+        self.assertEqual(
+            matrix["source_repository"]["url"],
+            "https://github.com/zksecurity/zkvm-benchmarks.git",
+        )
+
+    def test_uncommitted_portfolio_entries_are_declared_not_hidden(self):
+        provisioning = self.m.group_for_board("cairo_cpu").workload_provisioning
+        pending = provisioning["pending"]
+        self.assertIn("cairo_memory_7m", pending)
+        self.assertEqual(pending["cairo_memory_7m"]["committed_cells"], 604162096)
+        runnable = {
+            w.workload_id for w in self.m.group_for_board("cairo_cpu").workloads
+        }
+        self.assertEqual(runnable & set(pending), set())
+        self.assertEqual(
+            provisioning["documentation"], "autoresearch/schema/cairo-proof-v1.md",
+        )
+        self.assertTrue(
+            (REPO_ROOT / provisioning["documentation"]).is_file(),
+        )
+
+    def test_cairo_report_schema_is_registered(self):
+        self.assertIn("cairo_proof_v1", manifest_mod.REPORT_SCHEMA_VERSIONS)
+        self.assertEqual(manifest_mod.REPORT_SCHEMA_VERSIONS["cairo_proof_v1"], 1)
+
+
+class CairoManifestValidationTest(unittest.TestCase):
+    """Every Cairo-specific manifest rule fails closed."""
+
+    def _load(self, **overrides) -> Manifest:
+        raw = raw_manifest(**overrides)
+        manifest_mod._validate(raw)
+        return Manifest(root=REPO_ROOT, raw=raw)
+
+    def test_valid_fixture_group_loads(self):
+        manifest = self._load()
+        self.assertEqual(manifest.group("cairo_cpu").board, "cairo_cpu")
+
+    def test_promotion_eligible_cairo_group_is_rejected(self):
+        raw = raw_manifest()
+        raw["workload_registry"]["groups"]["cairo_cpu"]["promotion_eligible"] = True
+        with self.assertRaisesRegex(ManifestError, "promotion eligible"):
+            manifest_mod._validate(raw)
+
+    def test_live_unpromotable_group_must_say_why(self):
+        raw = raw_manifest()
+        del raw["workload_registry"]["groups"]["cairo_cpu"]["promotion_blocked_reason"]
+        with self.assertRaisesRegex(ManifestError, "promotion_blocked_reason"):
+            manifest_mod._validate(raw)
+
+    def test_missing_oracle_is_rejected(self):
+        raw = raw_manifest()
+        del raw["workload_registry"]["groups"]["cairo_cpu"]["correctness_oracle"]
+        with self.assertRaisesRegex(ManifestError, "correctness_oracle must pin"):
+            manifest_mod._validate(raw)
+
+    def test_unpinned_oracle_commit_is_rejected(self):
+        raw = raw_manifest()
+        oracle = raw["workload_registry"]["groups"]["cairo_cpu"]["correctness_oracle"]
+        oracle["commit"] = "82f21252"
+        with self.assertRaisesRegex(ManifestError, "full lowercase Git commit"):
+            manifest_mod._validate(raw)
+
+    def test_non_final_validator_oracle_is_rejected(self):
+        raw = raw_manifest()
+        oracle = raw["workload_registry"]["groups"]["cairo_cpu"]["correctness_oracle"]
+        oracle["final_validator"] = False
+        with self.assertRaisesRegex(ManifestError, "final validator"):
+            manifest_mod._validate(raw)
+
+    def test_foreign_oracle_authority_is_rejected(self):
+        raw = raw_manifest()
+        oracle = raw["workload_registry"]["groups"]["cairo_cpu"]["correctness_oracle"]
+        oracle["authority"] = "pinned-rust-stwo"
+        with self.assertRaisesRegex(ManifestError, "official stwo-cairo verifier"):
+            manifest_mod._validate(raw)
+
+    def test_unknown_mechanism_field_is_rejected(self):
+        raw = raw_manifest()
+        group = raw["workload_registry"]["groups"]["cairo_cpu"]
+        group["mechanism_telemetry"]["required_fields"].append("prove_ms")
+        with self.assertRaisesRegex(ManifestError, "unsupported mechanism field"):
+            manifest_mod._validate(raw)
+
+    def test_missing_stable_mechanism_field_is_rejected(self):
+        raw = raw_manifest()
+        group = raw["workload_registry"]["groups"]["cairo_cpu"]
+        group["mechanism_telemetry"]["required_fields"].remove("proof_sha256")
+        with self.assertRaisesRegex(ManifestError, "omits stable field"):
+            manifest_mod._validate(raw)
+
+    def test_missing_phase_telemetry_is_rejected(self):
+        raw = raw_manifest()
+        group = raw["workload_registry"]["groups"]["cairo_cpu"]
+        group["mechanism_telemetry"]["required_fields"].remove("phase_seconds")
+        with self.assertRaisesRegex(ManifestError, "phase_seconds"):
+            manifest_mod._validate(raw)
+
+    def test_lax_mechanism_telemetry_is_rejected(self):
+        raw = raw_manifest()
+        group = raw["workload_registry"]["groups"]["cairo_cpu"]
+        group["mechanism_telemetry"]["fail_closed"] = False
+        with self.assertRaisesRegex(ManifestError, "must fail closed"):
+            manifest_mod._validate(raw)
+
+    def test_resource_telemetry_is_refused_for_cairo(self):
+        raw = raw_manifest()
+        group = raw["workload_registry"]["groups"]["cairo_cpu"]
+        group["resource_telemetry"] = {"fail_closed": True}
+        with self.assertRaisesRegex(ManifestError, "only valid for"):
+            manifest_mod._validate(raw)
+
+    def test_acceptance_corpus_shape_fails_closed(self):
+        raw = raw_manifest()
+        group = raw["workload_registry"]["groups"]["cairo_cpu"]
+        group["acceptance_corpus"] = {"path": "vectors/x.json"}
+        with self.assertRaisesRegex(ManifestError, "requires path and sha256"):
+            manifest_mod._validate(raw)
+        group["acceptance_corpus"] = {"path": "/etc/passwd", "sha256": "a" * 64}
+        with self.assertRaisesRegex(ManifestError, "repository vectors path"):
+            manifest_mod._validate(raw)
+        group["acceptance_corpus"] = {"path": "vectors/x.json", "sha256": "nope"}
+        with self.assertRaisesRegex(ManifestError, "canonical lowercase SHA-256"):
+            manifest_mod._validate(raw)
+
+    def test_drifted_acceptance_corpus_digest_fails_the_load(self):
+        raw = json.loads((REPO_ROOT / "autoresearch" / "MANIFEST.json").read_text())
+        group = raw["workload_registry"]["groups"]["cairo_cpu"]
+        group["acceptance_corpus"]["sha256"] = "0" * 64
+        with self.assertRaisesRegex(ManifestError, "digest drifted"):
+            manifest_mod._validate_acceptance_corpora(REPO_ROOT, raw)
+
+    def test_missing_acceptance_corpus_fails_a_complete_checkout(self):
+        raw = json.loads((REPO_ROOT / "autoresearch" / "MANIFEST.json").read_text())
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            (repo / "vectors" / "cairo").mkdir(parents=True)
+            with self.assertRaisesRegex(ManifestError, "not readable"):
+                manifest_mod._validate_acceptance_corpora(repo, raw)
+
+    def test_harness_only_tree_has_no_corpus_to_bind(self):
+        raw = json.loads((REPO_ROOT / "autoresearch" / "MANIFEST.json").read_text())
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_mod._validate_acceptance_corpora(Path(tmp), raw)
+
+    def test_pending_provisioning_entries_are_shape_checked(self):
+        raw = raw_manifest()
+        group = raw["workload_registry"]["groups"]["cairo_cpu"]
+        group["workload_provisioning"] = {
+            "note": "n", "documentation": "d",
+            "pending": {"x": {"vm_steps": 1, "committed_cells": 2, "reason": "r"}},
+        }
+        manifest_mod._validate(raw)
+        group["workload_provisioning"]["pending"]["x"]["vm_steps"] = 0
+        with self.assertRaisesRegex(ManifestError, "positive integer"):
+            manifest_mod._validate(raw)
+
+    def test_pending_entry_cannot_shadow_a_runnable_workload(self):
+        raw = raw_manifest()
+        group = raw["workload_registry"]["groups"]["cairo_cpu"]
+        group["workload_provisioning"] = {
+            "note": "n", "documentation": "d",
+            "pending": {
+                "cairo_all_opcodes": {
+                    "vm_steps": 1, "committed_cells": 2, "reason": "r",
+                },
+            },
+        }
+        with self.assertRaisesRegex(ManifestError, "both a runnable workload"):
+            manifest_mod._validate(raw)
+
+
+class CairoLedgerBoardsTest(unittest.TestCase):
+    def test_wave_one_boards_are_registered(self):
+        for board in ("cairo_cpu", "cairo_metal", "pr6_supremacy"):
+            self.assertIn(board, ledger.BOARDS)
+
+    def test_boards_are_append_only(self):
+        historical = (
+            "core_cpu", "core_hybrid", "core_metal", "core_cuda",
+            "heavy_native", "heavy_cairo", "stream", "riscv",
+        )
+        self.assertEqual(ledger.BOARDS[:len(historical)], historical)
+        self.assertEqual(len(set(ledger.BOARDS)), len(ledger.BOARDS))
+
+    def test_every_manifest_board_is_a_registered_board(self):
+        manifest = manifest_mod.load(REPO_ROOT)
+        for group in manifest.groups():
+            self.assertIn(group.board, ledger.BOARDS, group.group_id)
+
+
+class CairoReportParserTest(unittest.TestCase):
+    """cairo_proof_v1 parsing is fail-closed on a real product report."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        raw = raw_manifest()
+        manifest_mod._validate(raw)
+        self.manifest = Manifest(root=self.root, raw=raw)
+        self.group = self.manifest.group("cairo_cpu")
+        self.workload = self.manifest.workloads(board="cairo_cpu")[0]
+        self.report = load_report()
+        self.proof = self.root / "proof.json"
+        payload = b"cairo-proof-artifact"
+        self.proof.write_bytes(payload)
+        self.report["proof"]["bytes"] = len(payload)
+        self.report["proof"]["sha256"] = hashlib.sha256(payload).hexdigest()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _parse(self, report=None):
+        return runner._parse_cairo_report(
+            report if report is not None else self.report,
+            self.group, self.workload, self.proof,
+        )
+
+    def test_valid_report_is_accepted_and_normalized(self):
+        parsed = self._parse()
+        self.assertEqual(parsed["stwo_cairo_revision"], PINNED_STWO_CAIRO)
+        self.assertEqual(parsed["stwo_revision"], PINNED_STWO)
+        self.assertEqual(parsed["proof_format"], "json")
+        self.assertEqual(parsed["profile"], "official-live-cairo-canonical-small")
+        self.assertEqual(len(parsed["product_identity_sha256"]), 64)
+        self.assertGreater(parsed["prove_seconds"], 0.0)
+        self.assertGreater(parsed["verify_seconds"], 0.0)
+        self.assertEqual(parsed["execute_seconds"], 0.0)
+        self.assertEqual(parsed["cpu_fallbacks"], 0)
+
+    def test_wrong_product_schema_version_is_rejected(self):
+        self.report["schema_version"] = 3
+        with self.assertRaisesRegex(runner.RunError, "expected cairo_proof_v1"):
+            self._parse()
+
+    def test_unknown_top_level_field_is_rejected(self):
+        self.report["extra"] = 1
+        with self.assertRaisesRegex(ValueError, r"unknown=\['extra'\]"):
+            self._parse()
+
+    def test_unpinned_upstream_revision_is_rejected(self):
+        self.report["product"]["upstream"]["stwo_cairo_revision"] = "a" * 40
+        with self.assertRaisesRegex(ValueError, "manifest-pinned"):
+            self._parse()
+        self.report["product"]["upstream"]["stwo_cairo_revision"] = PINNED_STWO_CAIRO
+        self.report["product"]["upstream"]["stwo_revision"] = "b" * 40
+        with self.assertRaisesRegex(ValueError, "manifest-pinned"):
+            self._parse()
+
+    def test_foreign_product_binary_is_rejected(self):
+        self.report["product"]["name"] = "stwo-cairo-metal"
+        with self.assertRaisesRegex(ValueError, "declared binary"):
+            self._parse()
+
+    def test_debug_build_is_rejected(self):
+        self.report["product"]["optimize"] = "Debug"
+        with self.assertRaisesRegex(ValueError, "ReleaseFast"):
+            self._parse()
+
+    def test_backend_fallback_is_rejected(self):
+        self.report["backend_evidence"]["cpu_fallbacks"] = 1
+        with self.assertRaisesRegex(ValueError, "cpu_fallbacks must be zero"):
+            self._parse()
+
+    def test_unverified_sample_is_rejected(self):
+        self.report["verification"]["zig"] = False
+        with self.assertRaisesRegex(ValueError, "completed in-process"):
+            self._parse()
+
+    def test_report_must_bind_the_retained_proof(self):
+        self.report["proof"]["sha256"] = "c" * 64
+        with self.assertRaisesRegex(ValueError, "does not match the retained proof"):
+            self._parse()
+        self.report["proof"]["sha256"] = "not-hex"
+        with self.assertRaisesRegex(ValueError, "canonical lowercase SHA-256"):
+            self._parse()
+
+    def test_missing_proof_artifact_is_rejected(self):
+        self.proof.unlink()
+        with self.assertRaisesRegex(ValueError, "did not retain the requested proof"):
+            self._parse()
+
+    def test_prove_report_may_not_claim_execution(self):
+        self.report["execution"] = {
+            "program_type": "json", "program_sha256": "d" * 64,
+            "arguments_sha256": None, "adapter_sha256": "e" * 64, "wall_ns": 5,
+        }
+        with self.assertRaisesRegex(ValueError, "null execution"):
+            self._parse()
+
+    def test_workload_without_verify_is_refused(self):
+        raw = raw_manifest()
+        args = CAIRO_ARGS.replace(" --verify", "")
+        raw["workload_registry"]["groups"]["cairo_cpu"]["workloads"][
+            "cairo_all_opcodes"]["args"] = args
+        manifest_mod._validate(raw)
+        workload = Manifest(self.root, raw).workloads(board="cairo_cpu")[0]
+        with self.assertRaisesRegex(ValueError, "must request --verify"):
+            runner._parse_cairo_report(
+                self.report, self.group, workload, self.proof,
+            )
+
+    def test_workload_may_not_own_the_runner_output_paths(self):
+        raw = raw_manifest()
+        raw["workload_registry"]["groups"]["cairo_cpu"]["workloads"][
+            "cairo_all_opcodes"]["args"] = CAIRO_ARGS + " --proof /tmp/x.json"
+        manifest_mod._validate(raw)
+        workload = Manifest(self.root, raw).workloads(board="cairo_cpu")[0]
+        with self.assertRaisesRegex(ValueError, "runner owns"):
+            runner._parse_cairo_report(
+                self.report, self.group, workload, self.proof,
+            )
+
+    def test_declared_proof_format_must_match(self):
+        self.report["proof"]["format"] = "binary"
+        with self.assertRaisesRegex(ValueError, "is not the requested"):
+            self._parse()
+
+
+class CairoStageProfileTest(unittest.TestCase):
+    """TRACKS §3.2 named cutpoints: complete, classified, or fail closed."""
+
+    def setUp(self):
+        raw = raw_manifest()
+        manifest_mod._validate(raw)
+        self.workload = Manifest(REPO_ROOT, raw).workloads(board="cairo_cpu")[0]
+        self.profile = load_profile()
+
+    def test_every_named_cutpoint_is_derived(self):
+        phases = runner._parse_cairo_stage_profile(self.profile, self.workload)
+        self.assertEqual(
+            set(phases),
+            {"witness", "commit", "interaction", "composition", "fri"},
+        )
+        for phase, seconds in phases.items():
+            self.assertGreater(seconds, 0.0, phase)
+
+    def test_phase_partition_covers_every_root_exactly_once(self):
+        owners = {}
+        for phase, (required, optional) in runner.CAIRO_PHASE_STAGES.items():
+            for stage_id in required + optional:
+                self.assertNotIn(stage_id, owners)
+                owners[stage_id] = phase
+        roots = [node["id"] for node in self.profile["stages"]]
+        self.assertTrue(set(roots) <= set(owners))
+        total = sum(node["seconds"] for node in self.profile["stages"])
+        phases = runner._parse_cairo_stage_profile(self.profile, self.workload)
+        self.assertAlmostEqual(total, sum(phases.values()), places=9)
+
+    def test_unclassified_stage_root_fails_closed(self):
+        profile = copy.deepcopy(self.profile)
+        profile["stages"].append(
+            {"id": "brand_new_stage", "label": "New", "seconds": 1.0},
+        )
+        with self.assertRaisesRegex(ValueError, "unclassified Cairo stage root"):
+            runner._parse_cairo_stage_profile(profile, self.workload)
+
+    def test_missing_mandatory_cutpoint_fails_closed(self):
+        profile = copy.deepcopy(self.profile)
+        profile["stages"] = [
+            node for node in profile["stages"]
+            if node["id"] != "fri_quotient_build_and_commit"
+        ]
+        with self.assertRaisesRegex(ValueError, "missing mandatory cutpoint"):
+            runner._parse_cairo_stage_profile(profile, self.workload)
+
+    def test_wrong_stage_schema_version_fails_closed(self):
+        profile = copy.deepcopy(self.profile)
+        profile["schema_version"] = 2
+        with self.assertRaisesRegex(ValueError, "schema_version is not"):
+            runner._parse_cairo_stage_profile(profile, self.workload)
+
+    def test_non_cairo_profile_fails_closed(self):
+        profile = copy.deepcopy(self.profile)
+        profile["example"] = "wide_fibonacci"
+        with self.assertRaisesRegex(ValueError, "not a Cairo profile"):
+            runner._parse_cairo_stage_profile(profile, self.workload)
+
+    def test_manifest_declares_the_full_named_cutpoint_set(self):
+        derived = set(runner.CAIRO_PHASE_STAGES) | {"execute", "verify"}
+        derived |= set(runner.CAIRO_UNINSTRUMENTED_PHASES)
+        self.assertEqual(derived, set(manifest_mod.CAIRO_PHASE_NAMES))
+
+
+class CairoBenchOnceTest(unittest.TestCase):
+    """bench_once dispatches Cairo to the cold-process warmup/sample loop."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.out_dir = self.root / "runs"
+        raw = raw_manifest()
+        manifest_mod._validate(raw)
+        self.manifest = Manifest(root=self.root, raw=raw)
+        self.workload = self.manifest.workloads(board="cairo_cpu")[0]
+        self._install_product()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _install_product(self, mutate: str = "pass", payload: bytes = b"proof-bytes"):
+        binary = self.root / "bin" / "stwo-cairo-cpu"
+        binary.parent.mkdir(parents=True, exist_ok=True)
+        source = (
+            FAKE_PRODUCT
+            .replace("REPORT_JSON", repr(json.dumps(load_report())))
+            .replace("PROFILE_JSON", repr(json.dumps(load_profile())))
+            .replace("PROOF_PAYLOAD", repr(payload))
+            .replace("MUTATE", mutate)
+        )
+        binary.write_text(source)
+        binary.chmod(binary.stat().st_mode | stat.S_IEXEC)
+
+    def test_cold_process_loop_produces_dual_boundary_and_phases(self):
+        result = runner.bench_once(
+            self.root, self.manifest, self.workload, 1, 2, self.out_dir, "a1",
+        )
+        self.assertEqual(result.proof_verified, 2)
+        self.assertTrue(result.byte_identical)
+        self.assertGreater(result.prove_ms, 0.0)
+        self.assertGreater(result.request_ms, 0.0)
+        self.assertEqual(result.peak_rss_mib, None)
+        self.assertIs(result.resources_complete, False)
+        phases = result.mechanism["phase_seconds"]
+        self.assertEqual(set(phases), set(manifest_mod.CAIRO_PHASE_NAMES))
+        self.assertIsNone(phases["serialize"])
+        self.assertGreater(phases["fri"], 0.0)
+        envelope = json.loads(Path(result.report_path).read_text())
+        self.assertEqual(envelope["schema"], "cairo_proof_v1")
+        self.assertEqual(envelope["measurement_boundary"], "cold_process")
+        self.assertEqual(len(envelope["measured_samples"]), 2)
+        self.assertEqual(len(envelope["product_reports"]), 2)
+        self.assertFalse(envelope["phase_profile_source"]["scored"])
+
+    def test_mechanism_covers_exactly_the_declared_required_fields(self):
+        result = runner.bench_once(
+            self.root, self.manifest, self.workload, 1, 1, self.out_dir, "a1",
+        )
+        declared = self.manifest.group("cairo_cpu").mechanism_telemetry[
+            "required_fields"]
+        self.assertEqual(sorted(result.mechanism), sorted(declared))
+        self.assertTrue(
+            set(declared) <= manifest_mod.CAIRO_MECHANISM_FIELDS,
+        )
+
+    def test_phase_profile_is_recorded_on_the_last_discarded_warmup(self):
+        runner.bench_once(
+            self.root, self.manifest, self.workload, 2, 1, self.out_dir, "a1",
+        )
+        stages = list(self.out_dir.glob("cairo_all_opcodes.a1.stages.json"))
+        self.assertEqual(len(stages), 1)
+        # Warmup proofs are removed; exactly the measured samples are retained.
+        proofs = sorted(p.name for p in self.out_dir.glob("*.proof"))
+        self.assertEqual(proofs, ["cairo_all_opcodes.a1.i2.proof"])
+
+    def test_zero_warmups_is_refused_because_phase_telemetry_is_mandatory(self):
+        with self.assertRaisesRegex(runner.RunError, "at least one warmup"):
+            runner.bench_once(
+                self.root, self.manifest, self.workload, 0, 1, self.out_dir, "a1",
+            )
+
+    def test_drifting_statement_between_samples_fails_closed(self):
+        self._install_product(
+            mutate='\nif proof_path.endswith("i2.proof"):\n'
+                   '    REPORT["input"]["sha256"] = "f" * 64\n',
+        )
+        with self.assertRaisesRegex(runner.RunError, "input_sha256 changed"):
+            runner.bench_once(
+                self.root, self.manifest, self.workload, 1, 2, self.out_dir, "a1",
+            )
+
+    def test_missing_binary_refuses_to_fabricate(self):
+        (self.root / "bin" / "stwo-cairo-cpu").unlink()
+        with self.assertRaisesRegex(runner.RunError, "refusing to fabricate"):
+            runner.bench_once(
+                self.root, self.manifest, self.workload, 1, 1, self.out_dir, "a1",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Opens the campaign-v3 **wave-1 Cairo tracks** (TRACKS §8) with exactly the machinery §8 lists as mechanical work items.

## What lands

**MANIFEST — two new workload groups** (TRACKS §2, §3.1–3.3, §7)

| group | board | state | promotion |
|---|---|---|---|
| `cairo_cpu` | `cairo_cpu` | enabled | **false** — `promotion_blocked_reason` names the missing M5 calibration |
| `cairo_metal` | `cairo_metal` | disabled | **false** — `disabled_reason` cites the `parity_gated` product state |

- Build steps/binaries come from the product catalog: `zig build stwo-cairo-cpu -Doptimize=ReleaseFast` → `zig-out/bin/stwo-cairo-cpu`, and the `stwo-cairo-metal` equivalent.
- Both pin the **official Stwo-Cairo verifier** as `final_validator`: `starkware-libs/stwo-cairo@82f21252a68ec006d73e299f5bf1ce6d4db0ee78` + `starkware-libs/stwo@7b211edde786775016ef3eecb837a6240d8fe792`, adapter `tools/stwo-cairo-official-verifier-rs`. Taken from that package's `Cargo.toml`/`Cargo.lock` and the Cairo Lane of `conformance/upstream.md`.
- `cairo_cpu` wires `vectors/cairo/cairo_program_matrix.json` as its `acceptance_corpus` (path + sha256, digest-bound at manifest load).
- The six campaign-portfolio workloads whose prover inputs are host-local are declared under `workload_provisioning.pending` so the basket's incompleteness is loud, never silent.

**`cairo_proof_v1` report schema + parser**

Defined strictly from what the product CLI already emits — a `schema_version: 2` proving report on stdout plus a `schema_version: 1` stage profile from `--stage-profile-out`. No field was invented. `_parse_cairo_report` / `_parse_cairo_stage_profile` sit next to the riscv/native parsers and fail closed on: exact field sets, the pinned upstream revisions, the declared binary, `ReleaseFast`, any CPU fallback, an unverified sample, a proof that does not hash to the retained artifact, and any unclassified stage root.

**Dual boundary (TRACKS §3.1).** The Cairo CLIs prove one statement per process, so `_bench_cairo` owns the warmup/sample loop and **one sample is one cold process**. The scored boundary is the cold-process boundary; `prove_ms` is demoted to telemetry. The mandatory phase profile is recorded on the **last discarded warmup** so scored samples run uninstrumented.

**Ledger.** `BOARDS` gains `cairo_cpu`, `cairo_metal`, `pr6_supremacy` — appended only, closing the TRACKS §3.4 objective-board registration gap.

**Docs.** `autoresearch/schema/cairo-proof-v1.md` — full field set, phase cutpoint table, large-fixture provisioning commands, and every gap in the current CLI.

## Verified

- `python3 -m unittest discover -s autoresearch/tests` → **428 OK** (373 baseline + 55 new).
- `zig build stwo-cairo-cpu -Doptimize=ReleaseFast` builds on this host; `bench_once` and `paired_rounds` were run end-to-end against the real product on the two committed fixtures.
- `python3 scripts/check_upstream_pins.py` passes.

## Not in this PR

No benchmark numbers, anchors, or A/A dispersion values are recorded anywhere — those require the designated Apple M5 Max judge host and are a handoff. `rust_oracle_check` dispatch for `cairo_proof_v1` and the `paired_rounds` cross-arm mechanism-drift check for Cairo are deliberately left for follow-ups so this PR stays inside its file ownership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
