### PR TITLE
harness: the confirmation ladder — sequential stop, fast boundary, proxy receipts (TRACKS §3.5/§3.6)

### DIFF
--- a/autoresearch/MANIFEST.json
+++ b/autoresearch/MANIFEST.json
@@ -1139,7 +1139,48 @@
       "auto_boost_rounds": 5,
       "maximum_rounds": 25
     },
-    "neutral_band_note": "Promotion requires the declared-objective CI entirely below 1 - theta, where theta = max(theta_floor, dispersion_multiplier x per-class A/A dispersion recorded in the ledger epoch)."
+    "neutral_band_note": "Promotion requires the declared-objective CI entirely below 1 - theta, where theta = max(theta_floor, dispersion_multiplier x per-class A/A dispersion recorded in the ledger epoch).",
+    "confirmation_ladder": {
+      "schema": "stwo_perf_confirmation_ladder_v1",
+      "sequential_stop": {
+        "enabled": false,
+        "rule": "pocock_constant_boundary_bonferroni_v1",
+        "alpha": 0.05,
+        "stop_on_decisive_miss": true
+      },
+      "tiers": {
+        "T0": {
+          "cost_target_seconds": 30,
+          "warmups": 1,
+          "samples": 1,
+          "min_phase_move": 0.02,
+          "note": "correctness smoke plus ONE stage-profiled sample on the proxy fixture; the claimed phase must move here before T1 is scheduled. One warmup is the floor, not a nicety: the Cairo arm records its mandatory phase profile on a discarded warmup, so warmups=0 would leave that track with no phase evidence at all."
+        },
+        "T1": {
+          "cost_target_seconds": 300,
+          "note": "paired ABBA on proxy fixtures with sequential early stopping and the PoW-excluded boundary; never ranks."
+        },
+        "T2": {
+          "cost_target_seconds": 2700,
+          "note": "full dual-boundary paired run on the contributor host, real classes, guards impact-mapped; the claimed verdict."
+        },
+        "T3": {
+          "cost_target_seconds": null,
+          "note": "judge-scheduled re-run plus audits on the designated host; the scored row. No cost target — the judge never trades honesty for time."
+        }
+      },
+      "proxy_validity": {
+        "receipt_schema": "stwo_perf_proxy_validity_receipt_v1",
+        "receipt_dir": "autoresearch/reference/proxy_validity",
+        "min_correlation": 0.8,
+        "min_observations": 5
+      },
+      "cost_telemetry": {
+        "statistic": "median",
+        "window": 5
+      },
+      "note": "TRACKS §3.5/§3.6. sequential_stop.enabled arms the pre-registered spending rule on scored paired runs; the T1 iterate path arms it explicitly because T1 never ranks. Absent this block the runner keeps pre-ladder fixed min/max-round behavior. Tier cost targets are CI-checked per track by scripts/check_tier_cost_targets.py."
+    }
   },
   "qualification_policy": {
     "schema_version": 1,

--- a/autoresearch/cli/stwo_perf/__main__.py
+++ b/autoresearch/cli/stwo_perf/__main__.py
@@ -91,6 +91,13 @@ def _resolve_board(args, m) -> str:
 
 def cmd_run(args) -> int:
     from . import runner
+    if getattr(args, "fast_boundary", False):
+        return _fail(
+            "--fast-boundary is a T1 iterate flag: `stwo-perf run` produces the "
+            "claimed (T2) verdict and T2/T3 keep the full dual boundary — the "
+            "ranked number never excludes anything (TRACKS §3.5). Use "
+            "`stwo-perf ladder t1 --fast-boundary` for the inner loop."
+        )
     m = manifest_mod.load()
     out_dir = m.root / "autoresearch" / ".runs" / "latest"
     board = _resolve_board(args, m)
@@ -169,6 +176,106 @@ def cmd_run(args) -> int:
     print(render.verdict(verdict))
     print()
     print(ansi.style(f"  verdict written to {out}", "dim"))
+    return 0
+
+
+def cmd_ladder(args) -> int:
+    """Confirmation-ladder tiers below the ranked path (TRACKS §3.5)."""
+    from . import runner
+    m = manifest_mod.load()
+    out_dir = m.root / "autoresearch" / ".runs" / "ladder"
+    try:
+        if args.ladder_cmd == "t0":
+            result = runner.phase_prefilter(
+                Path(args.predecessor).resolve(), m.root, m,
+                args.workload_class, out_dir,
+                board=args.board, phase=args.phase, era=args.era,
+            )
+        elif args.ladder_cmd == "t1":
+            result = runner.iterate_estimate(
+                m.root, Path(args.predecessor).resolve(), m,
+                args.workload_class, out_dir,
+                board=args.board, fast_boundary=args.fast_boundary,
+                era=args.era,
+            )
+        else:
+            observations = []
+            for spec in args.observation:
+                proxy_run, separator, class_run = spec.rpartition(":")
+                if not separator or not proxy_run or not class_run:
+                    return _fail(
+                        "--observation takes PROXY_RUN.json:CLASS_RUN.json"
+                    )
+                observations.append((Path(proxy_run), Path(class_run)))
+            result = runner.build_proxy_validity_receipt(
+                m.root, m, board=args.board,
+                workload_class=args.workload_class, era=args.era,
+                observations=observations,
+            )
+    except runner.RunError as exc:
+        return _fail(str(exc))
+
+    out = Path(args.out) if args.out else out_dir / f"{args.ladder_cmd}.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+
+    if args.ladder_cmd == "proxy-receipt":
+        measurement = result["measurement"]
+        print(ansi.kv_panel("proxy validity receipt", [
+            ("board", result["board"]),
+            ("class", result["workload_class"]),
+            ("era", str(result["era"])),
+            ("proxy", result["proxy"]["proxy_id"]),
+            ("observations", str(measurement["observation_count"])),
+            ("correlation", f"{measurement['correlation']:.6f}"),
+            ("floor", str(measurement["min_correlation"])),
+            ("valid", str(measurement["valid"])),
+        ]))
+        print(ansi.style(f"  receipt written to {out}", "dim"))
+        if not measurement["valid"]:
+            return _fail(
+                "proxy validity is below the registered floor — rotate the "
+                "proxy at the era boundary (TRACKS §3.5)"
+            )
+        print("  commit it under the registered receipt directory via a reviewed PR")
+        return 0
+
+    for marker in result["markers"]:
+        print(ansi.style(f"  ⚠ {marker}", "yellow"))
+    if args.ladder_cmd == "t0":
+        print(ansi.kv_panel("T0 phase prefilter", [
+            ("board", result["board"]),
+            ("class", result["workload_class"]),
+            ("workload", result["workload"]),
+            ("claimed phase", result["claimed_phase"]),
+            ("resolved phase", result["resolved_phase"]),
+            ("relative move", f"{result['relative_move']:.6f}"),
+            ("required move", str(result["min_phase_move"])),
+            ("correctness smoke", str(result["correctness_smoke"]["pass"])),
+            ("seconds", f"{result['measurement_seconds']:.2f}"),
+            ("pass", ansi.style(str(result["pass"]), "bold")),
+        ]))
+    else:
+        print(ansi.kv_panel("T1 iterate estimate", [
+            ("board", result["board"]),
+            ("class", result["workload_class"]),
+            ("boundary", result["boundary"]),
+            ("r geomean", f"{result['r_geomean']:.6f}"),
+            ("CI", f"[{result['ci'][0]:.6f}, {result['ci'][1]:.6f}]"),
+            ("theta", f"{result['theta']:.6f}"),
+            ("seconds", f"{result['measurement_seconds']:.2f}"),
+        ]))
+    print(ansi.style(f"  {result['note']}", "dim"))
+    print(ansi.style(f"  written to {out}", "dim"))
+    if not result.get("within_cost_target", True):
+        print(ansi.style(
+            f"  ⚠ tier exceeded its {result['cost_target_seconds']}s cost target — "
+            "shrink the proxy, not the honesty (TRACKS §3.6)", "yellow"))
+    if args.ladder_cmd == "t0" and not result["pass"]:
+        return _fail(
+            "T0 prefilter failed: the claimed phase did not move (or the "
+            "correctness smoke failed) — T1 is not scheduled"
+        )
     return 0
 
 
@@ -637,6 +744,58 @@ def build_parser() -> argparse.ArgumentParser:
         help="permit RISC-V A/A calibration before board activation; requires --aa",
     )
     p.add_argument("--out", help="verdict output path")
+    p.add_argument(
+        "--fast-boundary", action="store_true",
+        help="refused here by design: the claimed (T2) and ranked (T3) numbers "
+             "keep the full dual boundary; the PoW-excluded boundary belongs to "
+             "`stwo-perf ladder t1` (TRACKS §3.5)",
+    )
+
+    p = sub.add_parser(
+        "ladder",
+        help="confirmation-ladder tiers below the ranked path: T0 phase "
+             "prefilter, T1 iterate estimate, proxy validity receipts",
+    )
+    ladder = p.add_subparsers(dest="ladder_cmd", required=True)
+    t0 = ladder.add_parser(
+        "t0", help="one stage-profiled sample per arm; the claimed phase must move",
+    )
+    t0.add_argument("--phase", required=True,
+                    help="the §3.2 phase the submission claims to move")
+    t1 = ladder.add_parser(
+        "t1", help="paired ABBA on proxy fixtures with sequential early stopping",
+    )
+    t1.add_argument(
+        "--fast-boundary", action="store_true",
+        help="measure the PoW-excluded request boundary (pow 26 is ~constant "
+             "work and pure noise for paired deltas); refuses fail-closed when "
+             "the group's report schema exposes no measured PoW phase",
+    )
+    receipt = ladder.add_parser(
+        "proxy-receipt",
+        help="assemble an era proxy-validity receipt from measured runs "
+             "(judge host only; measures nothing itself)",
+    )
+    receipt.add_argument(
+        "--observation", action="append", default=[], required=True,
+        metavar="PROXY_RUN.json:CLASS_RUN.json",
+        help="one measured proxy/class pair; repeat until the registered "
+             "minimum observation count is met",
+    )
+    for tier_parser in (t0, t1, receipt):
+        tier_parser.add_argument("--board", required=True,
+                                 help="track board (validated against the manifest)")
+        tier_parser.add_argument(
+            "--class", dest="workload_class", required=True,
+            help="manifest-declared workload class",
+        )
+        tier_parser.add_argument("--era", type=int, default=None,
+                                 help="board era (default: current ledger epoch)")
+        tier_parser.add_argument("--out", help="output document path")
+    for tier_parser in (t0, t1):
+        tier_parser.add_argument(
+            "--predecessor", required=True, help="worktree of the paired A arm",
+        )
 
     p = sub.add_parser(
         "calibrate-metal",
@@ -801,6 +960,7 @@ HANDLERS = {
     "install-workflows": cmd_install_workflows, "feed": cmd_feed,
     "update": cmd_update,
     "calibrate-metal": cmd_calibrate_metal,
+    "ladder": cmd_ladder,
 }
 
 

--- a/autoresearch/cli/stwo_perf/manifest.py
+++ b/autoresearch/cli/stwo_perf/manifest.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import fnmatch
 import json
+import math
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -130,6 +132,62 @@ PR6_MECHANISM_TELEMETRY = {
         "metal_cpu_fallbacks",
     ],
 }
+# --- Confirmation ladder (TRACKS §3.5/§3.6) -------------------------------
+#
+# Everything here is OPTIONAL in the manifest: a manifest without a
+# gates_policy.confirmation_ladder block keeps exactly the pre-ladder runner
+# behavior. Presence of the block is what pre-registers the tier cost targets
+# and the sequential spending rule.
+CONFIRMATION_LADDER_SCHEMA = "stwo_perf_confirmation_ladder_v1"
+PROXY_VALIDITY_RECEIPT_SCHEMA = "stwo_perf_proxy_validity_receipt_v1"
+PROXY_VALIDITY_METHOD = "paired_ln_ratio_pearson_v1"
+# The one registered spending rule. A constant (Pocock-style) boundary with the
+# family-wise error split evenly across the planned looks: at look k of K the
+# decision uses a bootstrap CI at level 1 - alpha/K. Because alpha/K < alpha,
+# the boundary is strictly stricter than the fixed-sample gate, so an early
+# stop can never admit a run the full-power gate would have rejected.
+SEQUENTIAL_STOP_RULE = "pocock_constant_boundary_bonferroni_v1"
+LADDER_TIERS = ("T0", "T1", "T2", "T3")
+LADDER_TIER_KEYS = frozenset({"cost_target_seconds", "note"})
+LADDER_T0_EXTRA_KEYS = frozenset({"warmups", "samples", "min_phase_move"})
+SEQUENTIAL_STOP_KEYS = frozenset({
+    "enabled", "rule", "alpha", "stop_on_decisive_miss",
+})
+PROXY_VALIDITY_POLICY_KEYS = frozenset({
+    "receipt_schema", "receipt_dir", "min_correlation", "min_observations",
+})
+COST_TELEMETRY_KEYS = frozenset({"statistic", "window"})
+COST_TELEMETRY_STATISTICS = frozenset({"median", "max"})
+PROXY_FIXTURE_KEYS = frozenset({
+    "proxy_id", "args", "native_unit", "official_params",
+    "target_workload_ids", "note",
+})
+# A proxy is a SCALED SHAPE at official parameters (TRACKS §3.3). Restating any
+# security parameter in a proxy's args is how "fast confirmation" quietly
+# becomes "weakened confirmation", so the tokens are refused outright.
+PROXY_FORBIDDEN_ARG_TOKENS = (
+    "--pow-bits", "--n-queries", "--protocol", "--security", "--functional",
+)
+PROXY_VALIDITY_RECEIPT_KEYS = frozenset({
+    "schema", "board", "era", "workload_class", "proxy", "target",
+    "measured_at_utc", "host", "harness_commit", "measurement",
+    "artifact_sha256",
+})
+PROXY_RECEIPT_PROXY_KEYS = frozenset({
+    "proxy_id", "args", "native_unit", "official_params",
+})
+PROXY_RECEIPT_HOST_KEYS = frozenset({
+    "identity_sha256", "chip", "logical_cpu_count",
+})
+PROXY_RECEIPT_MEASUREMENT_KEYS = frozenset({
+    "method", "observations", "observation_count", "correlation",
+    "min_correlation", "min_observations", "valid",
+})
+PROXY_RECEIPT_OBSERVATION_KEYS = frozenset({
+    "proxy_ln_ratio", "class_ln_ratio", "proxy_evidence_sha256",
+    "class_evidence_sha256",
+})
+
 PR6_RESOURCE_TELEMETRY = {
     "fail_closed": True,
     "scope": "each_verified_sample",
@@ -253,6 +311,88 @@ class Manifest:
     @property
     def anchor_commit(self) -> str | None:
         return self.raw["harness"].get("anchor_commit")
+
+    @property
+    def confirmation_ladder(self) -> dict:
+        """Pre-registered ladder config, or {} when the manifest predates it."""
+        ladder = self.raw["gates_policy"].get("confirmation_ladder")
+        return dict(ladder) if isinstance(ladder, dict) else {}
+
+    def tier_cost_target_seconds(self, tier: str) -> int | None:
+        """Cost target for one ladder tier; None when judge-scheduled/absent."""
+        tiers = self.confirmation_ladder.get("tiers") or {}
+        spec = tiers.get(tier)
+        if not isinstance(spec, dict):
+            return None
+        target = spec.get("cost_target_seconds")
+        return target if isinstance(target, int) and not isinstance(target, bool) else None
+
+    def proxy_fixture(self, workload_class: str) -> dict | None:
+        """The class's declared proxy fixture (TRACKS §3.3), if any."""
+        self.workload_class(workload_class)
+        spec = self.raw["workload_registry"]["classes"][workload_class]
+        fixture = spec.get("proxy_fixture")
+        return dict(fixture) if isinstance(fixture, dict) else None
+
+    def proxy_validity_state(
+        self, board: str, workload_class: str, era: int,
+    ) -> dict:
+        """Resolve the era validity receipt for one (board, class) proxy.
+
+        Absence is never fatal and never fabricated: it downgrades T0/T1
+        results with a loud ``proxy unvalidated`` marker (TRACKS §3.5).
+        """
+        state = {
+            "validated": False,
+            "reason": "class declares no proxy fixture",
+            "receipt": None,
+            "correlation": None,
+            "era": era,
+        }
+        fixture = self.proxy_fixture(workload_class)
+        if fixture is None:
+            return state
+        policy = self.confirmation_ladder.get("proxy_validity") or {}
+        receipt_dir = policy.get("receipt_dir")
+        if not isinstance(receipt_dir, str) or not receipt_dir:
+            state["reason"] = (
+                "gates_policy.confirmation_ladder.proxy_validity.receipt_dir "
+                "is not registered"
+            )
+            return state
+        path = self.root / receipt_dir / proxy_receipt_filename(
+            board, workload_class, era,
+        )
+        state["receipt"] = str(path)
+        if not path.is_file():
+            state["reason"] = "proxy unvalidated: no era validity receipt at " + str(path)
+            return state
+        try:
+            document = json.loads(path.read_text(encoding="utf-8"))
+            receipt = validate_proxy_validity_receipt(
+                document,
+                board=board,
+                workload_class=workload_class,
+                era=era,
+                policy=policy,
+                proxy_fixture=fixture,
+            )
+        except (OSError, json.JSONDecodeError, ManifestError) as exc:
+            state["reason"] = f"proxy unvalidated: invalid era receipt ({exc})"
+            return state
+        measurement = receipt["measurement"]
+        state["correlation"] = measurement["correlation"]
+        state["validated"] = bool(measurement["valid"])
+        state["reason"] = (
+            "era receipt valid"
+            if state["validated"]
+            else (
+                "proxy unvalidated: measured correlation "
+                f"{measurement['correlation']} is below the registered floor "
+                f"{measurement['min_correlation']} — rotate the proxy"
+            )
+        )
+        return state
 
     def groups(self) -> list[WorkloadGroup]:
         """Workload groups in manifest order (registry v2)."""
@@ -480,6 +620,7 @@ def _validate(raw: dict) -> None:
     ):
         _validate_metal_calibration(raw["harness"], registry["classes"])
     _validate_search_health_policy(raw["gates_policy"], registry["classes"])
+    _validate_confirmation_ladder(raw["gates_policy"])
     if not registry["groups"]:
         raise ManifestError("workload_registry.groups is empty")
     seen_boards: set[str] = set()
@@ -874,10 +1015,17 @@ def _validate_classes(classes: object) -> None:
     for name, spec in classes.items():
         if not isinstance(name, str) or not name or not name.replace("_", "").isalnum():
             raise ManifestError(f"invalid workload class name: {name!r}")
-        if not isinstance(spec, dict) or set(spec) != {"scored", "resource", "sampling"}:
+        required = {"scored", "resource", "sampling"}
+        if not isinstance(spec, dict) or not required <= set(spec):
             raise ManifestError(
                 f"workload class {name} requires exactly scored, resource, and sampling"
             )
+        unknown = sorted(set(spec) - required - {"proxy_fixture"})
+        if unknown:
+            raise ManifestError(
+                f"workload class {name} has unsupported key(s): " + ", ".join(unknown)
+            )
+        _validate_class_proxy_fixture(name, spec.get("proxy_fixture"))
         if not isinstance(spec["scored"], bool):
             raise ManifestError(f"workload class {name}.scored must be a boolean")
         resource = spec["resource"]
@@ -920,6 +1068,426 @@ def _validate_classes(classes: object) -> None:
             raise ManifestError(
                 f"workload class {name}.sampling min_rounds exceeds max_rounds"
             )
+
+
+def _positive_number(value: object) -> bool:
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, (int, float))
+        and math.isfinite(float(value))
+        and float(value) > 0
+    )
+
+
+def _validate_confirmation_ladder(gates_policy: object) -> None:
+    """Validate the optional pre-registered confirmation ladder (TRACKS §3.5).
+
+    Absent block = pre-ladder manifest = pre-ladder behavior. Present block
+    must be complete: half-registered spending rules are not pre-registered.
+    """
+    if not isinstance(gates_policy, dict):
+        raise ManifestError("gates_policy must be an object")
+    ladder = gates_policy.get("confirmation_ladder")
+    if ladder is None:
+        return
+    if not isinstance(ladder, dict) or set(ladder) != {
+        "schema", "sequential_stop", "tiers", "proxy_validity",
+        "cost_telemetry", "note",
+    }:
+        raise ManifestError(
+            "gates_policy.confirmation_ladder requires exactly schema, "
+            "sequential_stop, tiers, proxy_validity, cost_telemetry, and note"
+        )
+    if ladder["schema"] != CONFIRMATION_LADDER_SCHEMA:
+        raise ManifestError(
+            "gates_policy.confirmation_ladder.schema must be "
+            + CONFIRMATION_LADDER_SCHEMA
+        )
+    if not isinstance(ladder["note"], str) or not ladder["note"].strip():
+        raise ManifestError("gates_policy.confirmation_ladder.note must be non-empty")
+
+    stop = ladder["sequential_stop"]
+    if not isinstance(stop, dict) or set(stop) != SEQUENTIAL_STOP_KEYS:
+        raise ManifestError(
+            "gates_policy.confirmation_ladder.sequential_stop requires exactly "
+            + ", ".join(sorted(SEQUENTIAL_STOP_KEYS))
+        )
+    if not isinstance(stop["enabled"], bool):
+        raise ManifestError("confirmation_ladder.sequential_stop.enabled must be a boolean")
+    if not isinstance(stop["stop_on_decisive_miss"], bool):
+        raise ManifestError(
+            "confirmation_ladder.sequential_stop.stop_on_decisive_miss must be a boolean"
+        )
+    if stop["rule"] != SEQUENTIAL_STOP_RULE:
+        raise ManifestError(
+            "confirmation_ladder.sequential_stop.rule must be "
+            + SEQUENTIAL_STOP_RULE
+            + " (the only pre-registered spending rule)"
+        )
+    alpha = stop["alpha"]
+    if not _positive_number(alpha) or float(alpha) > 0.5:
+        raise ManifestError(
+            "confirmation_ladder.sequential_stop.alpha must be in (0, 0.5]"
+        )
+
+    tiers = ladder["tiers"]
+    if not isinstance(tiers, dict) or tuple(tiers) != LADDER_TIERS:
+        raise ManifestError(
+            "confirmation_ladder.tiers must declare exactly "
+            + ", ".join(LADDER_TIERS)
+            + " in ladder order"
+        )
+    for tier, spec in tiers.items():
+        allowed = LADDER_TIER_KEYS | (
+            LADDER_T0_EXTRA_KEYS if tier == "T0" else frozenset()
+        )
+        if not isinstance(spec, dict) or not LADDER_TIER_KEYS <= set(spec):
+            raise ManifestError(
+                f"confirmation_ladder.tiers.{tier} requires cost_target_seconds and note"
+            )
+        unknown = sorted(set(spec) - allowed)
+        if unknown:
+            raise ManifestError(
+                f"confirmation_ladder.tiers.{tier} has unsupported key(s): "
+                + ", ".join(unknown)
+            )
+        target = spec["cost_target_seconds"]
+        if target is not None and (
+            type(target) is not int or not 1 <= target <= MAX_GROUP_WALL_CLOCK_SECONDS
+        ):
+            raise ManifestError(
+                f"confirmation_ladder.tiers.{tier}.cost_target_seconds must be null "
+                f"(judge-scheduled) or an integer in [1, {MAX_GROUP_WALL_CLOCK_SECONDS}]"
+            )
+        if not isinstance(spec["note"], str) or not spec["note"].strip():
+            raise ManifestError(
+                f"confirmation_ladder.tiers.{tier}.note must be non-empty"
+            )
+        if tier == "T0":
+            if type(spec.get("warmups")) is not int or not 0 <= spec["warmups"] <= 100:
+                raise ManifestError(
+                    "confirmation_ladder.tiers.T0.warmups must be an integer in [0, 100]"
+                )
+            if type(spec.get("samples")) is not int or not 1 <= spec["samples"] <= 32:
+                raise ManifestError(
+                    "confirmation_ladder.tiers.T0.samples must be an integer in [1, 32]"
+                )
+            move = spec.get("min_phase_move")
+            if not _positive_number(move) or float(move) >= 1.0:
+                raise ManifestError(
+                    "confirmation_ladder.tiers.T0.min_phase_move must be in (0, 1)"
+                )
+    ordered = [
+        tiers[tier]["cost_target_seconds"] for tier in LADDER_TIERS
+        if tiers[tier]["cost_target_seconds"] is not None
+    ]
+    if ordered != sorted(ordered) or len(set(ordered)) != len(ordered):
+        raise ManifestError(
+            "confirmation_ladder tier cost targets must increase strictly down the ladder"
+        )
+
+    proxy = ladder["proxy_validity"]
+    if not isinstance(proxy, dict) or set(proxy) != PROXY_VALIDITY_POLICY_KEYS:
+        raise ManifestError(
+            "confirmation_ladder.proxy_validity requires exactly "
+            + ", ".join(sorted(PROXY_VALIDITY_POLICY_KEYS))
+        )
+    if proxy["receipt_schema"] != PROXY_VALIDITY_RECEIPT_SCHEMA:
+        raise ManifestError(
+            "confirmation_ladder.proxy_validity.receipt_schema must be "
+            + PROXY_VALIDITY_RECEIPT_SCHEMA
+        )
+    receipt_dir = proxy["receipt_dir"]
+    if (
+        not isinstance(receipt_dir, str)
+        or not receipt_dir.startswith("autoresearch/")
+        or Path(receipt_dir).is_absolute()
+        or ".." in Path(receipt_dir).parts
+    ):
+        raise ManifestError(
+            "confirmation_ladder.proxy_validity.receipt_dir must be a repository "
+            "path under autoresearch/"
+        )
+    correlation = proxy["min_correlation"]
+    if not _positive_number(correlation) or float(correlation) > 1.0:
+        raise ManifestError(
+            "confirmation_ladder.proxy_validity.min_correlation must be in (0, 1]"
+        )
+    observations = proxy["min_observations"]
+    if type(observations) is not int or observations < 3:
+        raise ManifestError(
+            "confirmation_ladder.proxy_validity.min_observations must be an "
+            "integer >= 3 (a correlation from two points is not evidence)"
+        )
+
+    telemetry = ladder["cost_telemetry"]
+    if not isinstance(telemetry, dict) or set(telemetry) != COST_TELEMETRY_KEYS:
+        raise ManifestError(
+            "confirmation_ladder.cost_telemetry requires exactly "
+            + ", ".join(sorted(COST_TELEMETRY_KEYS))
+        )
+    if telemetry["statistic"] not in COST_TELEMETRY_STATISTICS:
+        raise ManifestError(
+            "confirmation_ladder.cost_telemetry.statistic must be "
+            + " or ".join(sorted(COST_TELEMETRY_STATISTICS))
+        )
+    if type(telemetry["window"]) is not int or not 1 <= telemetry["window"] <= 100:
+        raise ManifestError(
+            "confirmation_ladder.cost_telemetry.window must be an integer in [1, 100]"
+        )
+
+
+def _validate_class_proxy_fixture(name: str, fixture: object) -> None:
+    """Per-class proxy fixture: small shape, OFFICIAL params (TRACKS §3.3)."""
+    if fixture is None:
+        return
+    if not isinstance(fixture, dict) or set(fixture) != PROXY_FIXTURE_KEYS:
+        raise ManifestError(
+            f"workload class {name}.proxy_fixture requires exactly "
+            + ", ".join(sorted(PROXY_FIXTURE_KEYS))
+        )
+    proxy_id = fixture["proxy_id"]
+    if not isinstance(proxy_id, str) or not re.fullmatch(r"[a-z0-9_]{3,64}", proxy_id):
+        raise ManifestError(
+            f"workload class {name}.proxy_fixture.proxy_id must be lowercase "
+            "snake_case (3-64 chars)"
+        )
+    for key in ("args", "native_unit", "note"):
+        value = fixture[key]
+        if not isinstance(value, str) or not value.strip():
+            raise ManifestError(
+                f"workload class {name}.proxy_fixture.{key} must be a non-empty string"
+            )
+    if fixture["official_params"] is not True:
+        raise ManifestError(
+            f"workload class {name}.proxy_fixture.official_params must be true — "
+            "fast confirmation uses scaled shapes at official parameters, never "
+            "weakened parameters at full shapes"
+        )
+    lowered = fixture["args"].lower()
+    offending = sorted(
+        token for token in PROXY_FORBIDDEN_ARG_TOKENS if token in lowered
+    )
+    if offending:
+        raise ManifestError(
+            f"workload class {name}.proxy_fixture.args restates security "
+            "parameter(s) " + ", ".join(offending)
+            + "; a proxy scales geometry only"
+        )
+    targets = fixture["target_workload_ids"]
+    if (
+        not isinstance(targets, list)
+        or not targets
+        or any(not isinstance(item, str) or not item.strip() for item in targets)
+        or len(targets) != len(set(targets))
+    ):
+        raise ManifestError(
+            f"workload class {name}.proxy_fixture.target_workload_ids must be a "
+            "unique non-empty list of workload IDs"
+        )
+
+
+def proxy_receipt_filename(board: str, workload_class: str, era: int) -> str:
+    """Deterministic era-frozen receipt name (TRACKS §3.6)."""
+    return f"{board}-{workload_class}-era{int(era)}.json"
+
+
+def pearson_correlation(xs: list[float], ys: list[float]) -> float:
+    """Pearson r over paired ln-ratios; stdlib only, deterministic."""
+    if len(xs) != len(ys) or len(xs) < 3:
+        raise ManifestError("a correlation needs at least three paired observations")
+    n = float(len(xs))
+    mean_x = sum(xs) / n
+    mean_y = sum(ys) / n
+    dx = [x - mean_x for x in xs]
+    dy = [y - mean_y for y in ys]
+    numerator = sum(a * b for a, b in zip(dx, dy))
+    denominator = math.sqrt(sum(a * a for a in dx)) * math.sqrt(sum(b * b for b in dy))
+    if denominator <= 0.0:
+        raise ManifestError(
+            "a degenerate observation series (zero variance) has no correlation"
+        )
+    return numerator / denominator
+
+
+def validate_proxy_validity_receipt(
+    document: object,
+    *,
+    board: str | None = None,
+    workload_class: str | None = None,
+    era: int | None = None,
+    policy: dict | None = None,
+    proxy_fixture: dict | None = None,
+) -> dict:
+    """Validate a ``stwo_perf_proxy_validity_receipt_v1`` document.
+
+    The correlation is RECOMPUTED from the receipt's own paired observations:
+    a receipt cannot assert a validity number its evidence does not support.
+    """
+    if not isinstance(document, dict) or set(document) != PROXY_VALIDITY_RECEIPT_KEYS:
+        raise ManifestError(
+            "proxy validity receipt requires exactly "
+            + ", ".join(sorted(PROXY_VALIDITY_RECEIPT_KEYS))
+        )
+    if document["schema"] != PROXY_VALIDITY_RECEIPT_SCHEMA:
+        raise ManifestError(
+            "proxy validity receipt schema must be " + PROXY_VALIDITY_RECEIPT_SCHEMA
+        )
+    for key in ("board", "workload_class"):
+        value = document[key]
+        if not isinstance(value, str) or not value.strip():
+            raise ManifestError(f"proxy validity receipt {key} must be a non-empty string")
+    if type(document["era"]) is not int or document["era"] <= 0:
+        raise ManifestError("proxy validity receipt era must be a positive integer")
+    if board is not None and document["board"] != board:
+        raise ManifestError("proxy validity receipt is bound to another board")
+    if workload_class is not None and document["workload_class"] != workload_class:
+        raise ManifestError("proxy validity receipt is bound to another workload class")
+    if era is not None and document["era"] != era:
+        raise ManifestError("proxy validity receipt is bound to another era")
+
+    proxy = document["proxy"]
+    if not isinstance(proxy, dict) or set(proxy) != PROXY_RECEIPT_PROXY_KEYS:
+        raise ManifestError(
+            "proxy validity receipt proxy requires exactly "
+            + ", ".join(sorted(PROXY_RECEIPT_PROXY_KEYS))
+        )
+    if proxy["official_params"] is not True:
+        raise ManifestError("a receipt may only certify an official-parameter proxy")
+    if proxy_fixture is not None:
+        for key in ("proxy_id", "args", "native_unit"):
+            if proxy.get(key) != proxy_fixture.get(key):
+                raise ManifestError(
+                    f"proxy validity receipt {key} differs from the manifest proxy fixture"
+                )
+    target = document["target"]
+    if (
+        not isinstance(target, dict)
+        or set(target) != {"workload_ids"}
+        or not isinstance(target["workload_ids"], list)
+        or not target["workload_ids"]
+        or any(not isinstance(item, str) or not item.strip()
+               for item in target["workload_ids"])
+    ):
+        raise ManifestError(
+            "proxy validity receipt target must name the class workload IDs it predicts"
+        )
+    measured_at = document["measured_at_utc"]
+    if not isinstance(measured_at, str) or not re.fullmatch(
+        r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", measured_at,
+    ):
+        raise ManifestError(
+            "proxy validity receipt measured_at_utc must be YYYY-MM-DDTHH:MM:SSZ"
+        )
+    host = document["host"]
+    if not isinstance(host, dict) or set(host) != PROXY_RECEIPT_HOST_KEYS:
+        raise ManifestError(
+            "proxy validity receipt host requires exactly "
+            + ", ".join(sorted(PROXY_RECEIPT_HOST_KEYS))
+        )
+    if not isinstance(host["identity_sha256"], str) or not re.fullmatch(
+        r"[0-9a-f]{64}", host["identity_sha256"],
+    ):
+        raise ManifestError("proxy validity receipt host.identity_sha256 must be sha256 hex")
+    if not isinstance(host["chip"], str) or not host["chip"].strip():
+        raise ManifestError("proxy validity receipt host.chip must be non-empty")
+    if type(host["logical_cpu_count"]) is not int or host["logical_cpu_count"] <= 0:
+        raise ManifestError(
+            "proxy validity receipt host.logical_cpu_count must be a positive integer"
+        )
+    if not isinstance(document["harness_commit"], str) or not re.fullmatch(
+        r"[0-9a-f]{12,40}", document["harness_commit"],
+    ):
+        raise ManifestError(
+            "proxy validity receipt harness_commit must be lowercase hex (12-40 chars)"
+        )
+    if not isinstance(document["artifact_sha256"], str) or not re.fullmatch(
+        r"[0-9a-f]{64}", document["artifact_sha256"],
+    ):
+        raise ManifestError("proxy validity receipt artifact_sha256 must be sha256 hex")
+
+    measurement = document["measurement"]
+    if (
+        not isinstance(measurement, dict)
+        or set(measurement) != PROXY_RECEIPT_MEASUREMENT_KEYS
+    ):
+        raise ManifestError(
+            "proxy validity receipt measurement requires exactly "
+            + ", ".join(sorted(PROXY_RECEIPT_MEASUREMENT_KEYS))
+        )
+    if measurement["method"] != PROXY_VALIDITY_METHOD:
+        raise ManifestError(
+            "proxy validity receipt method must be " + PROXY_VALIDITY_METHOD
+        )
+    observations = measurement["observations"]
+    if not isinstance(observations, list) or len(observations) < 3:
+        raise ManifestError(
+            "proxy validity receipt needs at least three paired observations"
+        )
+    xs: list[float] = []
+    ys: list[float] = []
+    for index, item in enumerate(observations):
+        if not isinstance(item, dict) or set(item) != PROXY_RECEIPT_OBSERVATION_KEYS:
+            raise ManifestError(
+                f"proxy validity observation {index} requires exactly "
+                + ", ".join(sorted(PROXY_RECEIPT_OBSERVATION_KEYS))
+            )
+        for key in ("proxy_ln_ratio", "class_ln_ratio"):
+            value = item[key]
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(float(value))
+            ):
+                raise ManifestError(
+                    f"proxy validity observation {index}.{key} must be a finite number"
+                )
+        for key in ("proxy_evidence_sha256", "class_evidence_sha256"):
+            value = item[key]
+            if not isinstance(value, str) or not re.fullmatch(r"[0-9a-f]{64}", value):
+                raise ManifestError(
+                    f"proxy validity observation {index}.{key} must be sha256 hex"
+                )
+        xs.append(float(item["proxy_ln_ratio"]))
+        ys.append(float(item["class_ln_ratio"]))
+    if measurement["observation_count"] != len(observations):
+        raise ManifestError(
+            "proxy validity receipt observation_count disagrees with its observations"
+        )
+    recomputed = pearson_correlation(xs, ys)
+    correlation = measurement["correlation"]
+    if (
+        isinstance(correlation, bool)
+        or not isinstance(correlation, (int, float))
+        or not math.isclose(float(correlation), recomputed, rel_tol=0, abs_tol=1e-9)
+    ):
+        raise ManifestError(
+            "proxy validity receipt correlation is not the Pearson correlation of "
+            f"its own observations (recomputed {recomputed:.12f})"
+        )
+    floor = measurement["min_correlation"]
+    minimum = measurement["min_observations"]
+    if not _positive_number(floor) or float(floor) > 1.0:
+        raise ManifestError("proxy validity receipt min_correlation must be in (0, 1]")
+    if type(minimum) is not int or minimum < 3:
+        raise ManifestError("proxy validity receipt min_observations must be >= 3")
+    if policy is not None:
+        if float(floor) < float(policy["min_correlation"]):
+            raise ManifestError(
+                "proxy validity receipt weakens the registered correlation floor"
+            )
+        if minimum < int(policy["min_observations"]):
+            raise ManifestError(
+                "proxy validity receipt weakens the registered observation minimum"
+            )
+    expected_valid = (
+        float(correlation) >= float(floor) and len(observations) >= minimum
+    )
+    if measurement["valid"] is not expected_valid:
+        raise ManifestError(
+            "proxy validity receipt validity flag disagrees with its own thresholds"
+        )
+    return document
 
 
 def _validate_group_resource_telemetry(

--- a/autoresearch/cli/stwo_perf/runner.py
+++ b/autoresearch/cli/stwo_perf/runner.py
@@ -44,17 +44,69 @@ from scripts.native_cuda_diagnostic_lib.model import (
 
 from . import dimensions, ledger, search_health, stats
 from .manifest import (
+    CAIRO_PHASE_NAMES,
+    PROXY_VALIDITY_METHOD,
+    PROXY_VALIDITY_RECEIPT_SCHEMA,
     REPORT_SCHEMA_VERSIONS,
     RISCV_STABLE_MECHANISM_FIELDS,
+    SEQUENTIAL_STOP_RULE,
     Manifest,
     ManifestError,
     Workload,
     WorkloadGroup,
+    pearson_correlation,
+    validate_proxy_validity_receipt,
 )
 
 
 class RunError(RuntimeError):
     pass
+
+
+# --- Confirmation ladder (TRACKS §3.5) ------------------------------------
+LADDER_T0_SCHEMA = "stwo_perf_ladder_t0_prefilter_v1"
+LADDER_T1_SCHEMA = "stwo_perf_ladder_t1_estimate_v1"
+#: Boundary label recorded on every WorkloadScore. The default is today's
+#: paired quantity; the ladder's fast boundary is the opt-in alternative.
+FULL_BOUNDARY = "prove_ms"
+FAST_BOUNDARY = "verified_request_minus_pow_ms"
+
+#: report_schema -> path (in the group's report) to the proof-of-work phase in
+#: SECONDS. Deliberately empty: no shipped product emits a PoW cutpoint yet,
+#: even though §3.2 names it as a phase. ``--fast-boundary`` therefore fails
+#: closed on every schema until its product reports the number — the harness
+#: subtracts only measured PoW time, never a modeled or assumed one.
+POW_PHASE_SECONDS_FIELDS: dict[str, tuple[str, ...]] = {}
+
+#: report_schema -> phase name -> path to that phase's seconds. Phase names
+#: follow the §3.2 cutpoint vocabulary. Groups whose reports carry stage
+#: profiles contribute their stage tree on top of this map, so T0 attribution
+#: is generic over whatever phase evidence a schema actually provides.
+PHASE_SECONDS_FIELDS: dict[str, dict[str, tuple[str, ...]]] = {
+    "native_proof_v7": {
+        "input": ("timing", "input_seconds", "median"),
+        "prove": ("timing", "prove_seconds", "median"),
+        "serialize": ("timing", "proof_encode_seconds", "median"),
+        "verify": ("timing", "verify_seconds", "median"),
+        "request": ("timing", "request_seconds", "median"),
+    },
+    "riscv_proof_v2": {
+        "execute": ("mean_execution_seconds",),
+        "witness": ("mean_witness_seconds",),
+        "prove": ("mean_proving_seconds",),
+        "verify": ("mean_verification_seconds",),
+        "request": ("median_seconds",),
+    },
+    # The Cairo envelope publishes the §3.2 cutpoints directly, so the row is
+    # DERIVED from the canonical name tuple rather than restated: a schema that
+    # gains or renames a cutpoint cannot leave T0 quietly reading a stale set.
+    # ``serialize`` is always null (proof encode/write/hash is outside the
+    # recorder), so it drops out of the measured phase set and a claim on it
+    # fails T0 closed — the honest answer for an uninstrumented cutpoint.
+    "cairo_proof_v1": {
+        phase: ("phase_seconds", phase) for phase in CAIRO_PHASE_NAMES
+    },
+}
 
 
 _RESOURCE_ADMISSION_KEYS = {
@@ -315,6 +367,9 @@ class ArmResult:
     instructions: int | None = None
     cycles: int | None = None
     resources_complete: bool | None = None
+    #: Measured proof-of-work milliseconds, when the group's report schema
+    #: exposes the cutpoint. None means "not measured" — never "zero".
+    pow_ms: float | None = None
 
 
 @dataclass
@@ -336,6 +391,12 @@ class WorkloadScore:
     proof_bytes: int = 0
     measurement_seconds: float = 0.0
     resources_complete: bool | None = None
+    #: Which paired quantity ``ratios`` measures (FULL_BOUNDARY by default).
+    boundary: str = FULL_BOUNDARY
+    #: Pre-registered sequential-stop evidence, present only when armed.
+    sequential_stop: dict | None = None
+    #: Median PoW-excluded request ratio, present only under the fast boundary.
+    fast_request_ratio: float | None = None
 
 
 def portfolio_summary(scores: list[WorkloadScore], ci_level: float) -> dict:
@@ -556,10 +617,21 @@ def bench_once(
         if cairo_timeout <= 0:
             raise RunError(f"{workload.workload_id}: no command time budget remains")
         try:
-            return _bench_cairo(
+            cairo_result = _bench_cairo(
                 arm_root, group, workload, warmups, samples, out_dir,
                 tag, float(cairo_timeout), deadline_monotonic,
             )
+            # Ladder telemetry (TRACKS §3.5), read from the envelope the Cairo
+            # arm just wrote — only when a PoW cutpoint is actually registered.
+            if group.report_schema in POW_PHASE_SECONDS_FIELDS:
+                cairo_result.pow_ms = _pow_ms(
+                    _load_json_object(
+                        Path(cairo_result.report_path).read_text(encoding="utf-8"),
+                        "Cairo bench envelope",
+                    ),
+                    group,
+                )
+            return cairo_result
         except (OSError, KeyError, TypeError, ValueError) as exc:
             raise RunError(
                 f"{workload.workload_id}: malformed {group.report_schema} report: {exc}"
@@ -644,6 +716,9 @@ def bench_once(
         raise RunError(
             f"{workload.workload_id}: malformed {group.report_schema} report: {exc}"
         ) from exc
+    # Ladder telemetry (TRACKS §3.5): carried on every run so the PoW-excluded
+    # boundary is a projection of measured evidence, never a separate run.
+    result.pow_ms = _pow_ms(report, group)
     out_path.write_text(json.dumps(report, indent=1))
     return result
 
@@ -1631,6 +1706,179 @@ def _bench_cairo(
     )
 
 
+@dataclass(frozen=True)
+class SequentialStopPolicy:
+    """The pre-registered group-sequential spending rule (TRACKS §3.5).
+
+    Constant (Pocock-style) boundary: the family-wise error ``alpha`` is spent
+    evenly over the ``K`` planned looks, so look ``k`` decides on a bootstrap CI
+    at level ``1 - alpha/K``. Two consequences make it honest:
+
+    * the boundary is strictly stricter than the fixed-sample gate
+      (``alpha/K < alpha``), so a decisive clear at any look would also have
+      cleared the full-power gate — early stopping can never admit a run that
+      the fixed design would have rejected;
+    * the looks, their count, and alpha come from the manifest, never from the
+      run, so the design is pre-registered rather than chosen after seeing data.
+    """
+
+    rule: str
+    alpha: float
+    stop_on_decisive_miss: bool
+
+    def adjusted_level(self, looks: int) -> float:
+        if looks < 1:
+            raise RunError("a sequential design needs at least one planned look")
+        return 1.0 - (self.alpha / float(looks))
+
+
+def sequential_stop_policy(
+    policy: dict, *, armed: bool | None = None,
+) -> SequentialStopPolicy | None:
+    """Resolve the spending rule; ``None`` keeps pre-ladder round behavior.
+
+    ``armed=True`` is how a tier that never ranks (T1) turns the rule on even
+    when the manifest leaves it off for scored runs; it still refuses to invent
+    parameters when the manifest has not pre-registered them.
+    """
+    ladder = policy.get("confirmation_ladder")
+    spec = ladder.get("sequential_stop") if isinstance(ladder, dict) else None
+    if not isinstance(spec, dict):
+        if armed:
+            raise RunError(
+                "sequential early stopping requires a pre-registered "
+                "gates_policy.confirmation_ladder.sequential_stop block"
+            )
+        return None
+    enabled = bool(spec.get("enabled")) if armed is None else bool(armed)
+    if not enabled:
+        return None
+    if spec.get("rule") != SEQUENTIAL_STOP_RULE:
+        raise RunError(
+            f"unsupported sequential stop rule {spec.get('rule')!r}: only "
+            f"{SEQUENTIAL_STOP_RULE} is pre-registered"
+        )
+    alpha = spec.get("alpha")
+    if isinstance(alpha, bool) or not isinstance(alpha, (int, float)):
+        raise RunError("sequential stop alpha must be a number")
+    alpha = float(alpha)
+    if not 0.0 < alpha <= 0.5:
+        raise RunError("sequential stop alpha must be in (0, 0.5]")
+    return SequentialStopPolicy(
+        rule=SEQUENTIAL_STOP_RULE,
+        alpha=alpha,
+        stop_on_decisive_miss=bool(spec.get("stop_on_decisive_miss", True)),
+    )
+
+
+def _dig(report: object, path: tuple[str, ...]) -> object:
+    node: object = report
+    for key in path:
+        if not isinstance(node, dict) or key not in node:
+            return None
+        node = node[key]
+    return node
+
+
+def _finite_or_none(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    number = float(value)
+    return number if math.isfinite(number) else None
+
+
+def _flatten_stage_nodes(nodes: object, prefix: str, out: dict[str, float]) -> None:
+    if not isinstance(nodes, list):
+        return
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        node_id = node.get("id")
+        if not isinstance(node_id, str) or not node_id:
+            continue
+        name = f"{prefix}{node_id}"
+        seconds = _finite_or_none(node.get("seconds"))
+        if seconds is not None:
+            out[f"stage:{name}"] = seconds
+        _flatten_stage_nodes(node.get("children"), f"{name}.", out)
+
+
+def report_phases(report: dict, group: WorkloadGroup) -> dict[str, float]:
+    """Named phase seconds from whatever the group's report schema provides.
+
+    Combines the schema's declared §3.2 cutpoints with any stage-profile tree
+    the report carries (``--stage-profile-out`` shape), flattened to dotted
+    ``stage:<parent>.<child>`` names. Never scored — phase telemetry gates
+    scheduling and G3 only.
+    """
+    phases: dict[str, float] = {}
+    for name, path in PHASE_SECONDS_FIELDS.get(group.report_schema, {}).items():
+        seconds = _finite_or_none(_dig(report, path))
+        if seconds is not None:
+            phases[name] = seconds
+    timing = report.get("timing")
+    if isinstance(timing, dict):
+        profiles = timing.get("stage_profiles")
+        if isinstance(profiles, list):
+            for profile in profiles:
+                if isinstance(profile, dict):
+                    _flatten_stage_nodes(profile.get("stages"), "", phases)
+    single = report.get("stage_profile")
+    if isinstance(single, dict):
+        _flatten_stage_nodes(single.get("stages"), "", phases)
+    _flatten_stage_nodes(report.get("stages"), "", phases)
+    return phases
+
+
+def resolve_phase(phases: dict[str, float], phase: str) -> str:
+    """Map a submission's claimed phase name onto a measured phase key."""
+    if phase in phases:
+        return phase
+    stage_key = f"stage:{phase}"
+    if stage_key in phases:
+        return stage_key
+    suffixes = sorted(
+        key for key in phases
+        if key.split(":")[-1].split(".")[-1] == phase
+    )
+    if len(suffixes) == 1:
+        return suffixes[0]
+    if len(suffixes) > 1:
+        raise RunError(
+            f"claimed phase {phase!r} is ambiguous across measured phases: "
+            + ", ".join(suffixes[:6])
+        )
+    raise RunError(
+        f"claimed phase {phase!r} is not reported by this group; measured "
+        "phases: " + (", ".join(sorted(phases)[:12]) or "none")
+    )
+
+
+def _pow_ms(report: dict, group: WorkloadGroup) -> float | None:
+    path = POW_PHASE_SECONDS_FIELDS.get(group.report_schema)
+    if path is None:
+        return None
+    seconds = _finite_or_none(_dig(report, path))
+    if seconds is None or seconds < 0.0:
+        raise RunError(
+            f"group {group.group_id}: report declares a proof-of-work cutpoint "
+            "but did not report a finite non-negative value"
+        )
+    return seconds * 1000.0
+
+
+def require_pow_boundary(group: WorkloadGroup) -> None:
+    """Fail closed when a group cannot honestly exclude PoW from its boundary."""
+    if group.report_schema not in POW_PHASE_SECONDS_FIELDS:
+        raise RunError(
+            f"group {group.group_id}: report schema {group.report_schema!r} "
+            "exposes no proof-of-work cutpoint, so the PoW-excluded fast "
+            "boundary cannot be measured. The product must report the PoW "
+            "phase (§3.2) before --fast-boundary can subtract it; the harness "
+            "never subtracts an unmeasured cost."
+        )
+
+
 def paired_rounds(
     a_root: Path,
     b_root: Path,
@@ -1642,6 +1890,8 @@ def paired_rounds(
     round_budget: int | None = None,
     minimum_rounds_override: int | None = None,
     deadline_monotonic: float | None = None,
+    sequential_stop: bool | None = None,
+    fast_boundary: bool = False,
 ) -> WorkloadScore:
     """ABBA round pairs until the CI half-width is under theta/2 or a cap hits."""
     warmups = int(policy["warmups"])
@@ -1670,12 +1920,20 @@ def paired_rounds(
     proof_sizes_b: list[int] = []
     request_ratios: list[float] = []
     requests_b: list[float] = []
+    fast_ratios: list[float] = []
+    fast_requests_b: list[float] = []
     cross_digest: str | None = None
     cross_proof_bytes: int | None = None
     mechanism_reference: dict | None = None
     mechanism_verified: bool | None = None
     resources_complete: bool | None = None
     group = manifest.group(workload.group_id)
+    stop_policy = sequential_stop_policy(policy, armed=sequential_stop)
+    stop_evidence: dict | None = None
+    boundary = FULL_BOUNDARY
+    if fast_boundary:
+        require_pow_boundary(group)
+        boundary = FAST_BOUNDARY
 
     round_no = 0
     while round_no < max_rounds:
@@ -1776,9 +2034,20 @@ def paired_rounds(
         if a.request_ms and b.request_ms:
             request_ratios.append(b.request_ms / a.request_ms)
             requests_b.append(b.request_ms)
-        ratios.append(b.prove_ms / a.prove_ms)
-        a_meds.append(a.prove_ms)
-        b_meds.append(b.prove_ms)
+        if fast_boundary:
+            # BOTH numbers are reported: the full verified-request boundary
+            # above, and the PoW-excluded one that T0/T1 actually pair on.
+            fast_a = _fast_boundary_ms(a, workload)
+            fast_b_ms = _fast_boundary_ms(b, workload)
+            fast_ratios.append(fast_b_ms / fast_a)
+            fast_requests_b.append(fast_b_ms)
+            ratios.append(fast_b_ms / fast_a)
+            a_meds.append(fast_a)
+            b_meds.append(fast_b_ms)
+        else:
+            ratios.append(b.prove_ms / a.prove_ms)
+            a_meds.append(a.prove_ms)
+            b_meds.append(b.prove_ms)
         reports.extend([a.report_path, b.report_path])
         for dimension, a_value, b_value, a_values, b_values in (
             ("peak_rss_mib", a.peak_rss_mib, b.peak_rss_mib, rss_a, rss_b),
@@ -1799,6 +2068,13 @@ def paired_rounds(
             ci = stats.bootstrap_ci(ratios, seed=_seed(workload.workload_id, 0))
             if (ci[1] - ci[0]) / 2.0 <= stop_theta / 2.0:
                 break
+            if stop_policy is not None:
+                stop_evidence = _sequential_stop_look(
+                    stop_policy, ratios, workload, stop_theta,
+                    round_no, min_rounds, max_rounds,
+                )
+                if stop_evidence["decision"] != "continue":
+                    break
             if elapsed > cap:
                 break
         elif elapsed > cap and round_no >= 3:
@@ -1840,6 +2116,7 @@ def paired_rounds(
         ("peak_rss_mib", rss_b),
         ("energy_j", energy_b),
         ("proof_bytes", proof_sizes_b),
+        ("fast_request_ms", fast_requests_b),
     ):
         if values:
             ordered_values = sorted(float(value) for value in values)
@@ -1847,6 +2124,16 @@ def paired_rounds(
     request_ratio = (
         sorted(request_ratios)[len(request_ratios) // 2] if request_ratios else None
     )
+    fast_request_ratio = (
+        sorted(fast_ratios)[len(fast_ratios) // 2] if fast_ratios else None
+    )
+    if stop_policy is not None and (
+        stop_evidence is None or stop_evidence["decision"] == "continue"
+    ):
+        stop_evidence = _sequential_stop_look(
+            stop_policy, ratios, workload, stop_theta,
+            len(ratios), min_rounds, max_rounds, exhausted=True,
+        )
     return WorkloadScore(
         workload=workload,
         ratios=ratios,
@@ -1867,7 +2154,66 @@ def paired_rounds(
         proof_bytes=cross_proof_bytes or 0,
         measurement_seconds=elapsed,
         resources_complete=resources_complete,
+        boundary=boundary,
+        sequential_stop=stop_evidence,
+        fast_request_ratio=fast_request_ratio,
     )
+
+
+def _fast_boundary_ms(arm: ArmResult, workload: Workload) -> float:
+    """Verified-request milliseconds minus the MEASURED proof-of-work phase."""
+    if arm.request_ms is None or arm.pow_ms is None:
+        raise RunError(
+            f"{workload.workload_id}: the PoW-excluded boundary needs both a "
+            "verified-request time and a measured proof-of-work phase"
+        )
+    remainder = arm.request_ms - arm.pow_ms
+    if not math.isfinite(remainder) or remainder <= 0.0:
+        raise RunError(
+            f"{workload.workload_id}: measured proof-of-work time is not "
+            "smaller than the verified request time"
+        )
+    return remainder
+
+
+def _sequential_stop_look(
+    stop_policy: SequentialStopPolicy,
+    ratios: list[float],
+    workload: Workload,
+    stop_theta: float,
+    round_no: int,
+    min_rounds: int,
+    max_rounds: int,
+    *,
+    exhausted: bool = False,
+) -> dict:
+    """One pre-registered look at the theta bar; deterministic by construction."""
+    looks = max(max_rounds - min_rounds + 1, 1)
+    level = stop_policy.adjusted_level(looks)
+    adjusted = stats.bootstrap_ci(
+        ratios, level=level, seed=_seed(workload.workload_id, 0),
+    )
+    bar = 1.0 - stop_theta
+    if adjusted[1] < bar:
+        decision = "decisive_clear"
+    elif stop_policy.stop_on_decisive_miss and adjusted[0] > bar:
+        decision = "decisive_miss"
+    else:
+        decision = "budget_exhausted" if exhausted else "continue"
+    return {
+        "rule": stop_policy.rule,
+        "alpha": stop_policy.alpha,
+        "planned_looks": looks,
+        "look": max(round_no - min_rounds + 1, 1),
+        "min_rounds": min_rounds,
+        "max_rounds": max_rounds,
+        "rounds": len(ratios),
+        "adjusted_ci_level": level,
+        "adjusted_ci": [adjusted[0], adjusted[1]],
+        "theta_bar": bar,
+        "decision": decision,
+        "stop_on_decisive_miss": stop_policy.stop_on_decisive_miss,
+    }
 
 
 def _seed(workload_id: str, round_no: int) -> int:
@@ -2123,6 +2469,418 @@ def _rounded_candidate_geomean(
     if not values or any(value is None for value in values):
         return None
     return round(stats.geometric_mean([float(value) for value in values]), 6)
+
+
+def _current_era(repo_root: Path, era: int | None) -> int:
+    if era is not None:
+        return int(era)
+    try:
+        return int(ledger.current_epoch(repo_root)["epoch"])
+    except (ledger.LedgerError, KeyError, OSError, ValueError) as exc:
+        raise RunError(f"cannot resolve the current era: {exc}") from exc
+
+
+def proxy_selection(
+    manifest: Manifest, board: str, workload_class: str, era: int,
+) -> tuple[list[Workload], dict | None, dict, list[str]]:
+    """Resolve the class's proxy fixture and its era validity state.
+
+    Returns ``(workloads, fixture, validity, markers)``. A class without a
+    declared proxy falls back to its real workloads and says so loudly: the
+    ladder degrades to "slow but honest", never to "fast but unlabelled".
+    """
+    group = manifest.group_for_board(board)
+    fixture = manifest.proxy_fixture(workload_class)
+    validity = manifest.proxy_validity_state(board, workload_class, era)
+    markers: list[str] = []
+    if fixture is None:
+        markers.append(
+            f"no proxy fixture declared for class {workload_class}; iterating "
+            "on the full class basket"
+        )
+        return (
+            _board_workloads(manifest, board, workload_class),
+            None,
+            validity,
+            markers,
+        )
+    if not validity["validated"]:
+        markers.append("proxy unvalidated: " + str(validity["reason"]))
+    workload = Workload(
+        fixture["proxy_id"],
+        workload_class,
+        fixture["args"],
+        fixture["native_unit"],
+        group.group_id,
+    )
+    return [workload], fixture, validity, markers
+
+
+def phase_prefilter(
+    predecessor_root: Path,
+    repo_root: Path,
+    manifest: Manifest,
+    workload_class: str,
+    out_dir: Path,
+    *,
+    board: str,
+    phase: str,
+    era: int | None = None,
+) -> dict:
+    """T0: one stage-profiled sample per arm; the claimed phase must move.
+
+    A claimed FRI win that only moves witness time dies here in seconds
+    instead of surviving to a 45-minute T2 run (TRACKS §3.5). T0 never ranks.
+    """
+    era = _current_era(repo_root, era)
+    ladder = manifest.confirmation_ladder
+    tier = (ladder.get("tiers") or {}).get("T0")
+    if not isinstance(tier, dict):
+        raise RunError(
+            "T0 requires a pre-registered gates_policy.confirmation_ladder.tiers.T0"
+        )
+    warmups = int(tier["warmups"])
+    samples = int(tier["samples"])
+    min_move = float(tier["min_phase_move"])
+    workloads, fixture, validity, markers = proxy_selection(
+        manifest, board, workload_class, era,
+    )
+    if not workloads:
+        raise RunError(
+            f"no enabled workloads registered for board {board}, class {workload_class}"
+        )
+    workload = workloads[0]
+    group = manifest.group(workload.group_id)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    build_arm(predecessor_root, manifest, groups=[group])
+    build_arm(repo_root, manifest, groups=[group])
+    started = time.monotonic()
+    arms: dict[str, ArmResult] = {}
+    reports: dict[str, dict] = {}
+    for arm, root in (("a", predecessor_root), ("b", repo_root)):
+        arms[arm] = bench_once(
+            root, manifest, workload, warmups, samples, out_dir, f"t0{arm}",
+        )
+        reports[arm] = _load_json_object(
+            Path(arms[arm].report_path).read_text(encoding="utf-8"),
+            "T0 bench report",
+        )
+    elapsed = time.monotonic() - started
+    a, b = arms["a"], arms["b"]
+    # Correctness smoke: the cross-arm proof identity that G1 demands, checked
+    # before any timing claim is believed.
+    smoke_ok = bool(a.proof_digest and b.proof_digest and a.proof_digest == b.proof_digest)
+    phases_a = report_phases(reports["a"], group)
+    phases_b = report_phases(reports["b"], group)
+    if not phases_a or not phases_b:
+        raise RunError(
+            f"group {group.group_id}: report schema {group.report_schema!r} "
+            "exposes no phase cutpoints (§3.2); T0 phase attribution is "
+            "impossible for this group"
+        )
+    key = resolve_phase(phases_a, phase)
+    if key not in phases_b:
+        raise RunError(f"candidate arm does not report the claimed phase {phase!r}")
+    before, after = phases_a[key], phases_b[key]
+    if before <= 0.0:
+        raise RunError(f"predecessor phase {key} is not a positive duration")
+    relative_move = (before - after) / before
+    moved = relative_move >= min_move
+    target = manifest.tier_cost_target_seconds("T0")
+    return {
+        "schema": LADDER_T0_SCHEMA,
+        "tier": "T0",
+        "ranks": False,
+        "board": board,
+        "workload_class": workload_class,
+        "workload": workload.workload_id,
+        "era": era,
+        "claimed_phase": phase,
+        "resolved_phase": key,
+        "phase_seconds": {"predecessor": before, "candidate": after},
+        "relative_move": relative_move,
+        "min_phase_move": min_move,
+        "phase_moved": moved,
+        "correctness_smoke": {
+            "pass": smoke_ok,
+            "predecessor_proof_digest": a.proof_digest,
+            "candidate_proof_digest": b.proof_digest,
+        },
+        "pass": bool(moved and smoke_ok),
+        "measured_phases": {
+            "predecessor": phases_a,
+            "candidate": phases_b,
+        },
+        "proxy": fixture,
+        "proxy_validity": validity,
+        "markers": markers,
+        "measurement_seconds": elapsed,
+        "cost_target_seconds": target,
+        "within_cost_target": target is None or elapsed <= float(target),
+        "reports": [a.report_path, b.report_path],
+        "note": (
+            "T0 gates scheduling only: it never ranks and never writes a "
+            "scored row (TRACKS §3.5)."
+        ),
+    }
+
+
+def iterate_estimate(
+    repo_root: Path,
+    predecessor_root: Path,
+    manifest: Manifest,
+    workload_class: str,
+    out_dir: Path,
+    *,
+    board: str,
+    fast_boundary: bool = False,
+    era: int | None = None,
+    round_budget: int | None = None,
+) -> dict:
+    """T1: paired ABBA on proxy fixtures with sequential early stopping.
+
+    The agent's inner loop. It produces an ESTIMATE document, never a verdict:
+    T1 output can never be promoted, submitted, or ranked (TRACKS §3.5b's
+    local-iterate vs ranked separation).
+    """
+    era = _current_era(repo_root, era)
+    workloads, fixture, validity, markers = proxy_selection(
+        manifest, board, workload_class, era,
+    )
+    if not workloads:
+        raise RunError(
+            f"no enabled workloads registered for board {board}, class {workload_class}"
+        )
+    group_ids = {workload.group_id for workload in workloads}
+    if len(group_ids) != 1:
+        raise RunError(f"board {board} selected workloads from multiple groups")
+    group = manifest.group(next(iter(group_ids)))
+    policy = manifest.gates_for_workload(group.group_id, workload_class)
+    if fast_boundary:
+        require_pow_boundary(group)
+    dispersion = ledger.aa_dispersion(repo_root, board, workload_class)
+    theta = stats.theta(
+        dispersion,
+        float(policy["theta_floor"]),
+        float(policy["dispersion_multiplier"]),
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+    build_arm(predecessor_root, manifest, groups=[group])
+    build_arm(repo_root, manifest, groups=[group])
+    started = time.monotonic()
+    scores = [
+        paired_rounds(
+            predecessor_root, repo_root, manifest, workload, policy, out_dir,
+            stop_theta=theta,
+            round_budget=round_budget,
+            sequential_stop=True,
+            fast_boundary=fast_boundary,
+        )
+        for workload in workloads
+    ]
+    elapsed = time.monotonic() - started
+    portfolio = portfolio_summary(scores, float(policy["ci_level"]))
+    target = manifest.tier_cost_target_seconds("T1")
+    return {
+        "schema": LADDER_T1_SCHEMA,
+        "tier": "T1",
+        "ranks": False,
+        "board": board,
+        "workload_class": workload_class,
+        "era": era,
+        "boundary": FAST_BOUNDARY if fast_boundary else FULL_BOUNDARY,
+        "theta": theta,
+        "aa_dispersion": dispersion,
+        "r_geomean": portfolio["r"],
+        "ci": [portfolio["ci"][0], portfolio["ci"][1]],
+        "ci_level": portfolio["ci_level"],
+        "per_workload": {
+            score.workload.workload_id: {
+                "r": score.r,
+                "ci": [score.ci[0], score.ci[1]],
+                "rounds": len(score.ratios),
+                "boundary": score.boundary,
+                "a_median_ms": score.a_median_ms,
+                "b_median_ms": score.b_median_ms,
+                "request_ratio": score.request_ratio,
+                "fast_request_ratio": score.fast_request_ratio,
+                "sequential_stop": score.sequential_stop,
+                "measurement_seconds": score.measurement_seconds,
+            }
+            for score in scores
+        },
+        "proxy": fixture,
+        "proxy_validity": validity,
+        "markers": markers,
+        "measurement_seconds": elapsed,
+        "cost_target_seconds": target,
+        "within_cost_target": target is None or elapsed <= float(target),
+        "note": (
+            "T1 is a CI-bearing LOCAL estimate on proxy fixtures. It never "
+            "ranks; ranked rows come only from the judge path (TRACKS §3.5)."
+        ),
+    }
+
+
+def _proxy_observation_ln_ratio(document: dict, label: str) -> float:
+    """Extract a measured ln-ratio from a T1 estimate or a claimed/judged verdict."""
+    if document.get("schema") == LADDER_T1_SCHEMA:
+        ratio = document.get("r_geomean")
+    elif document.get("schema_version") == 1 and "score" in document:
+        score = document.get("score")
+        ratio = score.get("R_geomean") if isinstance(score, dict) else None
+    else:
+        raise RunError(
+            f"{label}: not a T1 estimate or a stwo-perf verdict; refusing to "
+            "read a ratio from an unknown document"
+        )
+    if (
+        isinstance(ratio, bool)
+        or not isinstance(ratio, (int, float))
+        or not math.isfinite(float(ratio))
+        or float(ratio) <= 0.0
+    ):
+        raise RunError(f"{label}: measured ratio is missing or not positive")
+    return math.log(float(ratio))
+
+
+def _proxy_document_board_class(document: dict) -> tuple[str | None, str | None]:
+    if document.get("schema") == LADDER_T1_SCHEMA:
+        return document.get("board"), document.get("workload_class")
+    objective = document.get("declared_objective")
+    if isinstance(objective, dict):
+        return objective.get("board"), objective.get("workload_class")
+    return None, None
+
+
+def _host_chip() -> str:
+    if platform.system() == "Darwin":
+        try:
+            chip = subprocess.run(
+                ["sysctl", "-n", "machdep.cpu.brand_string"],
+                capture_output=True, text=True, timeout=30,
+            )
+            if chip.returncode == 0 and chip.stdout.strip():
+                return chip.stdout.strip()
+        except (OSError, subprocess.SubprocessError):
+            pass
+    return platform.processor() or platform.machine() or "unknown"
+
+
+def build_proxy_validity_receipt(
+    repo_root: Path,
+    manifest: Manifest,
+    *,
+    board: str,
+    workload_class: str,
+    era: int,
+    observations: list[tuple[Path, Path]],
+    measured_at_utc: str | None = None,
+) -> dict:
+    """Assemble a ``stwo_perf_proxy_validity_receipt_v1`` from measured runs.
+
+    Every number in the receipt is read from measurement documents that already
+    exist on disk: this function measures nothing and invents nothing. It runs
+    on the designated judge host, once per era, per (board, class).
+    """
+    fixture = manifest.proxy_fixture(workload_class)
+    if fixture is None:
+        raise RunError(
+            f"class {workload_class} declares no proxy_fixture; there is "
+            "nothing to certify"
+        )
+    policy = manifest.confirmation_ladder.get("proxy_validity")
+    if not isinstance(policy, dict):
+        raise RunError(
+            "gates_policy.confirmation_ladder.proxy_validity is not registered"
+        )
+    minimum = int(policy["min_observations"])
+    if len(observations) < minimum:
+        raise RunError(
+            f"refusing to certify a proxy from {len(observations)} observation(s): "
+            f"the registered minimum is {minimum}"
+        )
+    records: list[dict] = []
+    xs: list[float] = []
+    ys: list[float] = []
+    for proxy_path, class_path in observations:
+        pairs = []
+        for path, label in ((proxy_path, "proxy run"), (class_path, "class run")):
+            try:
+                raw = Path(path).read_bytes()
+                document = _load_json_object(raw.decode("utf-8"), label)
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+                raise RunError(f"{label} {path}: unreadable ({exc})") from exc
+            observed_board, observed_class = _proxy_document_board_class(document)
+            if observed_board != board or observed_class != workload_class:
+                raise RunError(
+                    f"{label} {path}: measured {observed_board}/{observed_class}, "
+                    f"expected {board}/{workload_class}"
+                )
+            pairs.append((
+                _proxy_observation_ln_ratio(document, f"{label} {path}"),
+                hashlib.sha256(raw).hexdigest(),
+            ))
+        (proxy_ln, proxy_sha), (class_ln, class_sha) = pairs
+        xs.append(proxy_ln)
+        ys.append(class_ln)
+        records.append({
+            "proxy_ln_ratio": proxy_ln,
+            "class_ln_ratio": class_ln,
+            "proxy_evidence_sha256": proxy_sha,
+            "class_evidence_sha256": class_sha,
+        })
+    try:
+        correlation = pearson_correlation(xs, ys)
+    except ManifestError as exc:
+        raise RunError(str(exc)) from exc
+    floor = float(policy["min_correlation"])
+    document = {
+        "schema": PROXY_VALIDITY_RECEIPT_SCHEMA,
+        "board": board,
+        "era": int(era),
+        "workload_class": workload_class,
+        "proxy": {
+            "proxy_id": fixture["proxy_id"],
+            "args": fixture["args"],
+            "native_unit": fixture["native_unit"],
+            "official_params": True,
+        },
+        "target": {"workload_ids": list(fixture["target_workload_ids"])},
+        "measured_at_utc": measured_at_utc or time.strftime(
+            "%Y-%m-%dT%H:%M:%SZ", time.gmtime(),
+        ),
+        "host": {
+            "identity_sha256": hashlib.sha256(platform.node().encode()).hexdigest(),
+            "chip": _host_chip(),
+            "logical_cpu_count": os.cpu_count() or 1,
+        },
+        "harness_commit": _harness_commit(repo_root),
+        "measurement": {
+            "method": PROXY_VALIDITY_METHOD,
+            "observations": records,
+            "observation_count": len(records),
+            "correlation": correlation,
+            "min_correlation": floor,
+            "min_observations": minimum,
+            "valid": correlation >= floor and len(records) >= minimum,
+        },
+        "artifact_sha256": hashlib.sha256(
+            json.dumps(records, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest(),
+    }
+    try:
+        validate_proxy_validity_receipt(
+            document,
+            board=board,
+            workload_class=workload_class,
+            era=int(era),
+            policy=policy,
+            proxy_fixture=fixture,
+        )
+    except ManifestError as exc:
+        raise RunError(f"assembled receipt failed its own schema: {exc}") from exc
+    return document
 
 
 RUST_ORACLE_RELPATH = "tools/stwo-interop-rs/target/release/stwo-interop-rs"
@@ -2630,13 +3388,25 @@ def evaluate(
     guards_mode: str = "auto",
     audit_mode: bool = False,
     require_quiet_host: bool = False,
+    fast_boundary: bool = False,
 ) -> dict:
     """Run the full paired evaluation and assemble a verdict dict.
 
     `judged=True` is reachable only from the judge bot; the public CLI always
     evaluates claimed. The judged trust boundary is the HMAC signature applied
     by the judge (signing.py), never this flag alone.
+
+    ``fast_boundary`` exists only to be refused: T2 and T3 keep the full dual
+    boundary, so the parameter fails closed here rather than silently producing
+    a verdict whose number excluded work (TRACKS §3.5).
     """
+    if fast_boundary:
+        raise RunError(
+            "the PoW-excluded fast boundary is refused on judged/ranked "
+            "evaluation: T2 and T3 keep the full dual boundary — the ranked "
+            "number never excludes anything (TRACKS §3.5). Iterate with the "
+            "T1 path instead (stwo-perf ladder t1 --fast-boundary)."
+        )
     if judged and board == "core_metal":
         from .metal_calibration import CalibrationError, require_frozen
 
@@ -2914,6 +3684,12 @@ def evaluate(
                     "report_sha256s": s.report_sha256s,
                     "mechanism_verified": s.mechanism_verified,
                     "resources_complete": s.resources_complete,
+                    # Only present when the pre-registered sequential design was
+                    # armed, so pre-ladder verdicts keep their exact shape.
+                    **(
+                        {"sequential_stop": s.sequential_stop}
+                        if s.sequential_stop is not None else {}
+                    ),
                 }
                 for s in scores
             },

--- a/autoresearch/schema/confirmation-ladder.md
+++ b/autoresearch/schema/confirmation-ladder.md
@@ -1,0 +1,281 @@
+# Confirmation ladder — tiers, spending rule, proxy receipts
+
+Contract: `autoresearch/TRACKS.md` §3.5 (the ladder), §3.6 (acceptance), §8
+(wave-1 work items). This document is the schema reference for the harness
+implementation of the ladder: what is registered where, what each tier emits,
+and what an operator runs on the judge host.
+
+Ranked truth is expensive. The ladder makes every step *before* ranked as cheap
+as honesty allows, so agents iterate in seconds and the judge only ever confirms
+already-evidenced wins.
+
+| tier | cost target | what runs | emits | ranks? |
+|---|---|---|---|---|
+| T0 smoke | < 30 s | correctness smoke + ONE stage-profiled sample on the proxy fixture | `stwo_perf_ladder_t0_prefilter_v1` | never |
+| T1 iterate | < 300 s | paired ABBA on proxy fixtures, sequential early stop, PoW-excluded boundary | `stwo_perf_ladder_t1_estimate_v1` | never |
+| T2 claimed | < 2700 s | full dual-boundary paired run, real classes, guards impact-mapped | `verdict.json` (`kind: claimed`) | claimed only |
+| T3 ranked | judge-scheduled | judged re-run + audits on the designated host | signed `verdict.json` (`kind: judged`) | the scored row |
+
+## 1. Registration: `gates_policy.confirmation_ladder`
+
+The whole ladder is one optional manifest block. **A manifest without it keeps
+exactly the pre-ladder runner behavior** — that back-compatibility is a tested
+property, not a hope.
+
+```json
+"confirmation_ladder": {
+  "schema": "stwo_perf_confirmation_ladder_v1",
+  "sequential_stop": {
+    "enabled": false,
+    "rule": "pocock_constant_boundary_bonferroni_v1",
+    "alpha": 0.05,
+    "stop_on_decisive_miss": true
+  },
+  "tiers": {
+    "T0": {"cost_target_seconds": 30, "warmups": 1, "samples": 1,
+           "min_phase_move": 0.02, "note": "..."},
+    "T1": {"cost_target_seconds": 300, "note": "..."},
+    "T2": {"cost_target_seconds": 2700, "note": "..."},
+    "T3": {"cost_target_seconds": null, "note": "..."}
+  },
+  "proxy_validity": {
+    "receipt_schema": "stwo_perf_proxy_validity_receipt_v1",
+    "receipt_dir": "autoresearch/reference/proxy_validity",
+    "min_correlation": 0.8,
+    "min_observations": 5
+  },
+  "cost_telemetry": {"statistic": "median", "window": 5},
+  "note": "..."
+}
+```
+
+Validation lives in `manifest.py` (`_validate_confirmation_ladder`): the block
+is all-or-nothing, tier targets must increase strictly down the ladder, and
+`rule` must be the single registered spending rule. A half-registered design is
+not a pre-registered design.
+
+## 2. The sequential spending rule
+
+**Rule id: `pocock_constant_boundary_bonferroni_v1`.**
+
+* Looks happen at the end of each completed paired round `k` with
+  `min_rounds ≤ k ≤ max_rounds`. The number of planned looks is therefore
+  `K = max_rounds − min_rounds + 1`, fixed by the manifest before the run.
+* The family-wise error `alpha` is spent evenly across those looks (a constant,
+  Pocock-style boundary): look `k` decides on a bootstrap CI at level
+  `1 − alpha/K`, using the same deterministic seed as the run's final CI.
+* Stop conditions, evaluated against the bar `1 − theta`:
+  * **decisive clear** — adjusted CI upper bound `< 1 − theta`;
+  * **decisive miss** — adjusted CI lower bound `> 1 − theta`
+    (only when `stop_on_decisive_miss`);
+  * otherwise continue. Borderline effects pay full power to `max_rounds`.
+* The existing precision rule (half-width `≤ theta/2`), the `min_rounds` floor,
+  the `max_rounds` cap, and the wall-clock cap are all unchanged and still
+  bind — the sequential rule can only stop a run *earlier*, never later.
+
+Why this is honest: `alpha/K < alpha`, so the boundary is strictly stricter
+than the fixed-sample gate. A decisive clear at any look would also have
+cleared the nominal gate, so early stopping can never admit a run that the
+full-power design would have rejected. The run records its own design in
+`sequential_stop` evidence (rule, alpha, planned looks, look index, adjusted
+level, adjusted CI, bar, decision) so a reader can audit the stop.
+
+Arming:
+
+* `sequential_stop.enabled` arms the rule on scored paired runs (T2/T3, A/A).
+  It ships **false**: the ranked path keeps its fixed design until an era
+  boundary deliberately changes it.
+* The T1 iterate path arms the rule explicitly (`sequential_stop=True`) because
+  T1 never ranks. It still refuses to run when the manifest has not registered
+  the rule — the parameters are never ad hoc.
+
+## 3. PoW-excluded fast boundary
+
+`pow 26` is ~constant work and pure noise for paired deltas, so T0/T1 measure
+`verified_request_minus_pow_ms` while T2/T3 keep the full boundary. Both
+numbers are reported at T1: `request_ratio` (full) and `fast_request_ratio`
+(PoW-excluded).
+
+Fail-closed in three places:
+
+1. `runner.POW_PHASE_SECONDS_FIELDS` maps a `report_schema` to the report path
+   carrying the **measured** PoW seconds. It is deliberately **empty**: no
+   shipped product emits a PoW cutpoint yet, so `--fast-boundary` refuses on
+   every group today. The harness never subtracts a cost it did not measure.
+   *Product handoff:* emit the PoW phase (§3.2 names it) and register the field
+   path here; nothing else changes.
+
+   Known near-miss on Cairo: the Cairo stage profile already records a
+   `proof_of_work` stage with real seconds, but the phase mapping folds it into
+   the `fri` phase, and the profile is recorded on a **discarded warmup** while
+   the scored request time comes from the uninstrumented samples. Registering
+   that number would subtract a duration measured on a *different invocation*
+   than the one being timed. That is a decision about measurement scope, not a
+   wiring detail, so it is left to a reviewed change: either publish per-sample
+   PoW seconds in the `cairo_proof_v1` envelope, or accept the cross-invocation
+   subtraction explicitly for T1 (which never ranks).
+2. `runner.evaluate(..., fast_boundary=True)` always raises — the ranked and
+   claimed paths cannot express a PoW-excluded number even by accident.
+3. `stwo-perf run --fast-boundary` is rejected by the CLI with a pointer to
+   `stwo-perf ladder t1 --fast-boundary`.
+
+## 4. Proxy fixtures (`workload_registry.classes.<class>.proxy_fixture`)
+
+A proxy is a **scaled shape at official parameters** — never weakened
+parameters at a full shape (§3.3).
+
+```json
+"proxy_fixture": {
+  "proxy_id": "cairo_all_opcodes_proxy",
+  "args": "--fixture ... --warmups {warmups} --samples {samples}",
+  "native_unit": "committed cells",
+  "official_params": true,
+  "target_workload_ids": ["cairo_all_opcodes"],
+  "note": "scaled geometry, official pow 26 / 70 queries"
+}
+```
+
+`official_params` must be `true`, and the args may not restate any security
+parameter (`--pow-bits`, `--n-queries`, `--protocol`, `--security`,
+`--functional` are refused outright): a proxy scales geometry only. Classes
+without a proxy fixture are legal — the ladder then iterates on the full class
+basket and says so with a loud marker.
+
+## 5. Era validity receipts (`stwo_perf_proxy_validity_receipt_v1`)
+
+Per era, per `(board, class)`, the judge host measures the proxy→class
+predictive correlation and commits it as a receipt at
+`<receipt_dir>/<board>-<class>-era<N>.json`. Receipts are era-frozen like
+anchors. A proxy whose validity decays below `min_correlation` is rotated.
+
+```json
+{
+  "schema": "stwo_perf_proxy_validity_receipt_v1",
+  "board": "cairo_cpu",
+  "era": 3,
+  "workload_class": "huge",
+  "proxy": {"proxy_id": "...", "args": "...", "native_unit": "...",
+            "official_params": true},
+  "target": {"workload_ids": ["..."]},
+  "measured_at_utc": "2026-07-29T12:00:00Z",
+  "host": {"identity_sha256": "<64 hex>", "chip": "Apple M5",
+           "logical_cpu_count": 10},
+  "harness_commit": "<12-40 hex>",
+  "measurement": {
+    "method": "paired_ln_ratio_pearson_v1",
+    "observations": [
+      {"proxy_ln_ratio": -0.11, "class_ln_ratio": -0.09,
+       "proxy_evidence_sha256": "<64 hex>", "class_evidence_sha256": "<64 hex>"}
+    ],
+    "observation_count": 5,
+    "correlation": 0.93,
+    "min_correlation": 0.8,
+    "min_observations": 5,
+    "valid": true
+  },
+  "artifact_sha256": "<64 hex of the canonical observation list>"
+}
+```
+
+Anti-fabrication properties, enforced by
+`manifest.validate_proxy_validity_receipt`:
+
+* the correlation is **recomputed** from the receipt's own observations and
+  must match to 1e-9 — a receipt cannot assert a number its evidence does not
+  support;
+* every observation binds the sha256 of the measurement document it came from;
+* a receipt may not weaken the registered `min_correlation` or
+  `min_observations`;
+* `valid` must agree with the receipt's own thresholds;
+* the proxy identity must equal the manifest's declared fixture.
+
+**Absence is never fatal and never fabricated.** With no receipt (or an invalid
+one) `manifest.proxy_validity_state` reports `validated: false` and T0/T1
+documents carry a `proxy unvalidated: ...` marker. T0/T1 never rank, so an
+unvalidated proxy costs scheduling confidence, not correctness.
+
+### Operator commands (M5 judge host)
+
+Receipt generation is an M5 job: it consumes measurement documents that already
+exist and computes nothing new about the machine. For each of at least
+`min_observations` candidate/predecessor pairs, record one proxy run and one
+class run, then assemble:
+
+```sh
+# 1. per historical pair, on the judge host, under the judge lock:
+stwo-perf ladder t1 --board <track> --class <class> \
+    --predecessor <predecessor-worktree> \
+    --out /tmp/proxy-<n>.json
+stwo-perf run --board <track> --class <class> \
+    --predecessor <predecessor-worktree> \
+    --out /tmp/class-<n>.json
+
+# 2. assemble the era receipt (measures nothing; reads the runs above):
+stwo-perf ladder proxy-receipt --board <track> --class <class> --era <N> \
+    --observation /tmp/proxy-1.json:/tmp/class-1.json \
+    --observation /tmp/proxy-2.json:/tmp/class-2.json \
+    --observation /tmp/proxy-3.json:/tmp/class-3.json \
+    --observation /tmp/proxy-4.json:/tmp/class-4.json \
+    --observation /tmp/proxy-5.json:/tmp/class-5.json \
+    --out autoresearch/reference/proxy_validity/<track>-<class>-era<N>.json
+
+# 3. commit the receipt via a reviewed PR (era-frozen like anchors).
+```
+
+The command exits non-zero when the measured correlation is below the floor:
+that is the rotation signal, and the receipt is still written so the decay is
+on the record.
+
+## 6. T0 phase-attribution prefilter
+
+A submission names the phase it claims to move (§3.2 vocabulary). T0 runs one
+stage-profiled sample per arm on the proxy fixture and requires that phase to
+move by at least `tiers.T0.min_phase_move` before T1 is scheduled — a claimed
+FRI win that only moves witness time dies in 30 seconds, not 45 minutes.
+
+Phase evidence is read generically from whatever the group's report schema
+provides: the declared cutpoints in `runner.PHASE_SECONDS_FIELDS` plus any
+stage-profile tree in the report (`timing.stage_profiles`, `stage_profile`, or
+a bare `stages` list, as `--stage-profile-out` writes), flattened to dotted
+`stage:<parent>.<child>` names. A group whose reports carry no phase evidence
+at all fails closed rather than silently passing every claim.
+
+Registered rows: `native_proof_v7` (input/prove/serialize/verify/request),
+`riscv_proof_v2` (execute/witness/prove/verify/request), and `cairo_proof_v1`,
+whose row is **derived** from `manifest.CAIRO_PHASE_NAMES` so the ladder cannot
+drift from the schema's canonical cutpoint set. Cairo's `serialize` is always
+null (proof encode/write/hash is outside the recorder), so it drops out of the
+measured set and a claim on it fails T0 closed — as does a claim on any phase
+whose predecessor duration is zero (a prove-only workload's `execute`).
+
+`tiers.T0.warmups` is **1**, not 0: the Cairo arm records its mandatory phase
+profile on a discarded warmup, so a zero-warmup T0 would leave that track with
+no phase evidence at all.
+
+```sh
+stwo-perf ladder t0 --board <track> --class <class> --phase fri \
+    --predecessor <predecessor-worktree>
+```
+
+Exit code 1 means "T1 is not scheduled".
+
+## 7. Tier cost targets in CI (§3.6)
+
+`scripts/check_tier_cost_targets.py` reads the recorded telemetry —
+`score.portfolio.measurement_seconds` from claimed (T2) and judged (T3)
+verdicts, `measurement_seconds` from T0/T1 ladder documents — aggregates the
+last `cost_telemetry.window` observations per `(track, tier)` with
+`cost_telemetry.statistic`, and fails when the summary exceeds the tier's
+registered target.
+
+* Tracks are enumerated from `workload_registry.groups[*].board`, so a new
+  track is covered the moment its group lands.
+* T3 has no target (`null`): the judge never trades honesty for time.
+* A `(track, tier)` with no telemetry passes with a loud note. Fail-closed
+  applies to honesty, not to absent tracks.
+
+Wiring: `autoresearch/tests/test_tier_cost_targets.py` invokes the check over
+the repository, and the `autoresearch-validate` workflow already runs
+`python3 -m unittest discover -s autoresearch/tests`, so the target is enforced
+on every PR without adding a workflow step. Run it by hand with
+`python3 scripts/check_tier_cost_targets.py`.

--- a/autoresearch/tests/test_confirmation_ladder.py
+++ b/autoresearch/tests/test_confirmation_ladder.py
@@ -1,0 +1,977 @@
+"""Confirmation ladder: sequential stopping, fast boundary, proxies, T0.
+
+Contract: TRACKS §3.5 (ladder tiers and devices) and §3.6 (acceptance).
+"""
+
+import hashlib
+import json
+import math
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "cli"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from stwo_perf import manifest as manifest_mod, runner
+from stwo_perf.manifest import Manifest, ManifestError
+
+# W1's committed Cairo fixtures: the ladder reads the same evidence the
+# cairo_proof_v1 parser produces, so T0 is tested against a real envelope.
+from test_cairo_boards import (  # noqa: E402
+    FAKE_PRODUCT,
+    load_profile,
+    load_report,
+    raw_manifest as cairo_raw_manifest,
+)
+
+LADDER = {
+    "schema": manifest_mod.CONFIRMATION_LADDER_SCHEMA,
+    "sequential_stop": {
+        "enabled": False,
+        "rule": manifest_mod.SEQUENTIAL_STOP_RULE,
+        "alpha": 0.05,
+        "stop_on_decisive_miss": True,
+    },
+    "tiers": {
+        "T0": {
+            "cost_target_seconds": 30,
+            # One warmup is the floor: the Cairo arm records its mandatory
+            # phase profile on a discarded warmup.
+            "warmups": 1,
+            "samples": 1,
+            "min_phase_move": 0.02,
+            "note": "smoke plus one stage-profiled sample",
+        },
+        "T1": {"cost_target_seconds": 300, "note": "iterate"},
+        "T2": {"cost_target_seconds": 2700, "note": "claimed"},
+        "T3": {"cost_target_seconds": None, "note": "judge-scheduled"},
+    },
+    "proxy_validity": {
+        "receipt_schema": manifest_mod.PROXY_VALIDITY_RECEIPT_SCHEMA,
+        "receipt_dir": "autoresearch/reference/proxy_validity",
+        "min_correlation": 0.8,
+        "min_observations": 5,
+    },
+    "cost_telemetry": {"statistic": "median", "window": 5},
+    "note": "test ladder",
+}
+
+PROXY_FIXTURE = {
+    "proxy_id": "small_proxy",
+    "args": "--warmups {warmups} --samples {samples} --log-n-rows 12",
+    "native_unit": "trace rows",
+    "official_params": True,
+    "target_workload_ids": ["wf_small"],
+    "note": "scaled geometry at official parameters",
+}
+
+
+def legacy_policy(**overrides) -> dict:
+    """A resolved gate policy from a manifest that predates the ladder."""
+    policy = {
+        "ci_level": 0.95,
+        "theta_floor": 0.01,
+        "dispersion_multiplier": 2.0,
+        "targeted_class_budget": 1.02,
+        "matrix_row_budget": 1.05,
+        "warmups": 0,
+        "samples_per_round": 1,
+        "min_rounds": 3,
+        "max_rounds": 9,
+        "command_timeout_seconds": 60,
+        "wall_clock_cap_seconds": {"small": 600},
+    }
+    policy.update(overrides)
+    return policy
+
+
+def base_policy(**overrides) -> dict:
+    """A resolved gate policy carrying the registered (but idle) ladder."""
+    policy = legacy_policy(confirmation_ladder=LADDER)
+    policy.update(overrides)
+    return policy
+
+
+def make_raw(*, ladder: dict | None = None, proxy: dict | None = None) -> dict:
+    small = {
+        "scored": True,
+        "resource": {
+            "profile": "standard",
+            "command_timeout_seconds": 60,
+            "wall_clock_cap_seconds": 600,
+        },
+        "sampling": {
+            "warmups": 1,
+            "samples_per_round": 1,
+            "min_rounds": 3,
+            "max_rounds": 9,
+        },
+    }
+    if proxy is not None:
+        small["proxy_fixture"] = proxy
+    gates = {
+        "ci_level": 0.95,
+        "theta_floor": 0.01,
+        "dispersion_multiplier": 2.0,
+        "targeted_class_budget": 1.02,
+        "matrix_row_budget": 1.05,
+        "search_health": {
+            "trailing_window": 4,
+            "gradient_snr_threshold": 2.0,
+            "auto_boost_rounds": 2,
+            "maximum_rounds": 9,
+        },
+    }
+    if ladder is not None:
+        gates["confirmation_ladder"] = ladder
+    return {
+        "manifest_version": 2,
+        "harness": {"anchor_commit": None},
+        "editable_paths": [],
+        "locked_paths": [],
+        "gates_policy": gates,
+        "qualification_policy": {
+            "required_checks": ["allowed_diff"],
+            "max_active_per_user": 1,
+        },
+        "workload_registry": {
+            "classes": {"small": small},
+            "groups": {
+                "native": {
+                    "enabled": True,
+                    "promotion_eligible": True,
+                    "board": "core_cpu",
+                    "build_step": "true",
+                    "binary": "bin/fakebench",
+                    "report_schema": "native_proof_v7",
+                    "workloads": {
+                        "wf_small": {
+                            "class": "small",
+                            "args": "--warmups {warmups} --samples {samples}",
+                            "native_unit": "trace rows",
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+
+class LadderTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.out_dir = self.root / "runs"
+
+    def manifest(self, **kwargs) -> Manifest:
+        raw = make_raw(**kwargs)
+        manifest_mod._validate(raw)
+        return Manifest(root=self.root, raw=raw)
+
+    def workload(self, group_id: str = "native"):
+        return manifest_mod.Workload(
+            "wf_small", "small", "--warmups {warmups} --samples {samples}",
+            "trace rows", group_id,
+        )
+
+    def fake_bench(self, ratio_for_round, *, pow_ms=None, request_scale=1.0,
+                   phases=None):
+        """Deterministic stand-in for one paired bench invocation."""
+        calls: list[str] = []
+
+        def bench(arm_root, manifest, workload, warmups, samples, out_dir, tag,
+                  **_kwargs):
+            calls.append(tag)
+            out_dir.mkdir(parents=True, exist_ok=True)
+            path = out_dir / f"{workload.workload_id}.{tag}.json"
+            # Paired rounds tag as "<arm><round>"; T0 tags as "t0<arm>".
+            if tag.startswith("t0"):
+                arm, round_no = tag[-1], 1
+            else:
+                arm, round_no = tag[0], int(tag[1:])
+            ratio = 1.0 if arm == "a" else ratio_for_round(round_no)
+            prove_ms = 100.0 * ratio
+            document = {"tag": tag, "prove_ms": prove_ms}
+            if phases is not None:
+                document.update(phases(arm))
+            path.write_text(json.dumps(document))
+            return runner.ArmResult(
+                prove_ms=prove_ms,
+                proof_verified=samples,
+                byte_identical=True,
+                peak_rss_mib=None,
+                report_path=str(path),
+                proof_digest="d" * 64,
+                proof_bytes=1024,
+                request_ms=prove_ms * request_scale,
+                pow_ms=pow_ms,
+            )
+
+        return bench, calls
+
+    def run_rounds(self, bench, policy, **kwargs):
+        manifest = kwargs.pop("manifest", None) or self.manifest(ladder=LADDER)
+        with mock.patch.object(runner, "bench_once", bench):
+            return runner.paired_rounds(
+                self.root, self.root, manifest, self.workload(), policy,
+                self.out_dir, **kwargs,
+            )
+
+
+class SequentialStopTest(LadderTestCase):
+    """Pre-registered group-sequential spending (TRACKS §3.5)."""
+
+    NOISY_WIN = staticmethod(lambda round_no: 0.50 if round_no % 2 else 0.62)
+    BORDERLINE = staticmethod(lambda round_no: 0.97 if round_no % 2 else 1.01)
+    NOISY_LOSS = staticmethod(lambda round_no: 1.05 if round_no % 2 else 1.20)
+
+    def test_absent_config_is_exactly_todays_behavior(self):
+        """No ladder block, no ladder behavior: the back-compat contract."""
+        bench, _ = self.fake_bench(self.NOISY_WIN)
+        legacy = self.run_rounds(
+            bench, legacy_policy(), manifest=self.manifest(),
+        )
+        bench2, _ = self.fake_bench(self.NOISY_WIN)
+        registered_but_off = self.run_rounds(bench2, base_policy())
+        self.assertIsNone(legacy.sequential_stop)
+        self.assertIsNone(registered_but_off.sequential_stop)
+        self.assertEqual(runner.FULL_BOUNDARY, legacy.boundary)
+        self.assertEqual(len(legacy.ratios), len(registered_but_off.ratios))
+        self.assertEqual(legacy.r, registered_but_off.r)
+        self.assertEqual(legacy.ci, registered_but_off.ci)
+        # A large-but-noisy effect burns the whole round budget without the rule.
+        self.assertEqual(9, len(legacy.ratios))
+
+    def test_decisive_clear_stops_at_the_minimum_round_floor(self):
+        bench, calls = self.fake_bench(self.NOISY_WIN)
+        score = self.run_rounds(
+            bench, base_policy(), sequential_stop=True,
+        )
+        self.assertEqual(3, len(score.ratios))
+        self.assertEqual(6, len(calls))  # two arms per round, min_rounds honored
+        evidence = score.sequential_stop
+        self.assertEqual("decisive_clear", evidence["decision"])
+        self.assertEqual(manifest_mod.SEQUENTIAL_STOP_RULE, evidence["rule"])
+        self.assertEqual(7, evidence["planned_looks"])  # max 9 - min 3 + 1
+        self.assertEqual(1, evidence["look"])
+        self.assertAlmostEqual(1.0 - 0.05 / 7.0, evidence["adjusted_ci_level"])
+        # The stricter boundary implies the nominal gate: upper < 1 - theta.
+        self.assertLess(evidence["adjusted_ci"][1], evidence["theta_bar"])
+        self.assertLess(score.ci[1], evidence["theta_bar"])
+
+    def test_borderline_effect_pays_full_power(self):
+        bench, _ = self.fake_bench(self.BORDERLINE)
+        score = self.run_rounds(bench, base_policy(), sequential_stop=True)
+        self.assertEqual(9, len(score.ratios))
+        self.assertEqual("budget_exhausted", score.sequential_stop["decision"])
+
+    def test_decisive_miss_stops_early_only_when_registered(self):
+        bench, _ = self.fake_bench(self.NOISY_LOSS)
+        stopped = self.run_rounds(bench, base_policy(), sequential_stop=True)
+        self.assertEqual("decisive_miss", stopped.sequential_stop["decision"])
+        self.assertLess(len(stopped.ratios), 9)
+
+        ladder = json.loads(json.dumps(LADDER))
+        ladder["sequential_stop"]["stop_on_decisive_miss"] = False
+        bench2, _ = self.fake_bench(self.NOISY_LOSS)
+        full = self.run_rounds(
+            bench2, base_policy(confirmation_ladder=ladder),
+            sequential_stop=True,
+            manifest=self.manifest(ladder=ladder),
+        )
+        self.assertEqual(9, len(full.ratios))
+        self.assertEqual("budget_exhausted", full.sequential_stop["decision"])
+
+    def test_manifest_enabled_flag_arms_scored_runs(self):
+        ladder = json.loads(json.dumps(LADDER))
+        ladder["sequential_stop"]["enabled"] = True
+        bench, _ = self.fake_bench(self.NOISY_WIN)
+        score = self.run_rounds(
+            bench, base_policy(confirmation_ladder=ladder),
+            manifest=self.manifest(ladder=ladder),
+        )
+        self.assertEqual(3, len(score.ratios))
+        self.assertEqual("decisive_clear", score.sequential_stop["decision"])
+
+    def test_arming_without_registration_fails_closed(self):
+        bench, _ = self.fake_bench(self.NOISY_WIN)
+        with self.assertRaises(runner.RunError) as caught:
+            self.run_rounds(
+                bench, legacy_policy(), sequential_stop=True,
+                manifest=self.manifest(),
+            )
+        self.assertIn("pre-registered", str(caught.exception))
+
+    def test_unknown_rule_is_refused(self):
+        policy = legacy_policy(confirmation_ladder={
+            "sequential_stop": {"enabled": True, "rule": "made_up_v9", "alpha": 0.05},
+        })
+        with self.assertRaises(runner.RunError):
+            runner.sequential_stop_policy(policy)
+
+    def test_adjusted_level_is_stricter_than_the_nominal_gate(self):
+        policy = runner.SequentialStopPolicy(
+            manifest_mod.SEQUENTIAL_STOP_RULE, 0.05, True,
+        )
+        self.assertGreater(policy.adjusted_level(7), 0.95)
+        self.assertLess(policy.adjusted_level(7), 1.0)
+
+
+class FastBoundaryTest(LadderTestCase):
+    """PoW-excluded boundary: T0/T1 only, fail-closed everywhere else."""
+
+    def test_ranked_evaluation_refuses_the_flag(self):
+        with self.assertRaises(runner.RunError) as caught:
+            runner.evaluate(
+                self.root, self.root, self.manifest(ladder=LADDER), "small",
+                "time", "s3", False, self.out_dir, board="core_cpu",
+                fast_boundary=True,
+            )
+        message = str(caught.exception)
+        self.assertIn("full dual boundary", message)
+        self.assertIn("never excludes anything", message)
+
+    def test_judged_evaluation_refuses_the_flag(self):
+        with self.assertRaises(runner.RunError):
+            runner.evaluate(
+                self.root, self.root, self.manifest(ladder=LADDER), "small",
+                "time", "s3", True, self.out_dir, board="core_cpu",
+                fast_boundary=True,
+            )
+
+    def test_cli_run_refuses_the_flag(self):
+        from stwo_perf.__main__ import main
+        self.assertEqual(1, main(["run", "--fast-boundary", "--predecessor", "/tmp/x"]))
+
+    def test_group_without_a_measured_pow_phase_fails_closed(self):
+        bench, calls = self.fake_bench(lambda _round: 0.9)
+        with self.assertRaises(runner.RunError) as caught:
+            self.run_rounds(bench, base_policy(), fast_boundary=True)
+        self.assertIn("no proof-of-work cutpoint", str(caught.exception))
+        self.assertEqual([], calls)  # refused before a single measurement
+
+    def test_registered_schema_reports_both_boundaries(self):
+        bench, _ = self.fake_bench(
+            lambda round_no: 0.90 if round_no % 2 else 0.94,
+            pow_ms=40.0, request_scale=1.5,
+        )
+        with mock.patch.dict(
+            runner.POW_PHASE_SECONDS_FIELDS,
+            {"native_proof_v7": ("timing", "pow_seconds", "median")},
+            clear=False,
+        ):
+            score = self.run_rounds(
+                bench, base_policy(), fast_boundary=True, sequential_stop=None,
+            )
+        self.assertEqual(runner.FAST_BOUNDARY, score.boundary)
+        # Full boundary: request scales with prove, so the ratio is the raw one.
+        self.assertAlmostEqual(0.90, score.request_ratio, places=6)
+        # PoW-excluded: (0.9*150 - 40) / (150 - 40) = 95/110.
+        self.assertAlmostEqual(95.0 / 110.0, score.fast_request_ratio, places=6)
+        self.assertIn("fast_request_ms", score.candidate_resources)
+
+    def test_pow_extraction_reads_only_measured_seconds(self):
+        group = self.manifest(ladder=LADDER).group("native")
+        report = {"timing": {"pow_seconds": {"median": 0.25}}}
+        self.assertIsNone(runner._pow_ms(report, group))
+        with mock.patch.dict(
+            runner.POW_PHASE_SECONDS_FIELDS,
+            {"native_proof_v7": ("timing", "pow_seconds", "median")},
+            clear=False,
+        ):
+            self.assertAlmostEqual(250.0, runner._pow_ms(report, group))
+            with self.assertRaises(runner.RunError):
+                runner._pow_ms({"timing": {}}, group)
+
+    def test_shipped_registry_is_empty_so_the_flag_is_universally_refused(self):
+        # No product emits a PoW cutpoint yet; the harness must not pretend.
+        self.assertEqual({}, runner.POW_PHASE_SECONDS_FIELDS)
+
+
+class PhaseAttributionTest(LadderTestCase):
+    """T0 phase prefilter over whatever phases a schema provides (§3.2/§3.5)."""
+
+    def test_native_schema_phases(self):
+        group = self.manifest(ladder=LADDER).group("native")
+        phases = runner.report_phases({
+            "timing": {
+                "input_seconds": {"median": 0.1},
+                "prove_seconds": {"median": 1.0},
+                "proof_encode_seconds": {"median": 0.2},
+                "verify_seconds": {"median": 0.3},
+                "request_seconds": {"median": 1.6},
+            },
+        }, group)
+        self.assertEqual(
+            {"input", "prove", "serialize", "verify", "request"}, set(phases),
+        )
+        self.assertAlmostEqual(1.0, phases["prove"])
+
+    def test_stage_profiles_flatten_into_dotted_phase_names(self):
+        group = self.manifest(ladder=LADDER).group("native")
+        phases = runner.report_phases({
+            "timing": {
+                "stage_profiles": [{
+                    "schema_version": 1,
+                    "stages": [{
+                        "id": "commit", "label": "commit", "seconds": 2.0,
+                        "children": [
+                            {"id": "merkle", "label": "merkle", "seconds": 1.25},
+                        ],
+                    }],
+                }],
+            },
+        }, group)
+        self.assertAlmostEqual(2.0, phases["stage:commit"])
+        self.assertAlmostEqual(1.25, phases["stage:commit.merkle"])
+        self.assertEqual("stage:commit.merkle", runner.resolve_phase(phases, "merkle"))
+
+    def test_bare_stage_profile_document_is_accepted(self):
+        group = self.manifest(ladder=LADDER).group("native")
+        phases = runner.report_phases(
+            {"schema_version": 1, "runtime": "cpu", "example": "x",
+             "stages": [{"id": "fri", "label": "FRI", "seconds": 0.5}]},
+            group,
+        )
+        self.assertAlmostEqual(0.5, phases["stage:fri"])
+
+    def test_unknown_phase_names_fail_closed(self):
+        with self.assertRaises(runner.RunError) as caught:
+            runner.resolve_phase({"prove": 1.0}, "fri")
+        self.assertIn("not reported by this group", str(caught.exception))
+
+    def test_ambiguous_phase_names_fail_closed(self):
+        phases = {"stage:a.commit": 1.0, "stage:b.commit": 2.0}
+        with self.assertRaises(runner.RunError) as caught:
+            runner.resolve_phase(phases, "commit")
+        self.assertIn("ambiguous", str(caught.exception))
+
+    def _prefilter(self, prove_by_arm, phase="prove", proxy=PROXY_FIXTURE):
+        def phases(arm):
+            return {"timing": {
+                "input_seconds": {"median": 0.1},
+                "prove_seconds": {"median": prove_by_arm[arm]},
+                "proof_encode_seconds": {"median": 0.2},
+                "verify_seconds": {"median": 0.3},
+                "request_seconds": {"median": 1.6},
+            }}
+
+        bench, calls = self.fake_bench(lambda _round: 1.0, phases=phases)
+        manifest = self.manifest(ladder=LADDER, proxy=proxy)
+        with mock.patch.object(runner, "bench_once", bench), \
+                mock.patch.object(runner, "build_arm", lambda *a, **k: None):
+            result = runner.phase_prefilter(
+                self.root, self.root, manifest, "small", self.out_dir,
+                board="core_cpu", phase=phase, era=3,
+            )
+        return result, calls
+
+    def test_claimed_phase_that_moves_passes_and_names_the_proxy(self):
+        result, calls = self._prefilter({"a": 1.0, "b": 0.8})
+        self.assertTrue(result["pass"])
+        self.assertTrue(result["phase_moved"])
+        self.assertAlmostEqual(0.2, result["relative_move"])
+        self.assertEqual("small_proxy", result["workload"])
+        self.assertFalse(result["ranks"])
+        self.assertEqual(["t0a", "t0b"], calls)  # exactly one sample per arm
+        self.assertEqual(30, result["cost_target_seconds"])
+
+    def test_claimed_phase_that_does_not_move_fails_before_t1(self):
+        result, _ = self._prefilter({"a": 1.0, "b": 0.999})
+        self.assertFalse(result["pass"])
+        self.assertFalse(result["phase_moved"])
+
+    def test_unvalidated_proxy_is_marked_not_hidden(self):
+        result, _ = self._prefilter({"a": 1.0, "b": 0.8})
+        self.assertFalse(result["proxy_validity"]["validated"])
+        self.assertTrue(
+            any(marker.startswith("proxy unvalidated") for marker in result["markers"])
+        )
+
+    def test_class_without_a_proxy_says_so(self):
+        result, _ = self._prefilter({"a": 1.0, "b": 0.8}, proxy=None)
+        self.assertIsNone(result["proxy"])
+        self.assertEqual("wf_small", result["workload"])
+        self.assertTrue(
+            any("no proxy fixture declared" in marker for marker in result["markers"])
+        )
+
+
+class CairoPhaseAttributionTest(unittest.TestCase):
+    """T0 on the wave-1 Cairo track, over a real cairo_proof_v1 envelope."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.out_dir = self.root / "runs"
+        raw = cairo_raw_manifest()
+        raw["gates_policy"]["confirmation_ladder"] = LADDER
+        manifest_mod._validate(raw)
+        self.manifest = Manifest(root=self.root, raw=raw)
+        self.workload = self.manifest.workloads(board="cairo_cpu")[0]
+        binary = self.root / "bin" / "stwo-cairo-cpu"
+        binary.parent.mkdir(parents=True, exist_ok=True)
+        binary.write_text(
+            FAKE_PRODUCT
+            .replace("REPORT_JSON", repr(json.dumps(load_report())))
+            .replace("PROFILE_JSON", repr(json.dumps(load_profile())))
+            .replace("PROOF_PAYLOAD", repr(b"proof-bytes"))
+            .replace("MUTATE", "pass")
+        )
+        binary.chmod(binary.stat().st_mode | stat.S_IEXEC)
+
+    def envelope(self) -> dict:
+        result = runner.bench_once(
+            self.root, self.manifest, self.workload, 1, 1, self.out_dir, "a1",
+        )
+        # The Cairo arm returns early from bench_once; ladder telemetry must
+        # still ride along (None here: no schema registers a PoW cutpoint).
+        self.assertIsNone(result.pow_ms)
+        return json.loads(Path(result.report_path).read_text(encoding="utf-8"))
+
+    def test_named_cutpoints_are_readable_for_t0(self):
+        group = self.manifest.group("cairo_cpu")
+        phases = runner.report_phases(self.envelope(), group)
+        instrumented = set(manifest_mod.CAIRO_PHASE_NAMES) - {"serialize"}
+        self.assertEqual(instrumented, set(phases))
+        for name in set(runner.CAIRO_PHASE_STAGES) | {"verify"}:
+            self.assertGreater(phases[name], 0.0)
+        # A prove-only workload never runs the VM: execute is honestly zero,
+        # which is a measured value, not a missing one.
+        self.assertEqual(0.0, phases["execute"])
+
+    def test_a_claim_on_a_zero_baseline_phase_fails_closed(self):
+        with mock.patch.object(runner, "build_arm", lambda *a, **k: None):
+            with self.assertRaises(runner.RunError) as caught:
+                runner.phase_prefilter(
+                    self.root, self.root, self.manifest, "small", self.out_dir,
+                    board="cairo_cpu", phase="execute", era=3,
+                )
+        self.assertIn("not a positive duration", str(caught.exception))
+
+    def test_uninstrumented_serialize_claim_fails_closed(self):
+        group = self.manifest.group("cairo_cpu")
+        phases = runner.report_phases(self.envelope(), group)
+        with self.assertRaises(runner.RunError) as caught:
+            runner.resolve_phase(phases, "serialize")
+        self.assertIn("not reported by this group", str(caught.exception))
+
+    def test_registry_row_tracks_the_canonical_cutpoint_names(self):
+        self.assertEqual(
+            set(manifest_mod.CAIRO_PHASE_NAMES),
+            set(runner.PHASE_SECONDS_FIELDS["cairo_proof_v1"]),
+        )
+
+    def test_t0_prefilter_runs_end_to_end_on_cairo(self):
+        moved = json.loads(json.dumps(load_report()))
+        # A candidate whose FRI phase halved: every stage that composes the
+        # phase moves, and nothing else does.
+        fri_stages = set(runner.CAIRO_PHASE_STAGES["fri"][0])
+        profile = json.loads(json.dumps(load_profile()))
+        for node in profile["stages"]:
+            if node["id"] in fri_stages:
+                node["seconds"] = node["seconds"] / 2.0
+        candidate = self.root / "candidate"
+        (candidate / "bin").mkdir(parents=True)
+        binary = candidate / "bin" / "stwo-cairo-cpu"
+        binary.write_text(
+            FAKE_PRODUCT
+            .replace("REPORT_JSON", repr(json.dumps(moved)))
+            .replace("PROFILE_JSON", repr(json.dumps(profile)))
+            .replace("PROOF_PAYLOAD", repr(b"proof-bytes"))
+            .replace("MUTATE", "pass")
+        )
+        binary.chmod(binary.stat().st_mode | stat.S_IEXEC)
+        with mock.patch.object(runner, "build_arm", lambda *a, **k: None):
+            result = runner.phase_prefilter(
+                self.root, candidate, self.manifest, "small", self.out_dir,
+                board="cairo_cpu", phase="fri", era=3,
+            )
+        self.assertTrue(result["pass"], result)
+        self.assertEqual("fri", result["resolved_phase"])
+        self.assertGreater(result["relative_move"], 0.4)
+        self.assertTrue(result["correctness_smoke"]["pass"])
+        self.assertFalse(result["ranks"])
+
+    def test_t0_rejects_a_claim_on_a_phase_that_did_not_move(self):
+        with mock.patch.object(runner, "build_arm", lambda *a, **k: None):
+            result = runner.phase_prefilter(
+                self.root, self.root, self.manifest, "small", self.out_dir,
+                board="cairo_cpu", phase="fri", era=3,
+            )
+        self.assertFalse(result["pass"])
+        self.assertFalse(result["phase_moved"])
+
+
+class ProxyFixtureManifestTest(LadderTestCase):
+    """Per-class proxy fixtures: scaled shape, OFFICIAL params (§3.3)."""
+
+    def _validate(self, fixture):
+        manifest_mod._validate(make_raw(ladder=LADDER, proxy=fixture))
+
+    def test_valid_fixture_is_accepted(self):
+        self._validate(PROXY_FIXTURE)
+
+    def test_absent_fixture_is_legal(self):
+        manifest_mod._validate(make_raw(ladder=LADDER))
+
+    def test_weakened_parameters_are_refused(self):
+        fixture = dict(PROXY_FIXTURE, official_params=False)
+        with self.assertRaises(ManifestError) as caught:
+            self._validate(fixture)
+        self.assertIn("official_params must be true", str(caught.exception))
+
+    def test_security_parameters_may_not_be_restated(self):
+        for token in ("--pow-bits 8", "--n-queries 4", "--protocol functional"):
+            fixture = dict(PROXY_FIXTURE, args=PROXY_FIXTURE["args"] + " " + token)
+            with self.assertRaises(ManifestError) as caught:
+                self._validate(fixture)
+            self.assertIn("scales geometry only", str(caught.exception))
+
+    def test_unknown_keys_are_refused(self):
+        fixture = dict(PROXY_FIXTURE, sneaky=True)
+        with self.assertRaises(ManifestError):
+            self._validate(fixture)
+
+    def test_target_workloads_are_required(self):
+        fixture = dict(PROXY_FIXTURE, target_workload_ids=[])
+        with self.assertRaises(ManifestError):
+            self._validate(fixture)
+
+    def test_unknown_class_keys_are_refused(self):
+        raw = make_raw(ladder=LADDER)
+        raw["workload_registry"]["classes"]["small"]["surprise"] = 1
+        with self.assertRaises(ManifestError):
+            manifest_mod._validate(raw)
+
+    def test_manifest_exposes_the_fixture(self):
+        manifest = self.manifest(ladder=LADDER, proxy=PROXY_FIXTURE)
+        self.assertEqual(PROXY_FIXTURE, manifest.proxy_fixture("small"))
+        self.assertIsNone(self.manifest(ladder=LADDER).proxy_fixture("small"))
+
+
+class LadderRegistrationTest(LadderTestCase):
+    """The ladder block is all-or-nothing (§3.5 pre-registration)."""
+
+    def test_absent_block_is_valid(self):
+        manifest_mod._validate(make_raw())
+
+    def test_partial_block_is_refused(self):
+        ladder = json.loads(json.dumps(LADDER))
+        del ladder["proxy_validity"]
+        with self.assertRaises(ManifestError):
+            manifest_mod._validate(make_raw(ladder=ladder))
+
+    def test_unregistered_rule_is_refused(self):
+        ladder = json.loads(json.dumps(LADDER))
+        ladder["sequential_stop"]["rule"] = "sequential_probability_ratio_v1"
+        with self.assertRaises(ManifestError):
+            manifest_mod._validate(make_raw(ladder=ladder))
+
+    def test_alpha_bounds(self):
+        for alpha in (0.0, -0.1, 0.75):
+            ladder = json.loads(json.dumps(LADDER))
+            ladder["sequential_stop"]["alpha"] = alpha
+            with self.assertRaises(ManifestError):
+                manifest_mod._validate(make_raw(ladder=ladder))
+
+    def test_targets_must_increase_down_the_ladder(self):
+        ladder = json.loads(json.dumps(LADDER))
+        ladder["tiers"]["T1"]["cost_target_seconds"] = 10
+        with self.assertRaises(ManifestError) as caught:
+            manifest_mod._validate(make_raw(ladder=ladder))
+        self.assertIn("increase strictly", str(caught.exception))
+
+    def test_repository_manifest_registers_the_contract_targets(self):
+        live = manifest_mod.load(Path(__file__).resolve().parents[2])
+        self.assertEqual(30, live.tier_cost_target_seconds("T0"))
+        self.assertEqual(300, live.tier_cost_target_seconds("T1"))
+        self.assertEqual(2700, live.tier_cost_target_seconds("T2"))
+        self.assertIsNone(live.tier_cost_target_seconds("T3"))
+        ladder = live.confirmation_ladder
+        self.assertEqual(
+            manifest_mod.SEQUENTIAL_STOP_RULE, ladder["sequential_stop"]["rule"],
+        )
+        # Ranked runs keep their fixed design until an era boundary says otherwise.
+        self.assertFalse(ladder["sequential_stop"]["enabled"])
+
+
+def observation(proxy_ln: float, class_ln: float) -> dict:
+    return {
+        "proxy_ln_ratio": proxy_ln,
+        "class_ln_ratio": class_ln,
+        "proxy_evidence_sha256": "a" * 64,
+        "class_evidence_sha256": "b" * 64,
+    }
+
+
+def receipt(observations: list[dict], **overrides) -> dict:
+    correlation = manifest_mod.pearson_correlation(
+        [item["proxy_ln_ratio"] for item in observations],
+        [item["class_ln_ratio"] for item in observations],
+    )
+    document = {
+        "schema": manifest_mod.PROXY_VALIDITY_RECEIPT_SCHEMA,
+        "board": "core_cpu",
+        "era": 3,
+        "workload_class": "small",
+        "proxy": {
+            "proxy_id": PROXY_FIXTURE["proxy_id"],
+            "args": PROXY_FIXTURE["args"],
+            "native_unit": PROXY_FIXTURE["native_unit"],
+            "official_params": True,
+        },
+        "target": {"workload_ids": ["wf_small"]},
+        "measured_at_utc": "2026-07-29T12:00:00Z",
+        "host": {
+            "identity_sha256": "c" * 64,
+            "chip": "Apple M5",
+            "logical_cpu_count": 10,
+        },
+        "harness_commit": "0123456789ab",
+        "measurement": {
+            "method": manifest_mod.PROXY_VALIDITY_METHOD,
+            "observations": observations,
+            "observation_count": len(observations),
+            "correlation": correlation,
+            "min_correlation": 0.8,
+            "min_observations": 5,
+            "valid": correlation >= 0.8 and len(observations) >= 5,
+        },
+        "artifact_sha256": hashlib.sha256(
+            json.dumps(observations, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest(),
+    }
+    document.update(overrides)
+    return document
+
+
+CORRELATED = [
+    observation(-0.10, -0.09),
+    observation(-0.20, -0.19),
+    observation(-0.05, -0.04),
+    observation(-0.30, -0.32),
+    observation(-0.15, -0.14),
+]
+
+
+class ProxyValidityReceiptTest(LadderTestCase):
+    """Era receipts: measured, recomputable, never asserted (§3.6)."""
+
+    def test_valid_receipt_round_trips(self):
+        document = manifest_mod.validate_proxy_validity_receipt(
+            receipt(CORRELATED), board="core_cpu", workload_class="small", era=3,
+            policy=LADDER["proxy_validity"], proxy_fixture=PROXY_FIXTURE,
+        )
+        self.assertTrue(document["measurement"]["valid"])
+        self.assertGreater(document["measurement"]["correlation"], 0.8)
+
+    def test_asserted_correlation_must_match_its_own_evidence(self):
+        tampered = receipt(CORRELATED)
+        tampered["measurement"]["correlation"] = 0.999999
+        with self.assertRaises(ManifestError) as caught:
+            manifest_mod.validate_proxy_validity_receipt(tampered)
+        self.assertIn("not the Pearson correlation", str(caught.exception))
+
+    def test_validity_flag_must_match_the_thresholds(self):
+        lying = receipt(CORRELATED)
+        lying["measurement"]["valid"] = False
+        with self.assertRaises(ManifestError) as caught:
+            manifest_mod.validate_proxy_validity_receipt(lying)
+        self.assertIn("validity flag disagrees", str(caught.exception))
+
+    def test_receipt_may_not_weaken_the_registered_floor(self):
+        weak = receipt(CORRELATED)
+        weak["measurement"]["min_correlation"] = 0.5
+        weak["measurement"]["min_observations"] = 3
+        with self.assertRaises(ManifestError) as caught:
+            manifest_mod.validate_proxy_validity_receipt(
+                weak, policy=LADDER["proxy_validity"],
+            )
+        self.assertIn("weakens the registered", str(caught.exception))
+
+    def test_two_observations_are_not_evidence(self):
+        with self.assertRaises(ManifestError):
+            manifest_mod.validate_proxy_validity_receipt(receipt(CORRELATED[:2]))
+
+    def test_binding_to_another_board_or_era_is_refused(self):
+        document = receipt(CORRELATED)
+        with self.assertRaises(ManifestError):
+            manifest_mod.validate_proxy_validity_receipt(document, board="riscv")
+        with self.assertRaises(ManifestError):
+            manifest_mod.validate_proxy_validity_receipt(document, era=4)
+
+    def test_receipt_identity_must_match_the_manifest_fixture(self):
+        document = receipt(CORRELATED)
+        document["proxy"]["args"] = "--log-n-rows 24"
+        with self.assertRaises(ManifestError):
+            manifest_mod.validate_proxy_validity_receipt(
+                document, proxy_fixture=PROXY_FIXTURE,
+            )
+
+    def test_unknown_schema_is_refused(self):
+        with self.assertRaises(ManifestError):
+            manifest_mod.validate_proxy_validity_receipt(
+                receipt(CORRELATED, schema="stwo_perf_proxy_validity_receipt_v2"),
+            )
+
+    def test_missing_receipt_marks_the_proxy_unvalidated(self):
+        manifest = self.manifest(ladder=LADDER, proxy=PROXY_FIXTURE)
+        state = manifest.proxy_validity_state("core_cpu", "small", 3)
+        self.assertFalse(state["validated"])
+        self.assertIn("proxy unvalidated", state["reason"])
+
+    def test_committed_receipt_validates_the_proxy(self):
+        manifest = self.manifest(ladder=LADDER, proxy=PROXY_FIXTURE)
+        path = (
+            self.root / LADDER["proxy_validity"]["receipt_dir"]
+            / manifest_mod.proxy_receipt_filename("core_cpu", "small", 3)
+        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(receipt(CORRELATED)))
+        state = manifest.proxy_validity_state("core_cpu", "small", 3)
+        self.assertTrue(state["validated"], state["reason"])
+        self.assertGreater(state["correlation"], 0.8)
+
+    def test_decayed_receipt_asks_for_rotation(self):
+        manifest = self.manifest(ladder=LADDER, proxy=PROXY_FIXTURE)
+        decayed = [
+            observation(-0.10, 0.05),
+            observation(-0.20, -0.01),
+            observation(-0.05, 0.02),
+            observation(-0.30, 0.04),
+            observation(-0.15, -0.02),
+        ]
+        path = (
+            self.root / LADDER["proxy_validity"]["receipt_dir"]
+            / manifest_mod.proxy_receipt_filename("core_cpu", "small", 3)
+        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(receipt(decayed)))
+        state = manifest.proxy_validity_state("core_cpu", "small", 3)
+        self.assertFalse(state["validated"])
+        self.assertIn("rotate the proxy", state["reason"])
+
+
+class ProxyReceiptBuilderTest(LadderTestCase):
+    """The M5 receipt command reads measurements; it never makes them."""
+
+    def _write_pair(self, index: int, proxy_r: float, class_r: float,
+                    board: str = "core_cpu") -> tuple[Path, Path]:
+        proxy_path = self.root / f"proxy-{index}.json"
+        class_path = self.root / f"class-{index}.json"
+        proxy_path.write_text(json.dumps({
+            "schema": runner.LADDER_T1_SCHEMA,
+            "board": board,
+            "workload_class": "small",
+            "r_geomean": proxy_r,
+        }))
+        class_path.write_text(json.dumps({
+            "schema_version": 1,
+            "kind": "claimed",
+            "declared_objective": {
+                "board": board, "workload_class": "small", "dimension": "time",
+            },
+            "score": {"R_geomean": class_r},
+        }))
+        return proxy_path, class_path
+
+    def _observations(self, count: int = 5, board: str = "core_cpu"):
+        pairs = [(0.90, 0.91), (0.80, 0.82), (0.95, 0.96), (0.70, 0.68), (0.85, 0.86)]
+        return [
+            self._write_pair(index, *pairs[index % len(pairs)], board=board)
+            for index in range(count)
+        ]
+
+    def test_receipt_is_assembled_from_measured_documents(self):
+        manifest = self.manifest(ladder=LADDER, proxy=PROXY_FIXTURE)
+        # The repository root is the harness identity the receipt must bind.
+        document = runner.build_proxy_validity_receipt(
+            Path(__file__).resolve().parents[2], manifest, board="core_cpu",
+            workload_class="small", era=3, observations=self._observations(),
+            measured_at_utc="2026-07-29T12:00:00Z",
+        )
+        manifest_mod.validate_proxy_validity_receipt(
+            document, board="core_cpu", workload_class="small", era=3,
+            policy=LADDER["proxy_validity"], proxy_fixture=PROXY_FIXTURE,
+        )
+        measurement = document["measurement"]
+        self.assertEqual(5, measurement["observation_count"])
+        self.assertTrue(measurement["valid"])
+        self.assertAlmostEqual(
+            math.log(0.90), measurement["observations"][0]["proxy_ln_ratio"],
+        )
+        # Every observation binds the bytes it was read from.
+        self.assertNotEqual(
+            measurement["observations"][0]["proxy_evidence_sha256"],
+            measurement["observations"][0]["class_evidence_sha256"],
+        )
+
+    def test_too_few_observations_are_refused(self):
+        manifest = self.manifest(ladder=LADDER, proxy=PROXY_FIXTURE)
+        with self.assertRaises(runner.RunError) as caught:
+            runner.build_proxy_validity_receipt(
+                self.root, manifest, board="core_cpu", workload_class="small",
+                era=3, observations=self._observations(3),
+            )
+        self.assertIn("registered minimum is 5", str(caught.exception))
+
+    def test_documents_from_another_board_are_refused(self):
+        manifest = self.manifest(ladder=LADDER, proxy=PROXY_FIXTURE)
+        with self.assertRaises(runner.RunError) as caught:
+            runner.build_proxy_validity_receipt(
+                self.root, manifest, board="core_cpu", workload_class="small",
+                era=3, observations=self._observations(board="riscv"),
+            )
+        self.assertIn("expected core_cpu/small", str(caught.exception))
+
+    def test_class_without_a_proxy_cannot_be_certified(self):
+        manifest = self.manifest(ladder=LADDER)
+        with self.assertRaises(runner.RunError) as caught:
+            runner.build_proxy_validity_receipt(
+                self.root, manifest, board="core_cpu", workload_class="small",
+                era=3, observations=self._observations(),
+            )
+        self.assertIn("nothing to certify", str(caught.exception))
+
+
+class IterateEstimateTest(LadderTestCase):
+    """T1 emits an estimate, never a verdict (§3.5b local-vs-ranked)."""
+
+    def _estimate(self, **kwargs):
+        bench, _ = self.fake_bench(lambda round_no: 0.50 if round_no % 2 else 0.62)
+        manifest = self.manifest(ladder=LADDER, proxy=PROXY_FIXTURE)
+        with mock.patch.object(runner, "bench_once", bench), \
+                mock.patch.object(runner, "build_arm", lambda *a, **k: None), \
+                mock.patch.object(runner.ledger, "aa_dispersion", lambda *a: None):
+            return runner.iterate_estimate(
+                self.root, self.root, manifest, "small", self.out_dir,
+                board="core_cpu", era=3, **kwargs,
+            )
+
+    def test_estimate_document_never_ranks(self):
+        result = self._estimate()
+        self.assertEqual(runner.LADDER_T1_SCHEMA, result["schema"])
+        self.assertFalse(result["ranks"])
+        self.assertNotIn("gates", result)
+        self.assertEqual(runner.FULL_BOUNDARY, result["boundary"])
+        self.assertEqual(300, result["cost_target_seconds"])
+
+    def test_sequential_stop_is_armed_at_t1(self):
+        result = self._estimate()
+        entry = result["per_workload"]["small_proxy"]
+        self.assertEqual(3, entry["rounds"])
+        self.assertEqual("decisive_clear", entry["sequential_stop"]["decision"])
+
+    def test_fast_boundary_without_pow_telemetry_fails_closed(self):
+        with self.assertRaises(runner.RunError):
+            self._estimate(fast_boundary=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/autoresearch/tests/test_tier_cost_targets.py
+++ b/autoresearch/tests/test_tier_cost_targets.py
@@ -1,0 +1,237 @@
+"""Tier cost targets are CI-checked per track (TRACKS §3.6).
+
+This module is also the CI wiring for scripts/check_tier_cost_targets.py: the
+autoresearch-validate workflow runs `python3 -m unittest discover -s
+autoresearch/tests`, so `test_repository_is_within_its_tier_cost_targets`
+enforces the targets on every PR without an extra workflow step.
+"""
+
+import contextlib
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.check_tier_cost_targets import (  # noqa: E402
+    T0_SCHEMA,
+    T1_SCHEMA,
+    TierCostError,
+    collect_observations,
+    evaluate,
+    load_policy,
+    main,
+)
+
+
+def ladder_manifest() -> dict:
+    return {
+        "gates_policy": {
+            "confirmation_ladder": {
+                "tiers": {
+                    "T0": {"cost_target_seconds": 30},
+                    "T1": {"cost_target_seconds": 300},
+                    "T2": {"cost_target_seconds": 2700},
+                    "T3": {"cost_target_seconds": None},
+                },
+                "cost_telemetry": {"statistic": "median", "window": 5},
+            },
+        },
+        "workload_registry": {
+            "groups": {
+                "native": {"board": "core_cpu"},
+                "cairo": {"board": "cairo_cpu"},
+            },
+        },
+    }
+
+
+class TierCostTargetTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        (self.root / "autoresearch").mkdir()
+        self.write_manifest(ladder_manifest())
+        self.telemetry = self.root / "autoresearch" / "submissions"
+        self.telemetry.mkdir()
+
+    def write_manifest(self, document: dict) -> None:
+        (self.root / "autoresearch" / "MANIFEST.json").write_text(
+            json.dumps(document), encoding="utf-8",
+        )
+
+    def write_ladder_doc(self, name: str, schema: str, board: str,
+                         seconds: float) -> None:
+        (self.telemetry / name).write_text(json.dumps({
+            "schema": schema,
+            "tier": "T1" if schema == T1_SCHEMA else "T0",
+            "board": board,
+            "workload_class": "small",
+            "measurement_seconds": seconds,
+        }), encoding="utf-8")
+
+    def write_verdict(self, name: str, board: str, seconds: float,
+                      kind: str = "claimed") -> None:
+        (self.telemetry / name).write_text(json.dumps({
+            "schema_version": 1,
+            "kind": kind,
+            "declared_objective": {
+                "board": board, "workload_class": "small", "dimension": "time",
+            },
+            "score": {"portfolio": {"measurement_seconds": seconds}},
+        }), encoding="utf-8")
+
+    def run_main(self, *argv) -> tuple[int, str]:
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer), contextlib.redirect_stderr(buffer):
+            code = main(["--repo-root", str(self.root), *argv])
+        return code, buffer.getvalue()
+
+    def test_absent_telemetry_passes_with_a_loud_note(self):
+        code, output = self.run_main()
+        self.assertEqual(0, code)
+        self.assertIn("core_cpu T1 has no recorded telemetry yet", output)
+        self.assertIn("cairo_cpu T2 has no recorded telemetry yet", output)
+        self.assertIn("passing an unmeasured track", output)
+
+    def test_tier_within_its_target_passes(self):
+        for index in range(3):
+            self.write_ladder_doc(f"t1-{index}.json", T1_SCHEMA, "core_cpu", 120.0)
+        code, output = self.run_main()
+        self.assertEqual(0, code)
+        self.assertIn("ok core_cpu T1", output)
+
+    def test_tier_over_its_target_fails_closed(self):
+        for index in range(3):
+            self.write_ladder_doc(f"t1-{index}.json", T1_SCHEMA, "core_cpu", 600.0)
+        code, output = self.run_main()
+        self.assertEqual(1, code)
+        self.assertIn("core_cpu T1 exceeds its 300s target", output)
+        self.assertIn("shrink the proxy, not the honesty", output)
+
+    def test_one_slow_outlier_does_not_condemn_a_track(self):
+        for index in range(4):
+            self.write_ladder_doc(f"t1-{index}.json", T1_SCHEMA, "core_cpu", 100.0)
+        self.write_ladder_doc("t1-9.json", T1_SCHEMA, "core_cpu", 5000.0)
+        code, output = self.run_main()
+        self.assertEqual(0, code)
+        self.assertIn("worst=5000.0s", output)
+
+    def test_t0_and_t2_tiers_are_checked_independently(self):
+        for index in range(3):
+            self.write_ladder_doc(f"t0-{index}.json", T0_SCHEMA, "cairo_cpu", 90.0)
+            self.write_verdict(f"v-{index}.json", "cairo_cpu", 100.0)
+        code, output = self.run_main()
+        self.assertEqual(1, code)
+        self.assertIn("cairo_cpu T0 exceeds its 30s target", output)
+        self.assertIn("ok cairo_cpu T2", output)
+
+    def test_judged_tier_has_no_cost_target(self):
+        for index in range(3):
+            self.write_verdict(f"j-{index}.json", "core_cpu", 99999.0, kind="judged")
+        code, output = self.run_main()
+        self.assertEqual(0, code)
+        self.assertNotIn("T3", output)
+
+    def test_tracks_are_enumerated_from_the_manifest_groups(self):
+        policy = load_policy(self.root)
+        self.assertEqual(["cairo_cpu", "core_cpu"], policy["tracks"])
+
+    def test_unregistered_ladder_fails_closed(self):
+        self.write_manifest({"gates_policy": {}, "workload_registry": {"groups": {}}})
+        code, output = self.run_main()
+        self.assertEqual(1, code)
+        self.assertIn("not registered", output)
+
+    def test_extra_telemetry_directories_are_scanned(self):
+        extra = self.root / "elsewhere"
+        extra.mkdir()
+        (extra / "t1.json").write_text(json.dumps({
+            "schema": T1_SCHEMA,
+            "board": "core_cpu",
+            "measurement_seconds": 400.0,
+        }), encoding="utf-8")
+        code, _ = self.run_main()
+        self.assertEqual(0, code)
+        code, output = self.run_main("--telemetry-dir", str(extra))
+        self.assertEqual(1, code)
+        self.assertIn("core_cpu T1 exceeds", output)
+
+    def test_unrelated_json_is_ignored(self):
+        (self.telemetry / "note.json").write_text(
+            json.dumps({"hello": "world"}), encoding="utf-8",
+        )
+        (self.telemetry / "broken.json").write_text("{not json", encoding="utf-8")
+        self.assertEqual({}, collect_observations(self.root))
+
+    def test_report_is_written_when_requested(self):
+        self.write_ladder_doc("t1.json", T1_SCHEMA, "core_cpu", 42.0)
+        report_path = self.root / "report" / "tier-costs.json"
+        code, _ = self.run_main("--report", str(report_path))
+        self.assertEqual(0, code)
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+        self.assertEqual("stwo_perf_tier_cost_report_v1", report["schema"])
+        rows = {(row["track"], row["tier"]): row for row in report["rows"]}
+        self.assertAlmostEqual(42.0, rows[("core_cpu", "T1")]["statistic"])
+        self.assertEqual([], report["violations"])
+
+    def test_max_statistic_is_supported(self):
+        document = ladder_manifest()
+        ladder = document["gates_policy"]["confirmation_ladder"]
+        ladder["cost_telemetry"]["statistic"] = "max"
+        self.write_manifest(document)
+        for index in range(4):
+            self.write_ladder_doc(f"t1-{index}.json", T1_SCHEMA, "core_cpu", 10.0)
+        self.write_ladder_doc("t1-9.json", T1_SCHEMA, "core_cpu", 600.0)
+        code, output = self.run_main()
+        self.assertEqual(1, code)
+        self.assertIn("core_cpu T1 exceeds", output)
+
+    def test_malformed_cost_telemetry_is_refused(self):
+        document = ladder_manifest()
+        document["gates_policy"]["confirmation_ladder"]["cost_telemetry"] = {
+            "statistic": "mean", "window": 5,
+        }
+        self.write_manifest(document)
+        with self.assertRaises(TierCostError):
+            load_policy(self.root)
+
+    def test_window_bounds_the_recency_slice(self):
+        policy = load_policy(self.root)
+        observations = {("core_cpu", "T1"): [
+            (f"run-{index}", float(index)) for index in range(20)
+        ]}
+        report = evaluate(policy, observations)
+        row = next(
+            row for row in report["rows"]
+            if (row["track"], row["tier"]) == ("core_cpu", "T1")
+        )
+        self.assertEqual(5, row["observations"])
+        self.assertAlmostEqual(17.0, row["statistic"])
+
+
+class RepositoryTierCostTest(unittest.TestCase):
+    """The check itself, over the real repository (§3.6 acceptance)."""
+
+    def test_repository_is_within_its_tier_cost_targets(self):
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer), contextlib.redirect_stderr(buffer):
+            code = main(["--repo-root", str(REPO_ROOT), "--quiet-absent"])
+        self.assertEqual(0, code, buffer.getvalue())
+
+    def test_recorded_verdict_telemetry_is_actually_found(self):
+        observations = collect_observations(REPO_ROOT)
+        t2_tracks = {
+            track for (track, tier) in observations if tier == "T2"
+        }
+        self.assertIn("core_cpu", t2_tracks)
+        self.assertIn("riscv", t2_tracks)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/check_tier_cost_targets.py
+++ b/scripts/check_tier_cost_targets.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Confirmation-ladder tier cost targets, checked per track (TRACKS §3.6).
+
+Every tier of the ladder has a pre-registered cost target in
+``autoresearch/MANIFEST.json`` (``gates_policy.confirmation_ladder.tiers``).
+This check reads the telemetry that real runs already record — verdict
+``score.portfolio.measurement_seconds`` for the claimed (T2) and judged (T3)
+tiers, and the ``measurement_seconds`` of T0/T1 ladder documents — and fails
+when a track's tier is over its target. The remedy is always the same one:
+*a track whose T1 exceeds five minutes must shrink its proxy, not its honesty.*
+
+Fail-closed applies to honesty, not to absent tracks: a track with no recorded
+telemetry for a tier passes with a loud note, because refusing to rank an
+unmeasured track would only encourage nobody to measure it.
+
+Wiring: the autoresearch-validate workflow runs
+``python3 -m unittest discover -s autoresearch/tests``, and
+``autoresearch/tests/test_tier_cost_targets.py`` invokes this check over the
+repository, so the target is enforced on every PR without a new workflow step.
+Run it directly with::
+
+    python3 scripts/check_tier_cost_targets.py
+    python3 scripts/check_tier_cost_targets.py --report /tmp/tier-costs.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+T0_SCHEMA = "stwo_perf_ladder_t0_prefilter_v1"
+T1_SCHEMA = "stwo_perf_ladder_t1_estimate_v1"
+LADDER_SCHEMAS = {T0_SCHEMA: "T0", T1_SCHEMA: "T1"}
+#: Default telemetry roots, relative to the repository root.
+TELEMETRY_ROOTS = ("autoresearch/submissions", "autoresearch/.runs")
+#: A measurement document larger than this is not one of ours.
+MAX_DOCUMENT_BYTES = 32 * 1024 * 1024
+
+
+class TierCostError(RuntimeError):
+    pass
+
+
+def load_policy(repo_root: Path) -> dict:
+    """Tier targets, telemetry statistic, and the track list from the manifest."""
+    try:
+        raw = json.loads(
+            (repo_root / "autoresearch" / "MANIFEST.json").read_text(encoding="utf-8")
+        )
+    except (OSError, json.JSONDecodeError) as exc:
+        raise TierCostError(f"cannot read MANIFEST.json: {exc}") from exc
+    ladder = raw.get("gates_policy", {}).get("confirmation_ladder")
+    if not isinstance(ladder, dict):
+        raise TierCostError(
+            "gates_policy.confirmation_ladder is not registered; tier cost "
+            "targets cannot be checked against an unregistered ladder"
+        )
+    tiers = ladder.get("tiers")
+    telemetry = ladder.get("cost_telemetry")
+    if not isinstance(tiers, dict) or not isinstance(telemetry, dict):
+        raise TierCostError("confirmation_ladder is missing tiers or cost_telemetry")
+    targets = {
+        tier: spec.get("cost_target_seconds")
+        for tier, spec in tiers.items()
+        if isinstance(spec, dict)
+    }
+    groups = raw.get("workload_registry", {}).get("groups", {})
+    tracks = sorted(
+        spec["board"] for spec in groups.values()
+        if isinstance(spec, dict) and isinstance(spec.get("board"), str)
+    )
+    statistic = telemetry.get("statistic")
+    window = telemetry.get("window")
+    if statistic not in ("median", "max") or type(window) is not int or window < 1:
+        raise TierCostError("confirmation_ladder.cost_telemetry is malformed")
+    return {
+        "targets": targets,
+        "tracks": tracks,
+        "statistic": statistic,
+        "window": window,
+    }
+
+
+def _document_observation(document: object) -> tuple[str, str, float] | None:
+    """Map one JSON document to ``(track, tier, seconds)`` when it is telemetry."""
+    if not isinstance(document, dict):
+        return None
+    schema = document.get("schema")
+    if schema in LADDER_SCHEMAS:
+        board = document.get("board")
+        seconds = document.get("measurement_seconds")
+        tier = LADDER_SCHEMAS[schema]
+    elif document.get("schema_version") == 1 and isinstance(document.get("score"), dict):
+        objective = document.get("declared_objective")
+        portfolio = document["score"].get("portfolio")
+        if not isinstance(objective, dict) or not isinstance(portfolio, dict):
+            return None
+        board = objective.get("board")
+        seconds = portfolio.get("measurement_seconds")
+        kind = document.get("kind")
+        if kind == "judged":
+            tier = "T3"
+        elif kind == "claimed":
+            tier = "T2"
+        else:
+            return None
+    else:
+        return None
+    if not isinstance(board, str) or not board:
+        return None
+    if isinstance(seconds, bool) or not isinstance(seconds, (int, float)):
+        return None
+    if float(seconds) <= 0.0:
+        return None
+    return board, tier, float(seconds)
+
+
+def collect_observations(
+    repo_root: Path, extra_dirs: list[Path] | None = None,
+) -> dict[tuple[str, str], list[tuple[str, float]]]:
+    """Gather ``(track, tier) -> [(source, seconds)]`` from recorded telemetry.
+
+    Sources are visited in sorted path order; submission directories are
+    date-prefixed, so "the last ``window`` entries" is a deterministic,
+    reproducible recency window rather than a filesystem-timestamp race.
+    """
+    roots = [repo_root / relative for relative in TELEMETRY_ROOTS]
+    roots.extend(extra_dirs or [])
+    observations: dict[tuple[str, str], list[tuple[str, float]]] = {}
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob("*.json")):
+            try:
+                if path.stat().st_size > MAX_DOCUMENT_BYTES:
+                    continue
+                document = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+                continue
+            found = _document_observation(document)
+            if found is None:
+                continue
+            board, tier, seconds = found
+            try:
+                source = str(path.relative_to(repo_root))
+            except ValueError:
+                source = str(path)
+            observations.setdefault((board, tier), []).append((source, seconds))
+    return observations
+
+
+def evaluate(
+    policy: dict,
+    observations: dict[tuple[str, str], list[tuple[str, float]]],
+) -> dict:
+    """Assess every (track, tier) with a registered target against telemetry."""
+    statistic_fn = (
+        statistics.median if policy["statistic"] == "median" else max
+    )
+    rows: list[dict] = []
+    tracks = sorted(set(policy["tracks"]) | {board for board, _ in observations})
+    for track in tracks:
+        for tier, target in policy["targets"].items():
+            if target is None:
+                continue  # judge-scheduled: no cost target by contract
+            recorded = observations.get((track, tier), [])
+            window = recorded[-policy["window"]:]
+            if not window:
+                rows.append({
+                    "track": track,
+                    "tier": tier,
+                    "target_seconds": target,
+                    "observations": 0,
+                    "statistic": None,
+                    "worst_seconds": None,
+                    "pass": True,
+                    "absent": True,
+                    "sources": [],
+                })
+                continue
+            values = [seconds for _source, seconds in window]
+            summary = float(statistic_fn(values))
+            rows.append({
+                "track": track,
+                "tier": tier,
+                "target_seconds": target,
+                "observations": len(window),
+                "statistic": summary,
+                "worst_seconds": max(values),
+                "pass": summary <= float(target),
+                "absent": False,
+                "sources": [source for source, _seconds in window],
+            })
+    return {
+        "schema": "stwo_perf_tier_cost_report_v1",
+        "statistic": policy["statistic"],
+        "window": policy["window"],
+        "rows": rows,
+        "violations": [row for row in rows if not row["pass"]],
+        "absent": [row for row in rows if row["absent"]],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=ROOT)
+    parser.add_argument(
+        "--telemetry-dir", type=Path, action="append", default=[],
+        help="extra directory of recorded run telemetry (repeatable)",
+    )
+    parser.add_argument("--report", type=Path, help="write the JSON assessment here")
+    parser.add_argument(
+        "--quiet-absent", action="store_true",
+        help="suppress the per-track absent-telemetry notes",
+    )
+    args = parser.parse_args(argv)
+    repo_root = args.repo_root.resolve()
+    try:
+        policy = load_policy(repo_root)
+    except TierCostError as exc:
+        print(f"tier cost targets: {exc}", file=sys.stderr)
+        return 1
+    report = evaluate(
+        policy, collect_observations(repo_root, args.telemetry_dir),
+    )
+    if args.report:
+        args.report.parent.mkdir(parents=True, exist_ok=True)
+        args.report.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+
+    for row in report["rows"]:
+        if row["absent"]:
+            if not args.quiet_absent:
+                print(
+                    f"tier cost targets: NOTE {row['track']} {row['tier']} has no "
+                    f"recorded telemetry yet (target {row['target_seconds']}s) — "
+                    "passing an unmeasured track, not excusing a slow one"
+                )
+            continue
+        state = "ok" if row["pass"] else "OVER"
+        print(
+            f"tier cost targets: {state} {row['track']} {row['tier']} "
+            f"{policy['statistic']}={row['statistic']:.1f}s worst="
+            f"{row['worst_seconds']:.1f}s target={row['target_seconds']}s "
+            f"(n={row['observations']})"
+        )
+    if report["violations"]:
+        for row in report["violations"]:
+            print(
+                f"tier cost targets: {row['track']} {row['tier']} exceeds its "
+                f"{row['target_seconds']}s target "
+                f"({policy['statistic']} {row['statistic']:.1f}s over "
+                f"{row['observations']} run(s)) — shrink the proxy, not the honesty",
+                file=sys.stderr,
+            )
+        print(
+            f"tier cost targets: {len(report['violations'])} violation(s)",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        "tier cost targets: every measured track/tier is within its "
+        "pre-registered cost target"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Wave-1 harness implementation of the **confirmation ladder** (TRACKS §3.5, §3.6, §8): sequential early stopping, the PoW-excluded fast boundary, per-class proxy fixtures with era validity receipts, the T0 phase-attribution prefilter, and CI-checked tier cost targets.

The ladder is the judge-capacity multiplier: exploration cost lives on contributor hosts at T0–T2; the M5 confirms, never explores.

| tier | target | what runs | emits | ranks? |
|---|---|---|---|---|
| T0 | < 30 s | correctness smoke + one stage-profiled sample on the proxy | `stwo_perf_ladder_t0_prefilter_v1` | never |
| T1 | < 300 s | paired ABBA on proxies, sequential stop, PoW-excluded boundary | `stwo_perf_ladder_t1_estimate_v1` | never |
| T2 | < 2700 s | full dual-boundary paired run | `verdict.json` (claimed) | claimed |
| T3 | judge-scheduled | judged re-run + audits | signed `verdict.json` | the scored row |

## The registered spending rule

`pocock_constant_boundary_bonferroni_v1` — the family-wise `alpha` is spent evenly across the `K = max_rounds − min_rounds + 1` planned looks, so look `k` decides on a bootstrap CI at level `1 − alpha/K`. A run stops on a **decisive clear** (adjusted upper `< 1 − theta`) or a **decisive miss** (adjusted lower `> 1 − theta`).

Why it is honest: `alpha/K < alpha`, so the boundary is strictly stricter than the fixed-sample gate — an early stop can never admit a run the full-power design would have rejected. Parameters come from `gates_policy`, never from the run; the stop records its own design (rule, alpha, planned looks, look index, adjusted level, adjusted CI, bar, decision).

`sequential_stop.enabled` ships **false**: ranked runs keep their fixed design until an era boundary changes it. T1 arms the rule explicitly because T1 never ranks. **With no ladder block the runner behaves exactly as before** — a tested back-compat property.

## Fail-closed surfaces

- `runner.POW_PHASE_SECONDS_FIELDS` is **empty**: no shipped product emits a PoW cutpoint, so `--fast-boundary` refuses on every group today. The harness never subtracts an unmeasured cost. Product handoff: emit the PoW phase (§3.2) and register the field path.
- `runner.evaluate(..., fast_boundary=True)` always raises; `stwo-perf run --fast-boundary` is refused with a pointer to `ladder t1`.
- Proxy `official_params` must be `true`, and proxy args may not restate `--pow-bits`, `--n-queries`, `--protocol`, `--security`, `--functional`.
- Receipt validation **recomputes** the Pearson correlation from the receipt's own sha256-bound observations; a receipt cannot assert a number its evidence does not support, cannot weaken the registered floors, and cannot disagree with its own validity flag.
- A group whose reports carry no phase evidence fails T0 closed instead of passing every claim; so does a claim on Cairo's always-null `serialize`, or on any phase whose predecessor duration is zero.
- No receipt = `proxy unvalidated` marker on T0/T1 output. Never a fabricated value.

## Tier cost targets in CI (§3.6)

`scripts/check_tier_cost_targets.py` reads telemetry that runs already record (`score.portfolio.measurement_seconds` for T2/T3, `measurement_seconds` for T0/T1 docs), aggregates the last `window` observations per `(track, tier)` with the registered statistic, and fails when a track is over target — *shrink the proxy, not the honesty*. Tracks are enumerated from `workload_registry.groups[*].board`, so new tracks are covered the moment their group lands. A `(track, tier)` with no telemetry passes with a loud note.

Current repository state (real telemetry, all within target):

```
ok core_cpu   T2 median=11.9s  worst=15.5s  target=2700s (n=5)
ok core_metal T2 median=2.9s   worst=3.6s   target=2700s (n=5)
ok riscv      T2 median=137.8s worst=210.3s target=2700s (n=5)
```

Wiring: `autoresearch/tests/test_tier_cost_targets.py` invokes the check over the repository, and `autoresearch-validate` already runs the harness test suite — enforced on every PR with no new workflow step.

## New CLI

```
stwo-perf ladder t0 --board B --class C --phase fri --predecessor W
stwo-perf ladder t1 --board B --class C --predecessor W [--fast-boundary]
stwo-perf ladder proxy-receipt --board B --class C --era N --observation P.json:C.json ...
stwo-perf run --fast-boundary        # refused by design
```

## M5 handoff

Receipt generation runs on the judge host and **measures nothing itself** — it reads measurement documents that already exist. Exact commands are in `autoresearch/schema/confirmation-ladder.md` §5. No receipt values are fabricated anywhere in this PR.

## Scope

`runner.py` (sequential stop, fast boundary, T0/T1, receipt builder), `manifest.py` (ladder + proxy + receipt validation), `__main__.py` (new flags/subcommand only, no routing changes), `MANIFEST.json` (`gates_policy.confirmation_ladder` only — no `workload_registry.groups` edits), `scripts/check_tier_cost_targets.py`, two new test modules, one schema doc. `conformance/performance-authority/**` untouched.

## Tests

`python3 -m unittest discover -s autoresearch/tests` → **506 tests OK** (373 baseline + W1's 55 + these 78), every pre-existing test unchanged.

## Rebased onto W1's cairo tracks (#145)

One conflict, in `runner.py`: both branches inserted a new function block immediately above `paired_rounds` (W1's cairo parser helpers, my ladder helpers). Resolved by keeping both — the regions are logically disjoint. `MANIFEST.json` and `manifest.py` auto-merged; the MANIFEST diff against main is `gates_policy.confirmation_ladder` only, with no `workload_registry` edits.

Closing the cairo gap while in there:

- **`cairo_proof_v1` phase row registered**, *derived* from `manifest.CAIRO_PHASE_NAMES` rather than restated, so the ladder cannot drift from the schema's canonical cutpoint set. T0 phase prefiltering now works on `cairo_cpu`/`cairo_metal`.
- **`tiers.T0.warmups` 0 → 1.** The Cairo arm records its mandatory phase profile on a discarded warmup, so a zero-warmup T0 would have left the wave-1 headline track with no phase evidence at all — it would have failed closed on every claim.
- **Ladder telemetry rides the cairo path too.** `_bench_cairo` returns early from `bench_once`, so the PoW hook is attached on that branch as well (a no-op today, and it only reads the envelope when a PoW cutpoint is actually registered).
- **6 new cairo tests**, running the real `_bench_cairo` → envelope → `report_phases` → `phase_prefilter` path against W1's committed fixtures (no mocked bench): cutpoint readability, a halved-FRI candidate passing T0 end to end, an unmoved phase failing, and the two fail-closed cases above.
- The tier-cost check picks up `cairo_cpu`/`cairo_metal` automatically (tracks are enumerated from the manifest's group boards) and reports them as unmeasured-but-passing.

### One finding worth a decision, deliberately not acted on

Cairo's stage profile **already records a `proof_of_work` stage with real seconds** (folded into the `fri` phase by W1's mapping). The PoW-excluded fast boundary is therefore one registry entry away on cairo — except that the profile is recorded on a **discarded warmup** while the scored request time comes from the uninstrumented samples, so registering it would subtract a duration measured on a *different invocation* than the one being timed. That is a decision about measurement scope, not a wiring detail, so `POW_PHASE_SECONDS_FIELDS` stays empty and the caveat is documented in the schema doc. Either publish per-sample PoW seconds in the `cairo_proof_v1` envelope, or accept the cross-invocation subtraction explicitly for T1 (which never ranks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
