### PR TITLE
harness: T1 fast boundary on cairo via a labelled cross-invocation PoW estimate (TRACKS §3.5)

### DIFF
--- a/autoresearch/cli/stwo_perf/__main__.py
+++ b/autoresearch/cli/stwo_perf/__main__.py
@@ -265,6 +265,9 @@ def cmd_ladder(args) -> int:
             ("theta", f"{result['theta']:.6f}"),
             ("seconds", f"{result['measurement_seconds']:.2f}"),
         ]))
+        evidence = result.get("boundary_evidence")
+        if evidence and evidence.get("estimate"):
+            print(ansi.style(f"  ⚠ {evidence['label']}", "yellow"))
     print(ansi.style(f"  {result['note']}", "dim"))
     print(ansi.style(f"  written to {out}", "dim"))
     if not result.get("within_cost_target", True):

--- a/autoresearch/cli/stwo_perf/runner.py
+++ b/autoresearch/cli/stwo_perf/runner.py
@@ -67,16 +67,78 @@ class RunError(RuntimeError):
 LADDER_T0_SCHEMA = "stwo_perf_ladder_t0_prefilter_v1"
 LADDER_T1_SCHEMA = "stwo_perf_ladder_t1_estimate_v1"
 #: Boundary label recorded on every WorkloadScore. The default is today's
-#: paired quantity; the ladder's fast boundary is the opt-in alternative.
+#: paired quantity; the ladder's fast boundary is the opt-in alternative. The
+#: estimated label is a DIFFERENT string on purpose: a cross-invocation
+#: subtraction must never be readable as a same-invocation measurement.
 FULL_BOUNDARY = "prove_ms"
 FAST_BOUNDARY = "verified_request_minus_pow_ms"
+FAST_BOUNDARY_ESTIMATED = "verified_request_minus_pow_ms_cross_invocation_estimate"
+#: The only tier allowed to pair on a cross-invocation PoW estimate.
+CROSS_INVOCATION_POW_TIER = "T1"
 
-#: report_schema -> path (in the group's report) to the proof-of-work phase in
-#: SECONDS. Deliberately empty: no shipped product emits a PoW cutpoint yet,
-#: even though §3.2 names it as a phase. ``--fast-boundary`` therefore fails
-#: closed on every schema until its product reports the number — the harness
+
+@dataclass(frozen=True)
+class PowBoundarySource:
+    """Where a report schema's MEASURED proof-of-work seconds come from.
+
+    ``invocation`` is the honesty-critical field. ``scored_sample`` means the
+    PoW time was measured on the very invocation being timed, so subtracting it
+    yields a measurement. ``discarded_warmup`` means it was measured on another
+    invocation of the same arm in the same round, so subtracting it yields an
+    ESTIMATE — admissible only on a tier that never ranks (TRACKS §3.5).
+    """
+
+    kind: str
+    invocation: str
+    note: str
+    field_path: tuple[str, ...] = ()
+    stage_ids: tuple[str, ...] = ()
+
+    @property
+    def cross_invocation(self) -> bool:
+        return self.invocation != "scored_sample"
+
+    @property
+    def boundary_label(self) -> str:
+        return FAST_BOUNDARY_ESTIMATED if self.cross_invocation else FAST_BOUNDARY
+
+    def describe(self, report_schema: str) -> dict:
+        return {
+            "report_schema": report_schema,
+            "kind": self.kind,
+            "invocation": self.invocation,
+            "stage_ids": list(self.stage_ids),
+            "field_path": list(self.field_path),
+            "cross_invocation": self.cross_invocation,
+            "estimate": self.cross_invocation,
+            "note": self.note,
+        }
+
+
+#: report_schema -> where its measured proof-of-work seconds live. A schema
+#: absent from this registry cannot use ``--fast-boundary`` at all: the harness
 #: subtracts only measured PoW time, never a modeled or assumed one.
-POW_PHASE_SECONDS_FIELDS: dict[str, tuple[str, ...]] = {}
+POW_PHASE_SECONDS_FIELDS: dict[str, PowBoundarySource] = {
+    # Cairo records `proof_of_work` in its stage profile, which the runner
+    # writes as a sidecar next to the bench envelope. That profile comes from
+    # the discarded warmup (scored samples run uninstrumented), so this is a
+    # cross-invocation ESTIMATE and is restricted to T1 accordingly.
+    "cairo_proof_v1": PowBoundarySource(
+        kind="stage_profile_sidecar",
+        invocation="discarded_warmup",
+        stage_ids=("proof_of_work",),
+        note=(
+            "Cairo scored samples run uninstrumented, so the PoW seconds come "
+            "from the same arm's discarded warmup in the same round. pow 26 is "
+            "~constant work (TRACKS §3.5), so this is a sound estimate for a "
+            "paired delta — but it is an estimate, it is labelled as one, and "
+            "only T1 (which never ranks) may pair on it. The long-term fix is "
+            "per-sample PoW seconds in the cairo_proof_v1 envelope."
+        ),
+    ),
+}
+#: Suffix of the stage-profile sidecar the Cairo arm writes beside its envelope.
+STAGE_PROFILE_SIDECAR_SUFFIX = ".stages.json"
 
 #: report_schema -> phase name -> path to that phase's seconds. Phase names
 #: follow the §3.2 cutpoint vocabulary. Groups whose reports carry stage
@@ -397,6 +459,9 @@ class WorkloadScore:
     sequential_stop: dict | None = None
     #: Median PoW-excluded request ratio, present only under the fast boundary.
     fast_request_ratio: float | None = None
+    #: What the fast boundary subtracted and how it was measured, present only
+    #: under ``fast_boundary``. Carries the cross-invocation estimate label.
+    boundary_evidence: dict | None = None
 
 
 def portfolio_summary(scores: list[WorkloadScore], ci_level: float) -> dict:
@@ -621,8 +686,9 @@ def bench_once(
                 arm_root, group, workload, warmups, samples, out_dir,
                 tag, float(cairo_timeout), deadline_monotonic,
             )
-            # Ladder telemetry (TRACKS §3.5), read from the envelope the Cairo
-            # arm just wrote — only when a PoW cutpoint is actually registered.
+            # Ladder telemetry (TRACKS §3.5): Cairo's PoW seconds live in the
+            # stage-profile sidecar this call just wrote, so the envelope is
+            # only read when a PoW cutpoint is actually registered.
             if group.report_schema in POW_PHASE_SECONDS_FIELDS:
                 cairo_result.pow_ms = _pow_ms(
                     _load_json_object(
@@ -630,6 +696,7 @@ def bench_once(
                         "Cairo bench envelope",
                     ),
                     group,
+                    cairo_result.report_path,
                 )
             return cairo_result
         except (OSError, KeyError, TypeError, ValueError) as exc:
@@ -718,7 +785,7 @@ def bench_once(
         ) from exc
     # Ladder telemetry (TRACKS §3.5): carried on every run so the PoW-excluded
     # boundary is a projection of measured evidence, never a separate run.
-    result.pow_ms = _pow_ms(report, group)
+    result.pow_ms = _pow_ms(report, group, out_path)
     out_path.write_text(json.dumps(report, indent=1))
     return result
 
@@ -1854,11 +1921,56 @@ def resolve_phase(phases: dict[str, float], phase: str) -> str:
     )
 
 
-def _pow_ms(report: dict, group: WorkloadGroup) -> float | None:
-    path = POW_PHASE_SECONDS_FIELDS.get(group.report_schema)
-    if path is None:
+def _stage_profile_sidecar(report_path: str | Path) -> Path:
+    """The stage-profile document written beside a bench envelope."""
+    path = Path(report_path)
+    return path.with_suffix(STAGE_PROFILE_SIDECAR_SUFFIX)
+
+
+def _pow_ms(
+    report: dict, group: WorkloadGroup, report_path: str | Path,
+) -> float | None:
+    """Measured proof-of-work milliseconds, or None when the schema has none."""
+    source = POW_PHASE_SECONDS_FIELDS.get(group.report_schema)
+    if source is None:
         return None
-    seconds = _finite_or_none(_dig(report, path))
+    if source.kind == "report_field":
+        seconds = _finite_or_none(_dig(report, source.field_path))
+    elif source.kind == "stage_profile_sidecar":
+        sidecar = _stage_profile_sidecar(report_path)
+        if not sidecar.is_file():
+            raise RunError(
+                f"group {group.group_id}: the proof-of-work stage profile is "
+                f"missing at {sidecar}; the PoW-excluded boundary refuses to "
+                "guess a duration that was not recorded"
+            )
+        try:
+            profile = _load_json_object(
+                sidecar.read_text(encoding="utf-8"), "stage profile",
+            )
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            raise RunError(
+                f"group {group.group_id}: unreadable proof-of-work stage "
+                f"profile at {sidecar}: {exc}"
+            ) from exc
+        stages: dict[str, float] = {}
+        _flatten_stage_nodes(profile.get("stages"), "", stages)
+        missing = [
+            stage_id for stage_id in source.stage_ids
+            if f"stage:{stage_id}" not in stages
+        ]
+        if missing:
+            raise RunError(
+                f"group {group.group_id}: the stage profile does not record "
+                + ", ".join(missing)
+                + "; the PoW-excluded boundary cannot subtract an unrecorded stage"
+            )
+        seconds = sum(stages[f"stage:{stage_id}"] for stage_id in source.stage_ids)
+    else:  # The registry is code; an unknown kind is a programming error.
+        raise RunError(
+            f"group {group.group_id}: unsupported proof-of-work source kind "
+            f"{source.kind!r}"
+        )
     if seconds is None or seconds < 0.0:
         raise RunError(
             f"group {group.group_id}: report declares a proof-of-work cutpoint "
@@ -1867,9 +1979,17 @@ def _pow_ms(report: dict, group: WorkloadGroup) -> float | None:
     return seconds * 1000.0
 
 
-def require_pow_boundary(group: WorkloadGroup) -> None:
-    """Fail closed when a group cannot honestly exclude PoW from its boundary."""
-    if group.report_schema not in POW_PHASE_SECONDS_FIELDS:
+def require_pow_boundary(
+    group: WorkloadGroup, tier: str | None = None,
+) -> PowBoundarySource:
+    """Resolve a group's PoW source, failing closed on both honesty rules.
+
+    Rule one: a schema with no measured PoW cutpoint cannot exclude one.
+    Rule two: a CROSS-INVOCATION source is an estimate, so only the tier that
+    never ranks may pair on it.
+    """
+    source = POW_PHASE_SECONDS_FIELDS.get(group.report_schema)
+    if source is None:
         raise RunError(
             f"group {group.group_id}: report schema {group.report_schema!r} "
             "exposes no proof-of-work cutpoint, so the PoW-excluded fast "
@@ -1877,6 +1997,15 @@ def require_pow_boundary(group: WorkloadGroup) -> None:
             "phase (§3.2) before --fast-boundary can subtract it; the harness "
             "never subtracts an unmeasured cost."
         )
+    if source.cross_invocation and tier != CROSS_INVOCATION_POW_TIER:
+        raise RunError(
+            f"group {group.group_id}: its proof-of-work seconds are measured on "
+            f"the {source.invocation} rather than the scored sample, so "
+            "subtracting them yields a cross-invocation ESTIMATE. That is "
+            f"admissible only at {CROSS_INVOCATION_POW_TIER}, which never ranks "
+            f"(TRACKS §3.5); this call declared tier={tier!r}."
+        )
+    return source
 
 
 def paired_rounds(
@@ -1892,8 +2021,13 @@ def paired_rounds(
     deadline_monotonic: float | None = None,
     sequential_stop: bool | None = None,
     fast_boundary: bool = False,
+    tier: str | None = None,
 ) -> WorkloadScore:
-    """ABBA round pairs until the CI half-width is under theta/2 or a cap hits."""
+    """ABBA round pairs until the CI half-width is under theta/2 or a cap hits.
+
+    ``tier`` is declared by ladder callers only; it gates the cross-invocation
+    PoW estimate to the tier that never ranks (see ``require_pow_boundary``).
+    """
     warmups = int(policy["warmups"])
     samples = int(policy["samples_per_round"])
     min_rounds = (
@@ -1931,9 +2065,12 @@ def paired_rounds(
     stop_policy = sequential_stop_policy(policy, armed=sequential_stop)
     stop_evidence: dict | None = None
     boundary = FULL_BOUNDARY
+    pow_source: PowBoundarySource | None = None
+    pow_ms_a: list[float] = []
+    pow_ms_b: list[float] = []
     if fast_boundary:
-        require_pow_boundary(group)
-        boundary = FAST_BOUNDARY
+        pow_source = require_pow_boundary(group, tier)
+        boundary = pow_source.boundary_label
 
     round_no = 0
     while round_no < max_rounds:
@@ -2044,6 +2181,10 @@ def paired_rounds(
             ratios.append(fast_b_ms / fast_a)
             a_meds.append(fast_a)
             b_meds.append(fast_b_ms)
+            # The subtracted quantity is itself evidence: record it per arm so
+            # a reader can see what was removed, not just the remainder.
+            pow_ms_a.append(float(a.pow_ms or 0.0))
+            pow_ms_b.append(float(b.pow_ms or 0.0))
         else:
             ratios.append(b.prove_ms / a.prove_ms)
             a_meds.append(a.prove_ms)
@@ -2157,6 +2298,10 @@ def paired_rounds(
         boundary=boundary,
         sequential_stop=stop_evidence,
         fast_request_ratio=fast_request_ratio,
+        boundary_evidence=_boundary_evidence(
+            pow_source, tier, pow_ms_a, pow_ms_b,
+            group.report_schema, fast_ratios, request_ratios,
+        ),
     )
 
 
@@ -2174,6 +2319,53 @@ def _fast_boundary_ms(arm: ArmResult, workload: Workload) -> float:
             "smaller than the verified request time"
         )
     return remainder
+
+
+def _median(values: list[float]) -> float | None:
+    return sorted(values)[len(values) // 2] if values else None
+
+
+def _boundary_evidence(
+    pow_source: PowBoundarySource | None,
+    tier: str | None,
+    pow_ms_a: list[float],
+    pow_ms_b: list[float],
+    report_schema: str,
+    fast_ratios: list[float],
+    request_ratios: list[float],
+) -> dict | None:
+    """Label what the fast boundary removed, and how well it knew it.
+
+    An estimate that reads like a measurement is the failure mode this block
+    exists to prevent, so the label is spelled out in words next to the numbers.
+    """
+    if pow_source is None:
+        return None
+    estimate = pow_source.cross_invocation
+    label = (
+        "cross-invocation estimate: the subtracted proof-of-work seconds were "
+        f"measured on the {pow_source.invocation} of the same arm in the same "
+        "round, not on the scored sample. pow 26 is ~constant work, so this is "
+        "sound for a paired delta on a tier that never ranks — it is not a "
+        "measurement of the scored invocation and must never be reported as one."
+        if estimate else
+        "measurement: the subtracted proof-of-work seconds were measured on the "
+        "scored sample itself."
+    )
+    return {
+        "boundary": pow_source.boundary_label,
+        "full_boundary": "verified_request_ms",
+        "estimate": estimate,
+        "label": label,
+        "tier": tier,
+        "pow_source": pow_source.describe(report_schema),
+        "pow_ms": {
+            "predecessor_median": _median(pow_ms_a),
+            "candidate_median": _median(pow_ms_b),
+        },
+        "rounds": len(fast_ratios),
+        "full_request_rounds": len(request_ratios),
+    }
 
 
 def _sequential_stop_look(
@@ -2657,7 +2849,9 @@ def iterate_estimate(
     group = manifest.group(next(iter(group_ids)))
     policy = manifest.gates_for_workload(group.group_id, workload_class)
     if fast_boundary:
-        require_pow_boundary(group)
+        # Resolve before building anything: a group that cannot honestly
+        # exclude PoW should cost the agent zero seconds to find out.
+        require_pow_boundary(group, CROSS_INVOCATION_POW_TIER)
     dispersion = ledger.aa_dispersion(repo_root, board, workload_class)
     theta = stats.theta(
         dispersion,
@@ -2675,6 +2869,7 @@ def iterate_estimate(
             round_budget=round_budget,
             sequential_stop=True,
             fast_boundary=fast_boundary,
+            tier=CROSS_INVOCATION_POW_TIER,
         )
         for workload in workloads
     ]
@@ -2688,7 +2883,10 @@ def iterate_estimate(
         "board": board,
         "workload_class": workload_class,
         "era": era,
-        "boundary": FAST_BOUNDARY if fast_boundary else FULL_BOUNDARY,
+        # The label comes from the scores, not from the request: a fast run on
+        # a cross-invocation source says "estimate" in the boundary name itself.
+        "boundary": scores[0].boundary,
+        "boundary_evidence": scores[0].boundary_evidence,
         "theta": theta,
         "aa_dispersion": dispersion,
         "r_geomean": portfolio["r"],
@@ -2704,6 +2902,7 @@ def iterate_estimate(
                 "b_median_ms": score.b_median_ms,
                 "request_ratio": score.request_ratio,
                 "fast_request_ratio": score.fast_request_ratio,
+                "boundary_evidence": score.boundary_evidence,
                 "sequential_stop": score.sequential_stop,
                 "measurement_seconds": score.measurement_seconds,
             }

--- a/autoresearch/schema/confirmation-ladder.md
+++ b/autoresearch/schema/confirmation-ladder.md
@@ -91,33 +91,80 @@ Arming:
 
 ## 3. PoW-excluded fast boundary
 
-`pow 26` is ~constant work and pure noise for paired deltas, so T0/T1 measure
+`pow 26` is ~constant work and pure noise for paired deltas, so T1 pairs on
 `verified_request_minus_pow_ms` while T2/T3 keep the full boundary. Both
-numbers are reported at T1: `request_ratio` (full) and `fast_request_ratio`
+numbers are always reported: `request_ratio` (full) and `fast_request_ratio`
 (PoW-excluded).
 
-Fail-closed in three places:
+### Where the subtracted number comes from
 
-1. `runner.POW_PHASE_SECONDS_FIELDS` maps a `report_schema` to the report path
-   carrying the **measured** PoW seconds. It is deliberately **empty**: no
-   shipped product emits a PoW cutpoint yet, so `--fast-boundary` refuses on
-   every group today. The harness never subtracts a cost it did not measure.
-   *Product handoff:* emit the PoW phase (§3.2 names it) and register the field
-   path here; nothing else changes.
+`runner.POW_PHASE_SECONDS_FIELDS` maps a `report_schema` to a
+`PowBoundarySource` describing **measured** PoW seconds. A schema absent from
+the registry cannot use `--fast-boundary` at all: the harness subtracts only
+measured PoW time, never a modeled or assumed one.
 
-   Known near-miss on Cairo: the Cairo stage profile already records a
-   `proof_of_work` stage with real seconds, but the phase mapping folds it into
-   the `fri` phase, and the profile is recorded on a **discarded warmup** while
-   the scored request time comes from the uninstrumented samples. Registering
-   that number would subtract a duration measured on a *different invocation*
-   than the one being timed. That is a decision about measurement scope, not a
-   wiring detail, so it is left to a reviewed change: either publish per-sample
-   PoW seconds in the `cairo_proof_v1` envelope, or accept the cross-invocation
-   subtraction explicitly for T1 (which never ranks).
-2. `runner.evaluate(..., fast_boundary=True)` always raises — the ranked and
-   claimed paths cannot express a PoW-excluded number even by accident.
-3. `stwo-perf run --fast-boundary` is rejected by the CLI with a pointer to
+The honesty-critical field is `invocation`:
+
+| `invocation` | meaning | boundary label | admissible at |
+|---|---|---|---|
+| `scored_sample` | measured on the very invocation being timed | `verified_request_minus_pow_ms` | any tier that may use the fast boundary |
+| `discarded_warmup` | measured on another invocation of the same arm, same round | `verified_request_minus_pow_ms_cross_invocation_estimate` | **T1 only** |
+
+Registered today — one entry:
+
+```python
+"cairo_proof_v1": PowBoundarySource(
+    kind="stage_profile_sidecar",
+    invocation="discarded_warmup",
+    stage_ids=("proof_of_work",),
+)
+```
+
+Cairo's stage profile records a real `proof_of_work` stage, but scored samples
+run uninstrumented, so the profile comes from the round's discarded warmup.
+Subtracting it therefore yields an **estimate**, not a measurement of the
+scored invocation. That is accepted deliberately and narrowly:
+
+- `pow 26` is ~constant work and pure noise for paired deltas — TRACKS §3.5's
+  own justification for excluding it;
+- the seconds are real measurements of the same arm, in the same round, on the
+  same host;
+- **T1 never ranks**, and the tier gate is enforced in code rather than by
+  convention.
+
+What keeps it from being laundered into a measurement:
+
+- a **different boundary string** (`..._cross_invocation_estimate`), so every
+  consumer of `boundary` sees the distinction without knowing this section
+  exists;
+- a `boundary_evidence` block on the score and in the T1 document recording the
+  source (`kind`, `invocation`, `stage_ids`, `cross_invocation`, `estimate`),
+  the subtracted PoW milliseconds per arm, and a sentence spelling out that the
+  number is not a measurement of the scored invocation;
+- the CLI prints that sentence as a warning on every estimated T1 run;
+- both numbers are always reported — `request_ratio` (full) alongside
+  `fast_request_ratio` (PoW-excluded).
+
+*Zig-side follow-up (the correct long-term fix):* publish **per-sample** PoW
+seconds in the `cairo_proof_v1` envelope. The source then becomes
+`invocation="scored_sample"`, the estimate label and the T1 gate drop away on
+their own, and no ladder code changes. This sits with the same product-CLI work
+item as "no product emits a PoW cutpoint at all" for native/riscv.
+
+### Fail-closed surfaces
+
+1. A schema with no registered PoW source refuses `--fast-boundary` outright.
+2. A **cross-invocation** source refuses any tier but `T1` —
+   `paired_rounds(..., fast_boundary=True)` without `tier="T1"` raises, so a
+   future caller cannot reach the estimate by omission.
+3. `runner.evaluate(..., fast_boundary=True)` always raises, registered source
+   or not — the ranked and claimed paths cannot express a PoW-excluded number
+   even by accident.
+4. `stwo-perf run --fast-boundary` is rejected by the CLI with a pointer to
    `stwo-perf ladder t1 --fast-boundary`.
+5. A missing stage-profile sidecar, a profile without the named stage, or a PoW
+   duration that is not smaller than the request all raise rather than produce
+   a boundary.
 
 ## 4. Proxy fixtures (`workload_registry.classes.<class>.proxy_fixture`)
 

--- a/autoresearch/tests/test_confirmation_ladder.py
+++ b/autoresearch/tests/test_confirmation_ladder.py
@@ -59,6 +59,15 @@ LADDER = {
     "note": "test ladder",
 }
 
+# A hypothetical schema that publishes PoW on the scored sample itself: the
+# same-invocation case the registry is designed to admit without a tier gate.
+SAMPLE_POW_SOURCE = runner.PowBoundarySource(
+    kind="report_field",
+    invocation="scored_sample",
+    note="test schema publishing per-sample proof-of-work seconds",
+    field_path=("timing", "pow_seconds", "median"),
+)
+
 PROXY_FIXTURE = {
     "proxy_id": "small_proxy",
     "args": "--warmups {warmups} --samples {samples} --log-n-rows 12",
@@ -354,42 +363,53 @@ class FastBoundaryTest(LadderTestCase):
         self.assertIn("no proof-of-work cutpoint", str(caught.exception))
         self.assertEqual([], calls)  # refused before a single measurement
 
-    def test_registered_schema_reports_both_boundaries(self):
+    def test_same_invocation_source_reports_both_boundaries(self):
         bench, _ = self.fake_bench(
             lambda round_no: 0.90 if round_no % 2 else 0.94,
             pow_ms=40.0, request_scale=1.5,
         )
         with mock.patch.dict(
-            runner.POW_PHASE_SECONDS_FIELDS,
-            {"native_proof_v7": ("timing", "pow_seconds", "median")},
+            runner.POW_PHASE_SECONDS_FIELDS, {"native_proof_v7": SAMPLE_POW_SOURCE},
             clear=False,
         ):
             score = self.run_rounds(
                 bench, base_policy(), fast_boundary=True, sequential_stop=None,
             )
+        # A same-invocation source is a measurement, so it keeps the plain label
+        # and needs no tier declaration.
         self.assertEqual(runner.FAST_BOUNDARY, score.boundary)
         # Full boundary: request scales with prove, so the ratio is the raw one.
         self.assertAlmostEqual(0.90, score.request_ratio, places=6)
         # PoW-excluded: (0.9*150 - 40) / (150 - 40) = 95/110.
         self.assertAlmostEqual(95.0 / 110.0, score.fast_request_ratio, places=6)
         self.assertIn("fast_request_ms", score.candidate_resources)
+        evidence = score.boundary_evidence
+        self.assertFalse(evidence["estimate"])
+        self.assertIn("measured on the scored sample itself", evidence["label"])
+        self.assertAlmostEqual(40.0, evidence["pow_ms"]["candidate_median"])
 
     def test_pow_extraction_reads_only_measured_seconds(self):
         group = self.manifest(ladder=LADDER).group("native")
         report = {"timing": {"pow_seconds": {"median": 0.25}}}
-        self.assertIsNone(runner._pow_ms(report, group))
+        path = self.root / "report.json"
+        self.assertIsNone(runner._pow_ms(report, group, path))
         with mock.patch.dict(
-            runner.POW_PHASE_SECONDS_FIELDS,
-            {"native_proof_v7": ("timing", "pow_seconds", "median")},
+            runner.POW_PHASE_SECONDS_FIELDS, {"native_proof_v7": SAMPLE_POW_SOURCE},
             clear=False,
         ):
-            self.assertAlmostEqual(250.0, runner._pow_ms(report, group))
+            self.assertAlmostEqual(250.0, runner._pow_ms(report, group, path))
             with self.assertRaises(runner.RunError):
-                runner._pow_ms({"timing": {}}, group)
+                runner._pow_ms({"timing": {}}, group, path)
 
-    def test_shipped_registry_is_empty_so_the_flag_is_universally_refused(self):
-        # No product emits a PoW cutpoint yet; the harness must not pretend.
-        self.assertEqual({}, runner.POW_PHASE_SECONDS_FIELDS)
+    def test_shipped_registry_admits_only_a_labelled_cairo_estimate(self):
+        # Every registered source must be honest about which invocation it was
+        # measured on; cairo is the only one, and it is an estimate.
+        self.assertEqual({"cairo_proof_v1"}, set(runner.POW_PHASE_SECONDS_FIELDS))
+        source = runner.POW_PHASE_SECONDS_FIELDS["cairo_proof_v1"]
+        self.assertEqual("discarded_warmup", source.invocation)
+        self.assertTrue(source.cross_invocation)
+        self.assertEqual(("proof_of_work",), source.stage_ids)
+        self.assertEqual(runner.FAST_BOUNDARY_ESTIMATED, source.boundary_label)
 
 
 class PhaseAttributionTest(LadderTestCase):
@@ -501,8 +521,12 @@ class PhaseAttributionTest(LadderTestCase):
         )
 
 
-class CairoPhaseAttributionTest(unittest.TestCase):
-    """T0 on the wave-1 Cairo track, over a real cairo_proof_v1 envelope."""
+#: The PoW stage recorded in W1's committed Cairo stage-profile fixture.
+CAIRO_FIXTURE_POW_SECONDS = 0.086572
+
+
+class CairoLadderTestCase(unittest.TestCase):
+    """A temp Cairo track backed by W1's committed product fixtures."""
 
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()
@@ -514,24 +538,32 @@ class CairoPhaseAttributionTest(unittest.TestCase):
         manifest_mod._validate(raw)
         self.manifest = Manifest(root=self.root, raw=raw)
         self.workload = self.manifest.workloads(board="cairo_cpu")[0]
-        binary = self.root / "bin" / "stwo-cairo-cpu"
+        self.install_product(self.root)
+
+    def install_product(self, root: Path, profile: dict | None = None) -> Path:
+        binary = root / "bin" / "stwo-cairo-cpu"
         binary.parent.mkdir(parents=True, exist_ok=True)
         binary.write_text(
             FAKE_PRODUCT
             .replace("REPORT_JSON", repr(json.dumps(load_report())))
-            .replace("PROFILE_JSON", repr(json.dumps(load_profile())))
+            .replace("PROFILE_JSON", repr(json.dumps(profile or load_profile())))
             .replace("PROOF_PAYLOAD", repr(b"proof-bytes"))
             .replace("MUTATE", "pass")
         )
         binary.chmod(binary.stat().st_mode | stat.S_IEXEC)
+        return binary
+
+
+class CairoPhaseAttributionTest(CairoLadderTestCase):
+    """T0 on the wave-1 Cairo track, over a real cairo_proof_v1 envelope."""
 
     def envelope(self) -> dict:
         result = runner.bench_once(
             self.root, self.manifest, self.workload, 1, 1, self.out_dir, "a1",
         )
         # The Cairo arm returns early from bench_once; ladder telemetry must
-        # still ride along (None here: no schema registers a PoW cutpoint).
-        self.assertIsNone(result.pow_ms)
+        # still ride along, reading the stage-profile sidecar it just wrote.
+        self.assertAlmostEqual(CAIRO_FIXTURE_POW_SECONDS * 1000.0, result.pow_ms)
         return json.loads(Path(result.report_path).read_text(encoding="utf-8"))
 
     def test_named_cutpoints_are_readable_for_t0(self):
@@ -568,7 +600,6 @@ class CairoPhaseAttributionTest(unittest.TestCase):
         )
 
     def test_t0_prefilter_runs_end_to_end_on_cairo(self):
-        moved = json.loads(json.dumps(load_report()))
         # A candidate whose FRI phase halved: every stage that composes the
         # phase moves, and nothing else does.
         fri_stages = set(runner.CAIRO_PHASE_STAGES["fri"][0])
@@ -577,16 +608,7 @@ class CairoPhaseAttributionTest(unittest.TestCase):
             if node["id"] in fri_stages:
                 node["seconds"] = node["seconds"] / 2.0
         candidate = self.root / "candidate"
-        (candidate / "bin").mkdir(parents=True)
-        binary = candidate / "bin" / "stwo-cairo-cpu"
-        binary.write_text(
-            FAKE_PRODUCT
-            .replace("REPORT_JSON", repr(json.dumps(moved)))
-            .replace("PROFILE_JSON", repr(json.dumps(profile)))
-            .replace("PROOF_PAYLOAD", repr(b"proof-bytes"))
-            .replace("MUTATE", "pass")
-        )
-        binary.chmod(binary.stat().st_mode | stat.S_IEXEC)
+        self.install_product(candidate, profile)
         with mock.patch.object(runner, "build_arm", lambda *a, **k: None):
             result = runner.phase_prefilter(
                 self.root, candidate, self.manifest, "small", self.out_dir,
@@ -606,6 +628,131 @@ class CairoPhaseAttributionTest(unittest.TestCase):
             )
         self.assertFalse(result["pass"])
         self.assertFalse(result["phase_moved"])
+
+
+class CairoFastBoundaryTest(CairoLadderTestCase):
+    """T1 pairs on Cairo's PoW-excluded boundary — labelled as an estimate."""
+
+    # The fake product returns in milliseconds where a real Cairo proof takes
+    # seconds, so the fixture's 86 ms PoW stage would exceed the whole cold
+    # process. Scale the recorded stage to keep the arithmetic realistic; the
+    # fixture value itself is asserted in CairoPhaseAttributionTest.
+    POW_SECONDS = 0.0005
+
+    def setUp(self):
+        super().setUp()
+        profile = json.loads(json.dumps(load_profile()))
+        for node in profile["stages"]:
+            if node["id"] == "proof_of_work":
+                node["seconds"] = self.POW_SECONDS
+        self.install_product(self.root, profile)
+
+    def _estimate(self, **kwargs):
+        with mock.patch.object(runner, "build_arm", lambda *a, **k: None), \
+                mock.patch.object(runner.ledger, "aa_dispersion", lambda *a: None):
+            return runner.iterate_estimate(
+                self.root, self.root, self.manifest, "small",
+                self.out_dir, board="cairo_cpu", era=3, **kwargs,
+            )
+
+    def test_t1_reports_both_boundaries_and_labels_the_estimate(self):
+        result = self._estimate(fast_boundary=True)
+        self.assertEqual(runner.FAST_BOUNDARY_ESTIMATED, result["boundary"])
+        evidence = result["boundary_evidence"]
+        self.assertTrue(evidence["estimate"])
+        self.assertEqual("T1", evidence["tier"])
+        self.assertIn("cross-invocation estimate", evidence["label"])
+        self.assertIn("must never be reported as one", evidence["label"])
+        source = evidence["pow_source"]
+        self.assertEqual("cairo_proof_v1", source["report_schema"])
+        self.assertEqual("discarded_warmup", source["invocation"])
+        self.assertEqual(["proof_of_work"], source["stage_ids"])
+        self.assertTrue(source["cross_invocation"])
+        # The subtracted quantity is recorded, not merely applied.
+        for arm in ("predecessor_median", "candidate_median"):
+            self.assertAlmostEqual(
+                self.POW_SECONDS * 1000.0, evidence["pow_ms"][arm],
+            )
+        entry = result["per_workload"][self.workload.workload_id]
+        # BOTH numbers survive: the full boundary and the PoW-excluded one.
+        self.assertIsNotNone(entry["request_ratio"])
+        self.assertIsNotNone(entry["fast_request_ratio"])
+        self.assertEqual(runner.FAST_BOUNDARY_ESTIMATED, entry["boundary"])
+
+    def test_the_fast_boundary_removes_exactly_the_measured_pow_time(self):
+        policy = self.manifest.gates_for_workload("cairo_cpu", "small")
+        score = runner.paired_rounds(
+            self.root, self.root, self.manifest, self.workload, policy,
+            self.out_dir, fast_boundary=True, tier="T1",
+        )
+        # Both candidate medians come from the SAME rounds, and the subtracted
+        # PoW estimate is one constant, so the gap is exactly that constant.
+        self.assertAlmostEqual(
+            self.POW_SECONDS * 1000.0,
+            score.candidate_resources["request_ms"]
+            - score.candidate_resources["fast_request_ms"],
+            places=9,
+        )
+        self.assertGreater(score.candidate_resources["fast_request_ms"], 0.0)
+        self.assertEqual(runner.FAST_BOUNDARY_ESTIMATED, score.boundary)
+
+    def test_a_pow_stage_larger_than_the_request_fails_closed(self):
+        # The unscaled fixture's PoW exceeds the fake product's whole cold
+        # process: subtracting it would invent a negative boundary.
+        self.install_product(self.root)
+        policy = self.manifest.gates_for_workload("cairo_cpu", "small")
+        with self.assertRaises(runner.RunError) as caught:
+            runner.paired_rounds(
+                self.root, self.root, self.manifest, self.workload, policy,
+                self.out_dir, fast_boundary=True, tier="T1",
+            )
+        self.assertIn("not smaller than the verified request", str(caught.exception))
+
+    def test_cross_invocation_estimate_is_refused_outside_t1(self):
+        policy = self.manifest.gates_for_workload("cairo_cpu", "small")
+        with self.assertRaises(runner.RunError) as caught:
+            runner.paired_rounds(
+                self.root, self.root, self.manifest, self.workload, policy,
+                self.out_dir, fast_boundary=True,
+            )
+        message = str(caught.exception)
+        self.assertIn("cross-invocation ESTIMATE", message)
+        self.assertIn("admissible only at T1", message)
+
+    def test_a_declared_ranked_tier_is_refused(self):
+        policy = self.manifest.gates_for_workload("cairo_cpu", "small")
+        for tier in ("T2", "T3"):
+            with self.assertRaises(runner.RunError):
+                runner.paired_rounds(
+                    self.root, self.root, self.manifest, self.workload, policy,
+                    self.out_dir, fast_boundary=True, tier=tier,
+                )
+
+    def test_ranked_evaluation_still_refuses_even_with_a_registered_source(self):
+        with self.assertRaises(runner.RunError) as caught:
+            runner.evaluate(
+                self.root, self.root, self.manifest, "small", "time", "s3",
+                False, self.out_dir, board="cairo_cpu", fast_boundary=True,
+            )
+        self.assertIn("never excludes anything", str(caught.exception))
+
+    def test_a_missing_stage_profile_sidecar_fails_closed(self):
+        group = self.manifest.group("cairo_cpu")
+        with self.assertRaises(runner.RunError) as caught:
+            runner._pow_ms({}, group, self.root / "absent.json")
+        self.assertIn("refuses to guess", str(caught.exception))
+
+    def test_a_profile_without_the_pow_stage_fails_closed(self):
+        group = self.manifest.group("cairo_cpu")
+        profile = json.loads(json.dumps(load_profile()))
+        profile["stages"] = [
+            node for node in profile["stages"] if node["id"] != "proof_of_work"
+        ]
+        report_path = self.root / "envelope.json"
+        runner._stage_profile_sidecar(report_path).write_text(json.dumps(profile))
+        with self.assertRaises(runner.RunError) as caught:
+            runner._pow_ms({}, group, report_path)
+        self.assertIn("does not record proof_of_work", str(caught.exception))
 
 
 class ProxyFixtureManifestTest(LadderTestCase):


### PR DESCRIPTION
## What

Implements the orchestrator's decision (b) on the PoW question raised in #146: **accept the cross-invocation subtraction, T1 only**, so `--fast-boundary` works on the wave-1 Cairo tracks.

Cairo's stage profile records a real `proof_of_work` stage, but scored samples run uninstrumented — the seconds come from the round's **discarded warmup**. Subtracting them yields an *estimate* of the scored invocation, not a measurement of it. That is accepted here because `pow 26` is ~constant work and pure noise for paired deltas (TRACKS §3.5's own justification), the seconds are real measurements of the same arm in the same round on the same host, and **T1 never ranks**.

## The registry shape

`POW_PHASE_SECONDS_FIELDS` grows from a bare field path to a typed `PowBoundarySource`. The honesty-critical field is `invocation`:

| `invocation` | meaning | boundary label | admissible at |
|---|---|---|---|
| `scored_sample` | measured on the invocation being timed | `verified_request_minus_pow_ms` | any tier that may use the fast boundary |
| `discarded_warmup` | measured on another invocation of the same arm, same round | `verified_request_minus_pow_ms_cross_invocation_estimate` | **T1 only** |

One entry registered:

```python
"cairo_proof_v1": PowBoundarySource(
    kind="stage_profile_sidecar",
    invocation="discarded_warmup",
    stage_ids=("proof_of_work",),
)
```

Cairo reads its PoW from the stage-profile sidecar the arm writes beside its envelope.

## Keeping an estimate from reading as a measurement

- **A different boundary string.** `..._cross_invocation_estimate` — every consumer of `boundary` sees the distinction without knowing this decision exists.
- **A `boundary_evidence` block** on the score and in the T1 document: the source (`kind`, `invocation`, `stage_ids`, `cross_invocation`, `estimate`), the subtracted PoW milliseconds per arm, and a sentence stating in words that the number is not a measurement of the scored invocation and must never be reported as one.
- **The CLI prints that sentence as a warning** on every estimated T1 run.
- **Both numbers still reported**: `request_ratio` (full) beside `fast_request_ratio` (PoW-excluded).

## Fail-closed surfaces (all tested)

1. A schema with no registered source refuses `--fast-boundary` outright.
2. A cross-invocation source refuses **every tier but T1** — `paired_rounds(..., fast_boundary=True)` without `tier="T1"` raises, so a future caller cannot reach the estimate by omission.
3. `runner.evaluate(..., fast_boundary=True)` still raises unconditionally, registered source or not.
4. `stwo-perf run --fast-boundary` still rejected with a pointer to `ladder t1`.
5. A missing sidecar, an absent `proof_of_work` stage, or a PoW duration not smaller than the request each raise instead of producing a boundary.

## Zig-side follow-up (recorded in the schema doc)

Publish **per-sample** PoW seconds in the `cairo_proof_v1` envelope. The source then becomes `invocation="scored_sample"`, and both the estimate label and the T1 gate drop away on their own with **no ladder code change**. This joins the existing product-CLI work item: native/riscv emit no PoW cutpoint at all, so `--fast-boundary` still refuses on those tracks.

## Scope

`runner.py` ladder regions (PoW registry/resolution, `paired_rounds` boundary handling, `iterate_estimate`), the T1 CLI panel, `autoresearch/tests/test_confirmation_ladder.py`, and `autoresearch/schema/confirmation-ladder.md`. No MANIFEST change, no cairo parser/oracle changes, no `conformance/performance-authority/**` touches — should not collide with W1's concurrent oracle-dispatch / mechanism-guard PR.

## Tests

`python3 -m unittest discover -s autoresearch/tests` → **514 OK** (8 new; 86 in the two ladder modules). Includes a happy path that runs the real `_bench_cairo` → sidecar → subtraction chain against W1's committed fixtures and asserts the gap between the full and PoW-excluded candidate medians is *exactly* the measured PoW constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
