### PR TITLE
W1: official Cairo verifier on the judged path + cairo mechanism drift guard (TRACKS §3.2, §8)

### DIFF
--- a/autoresearch/cli/stwo_perf/runner.py
+++ b/autoresearch/cli/stwo_perf/runner.py
@@ -45,6 +45,7 @@ from scripts.native_cuda_diagnostic_lib.model import (
 from . import dimensions, ledger, search_health, stats
 from .manifest import (
     CAIRO_PHASE_NAMES,
+    CAIRO_STABLE_MECHANISM_FIELDS,
     PROXY_VALIDITY_METHOD,
     PROXY_VALIDITY_RECEIPT_SCHEMA,
     REPORT_SCHEMA_VERSIONS,
@@ -235,6 +236,43 @@ CAIRO_PHASE_STAGES: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
     ),
 }
 CAIRO_UNINSTRUMENTED_PHASES = ("serialize",)
+
+# The pinned official Stwo-Cairo verifier, the same authority the build gates
+# use (build_support/products/cairo_cpu/oracle_gate.zig). The harness builds it
+# from the manifest's declared `build_command` — the manifest owns flag drift —
+# and runs the release profile so a judged run is not paying debug verification.
+CAIRO_ORACLE_AUTHORITY = "official-stwo-cairo-verifier"
+CAIRO_ORACLE_ADAPTER = "tools/stwo-cairo-official-verifier-rs"
+CAIRO_ORACLE_EXECUTABLE = "stwo-cairo-official-verifier"
+CAIRO_ORACLE_ADAPTER_VERSION = "stwo-cairo-official-verifier/1"
+CAIRO_ORACLE_IDENTITY_SCHEMA_VERSION = 1
+CAIRO_ORACLE_VERDICT_SCHEMA_VERSION = 1
+CAIRO_ORACLE_CHANNEL = "blake2s"
+CAIRO_ORACLE_BUILD_TIMEOUT = 3600
+CAIRO_ORACLE_VERIFY_TIMEOUT = 1800
+# Product proof-format spelling -> official Rust adapter transport. The
+# Cairo-serde felt array deliberately targets the Cairo verifier and is
+# rejected by this Rust adapter, so it can never be a scored transport.
+CAIRO_ORACLE_TRANSPORTS = {"json": "json", "binary": "binary"}
+_CAIRO_ORACLE_IDENTITY_KEYS = {
+    "schema_version", "adapter_version", "stwo_cairo", "stwo",
+    "cargo_lock_sha256", "executable_sha256", "channels", "proof_formats",
+    "max_proof_bytes", "prover_input_schema", "claim_summary_schema",
+    "max_input_bytes",
+}
+_CAIRO_ORACLE_VERDICT_KEYS = {
+    "schema_version", "adapter_version", "stwo_cairo_revision",
+    "stwo_revision", "proof_sha256", "channel", "proof_format", "verified",
+    "wall_time_ns", "error",
+}
+
+# Per-schema semantic (never implementation) mechanism telemetry: the fields a
+# paired round requires to be identical across the A and B arms and across
+# rounds. A schema absent here has no cross-arm mechanism contract.
+STABLE_MECHANISM_FIELDS_BY_SCHEMA: dict[str, tuple[str, frozenset]] = {
+    "riscv_proof_v2": ("RISC-V", RISCV_STABLE_MECHANISM_FIELDS),
+    "cairo_proof_v1": ("Cairo", CAIRO_STABLE_MECHANISM_FIELDS),
+}
 
 
 def _workload_resource_profile(workload: Workload) -> str:
@@ -882,6 +920,11 @@ def _commit_hex(value: object, field_name: str) -> str:
     if not isinstance(value, str) or not re.fullmatch(r"[0-9a-f]{40}", value):
         raise ValueError(f"{field_name} must be a full lowercase Git commit")
     return value
+
+
+def _commit_like(value: object) -> bool:
+    """Predicate form of `_commit_hex`, for policy shape checks."""
+    return isinstance(value, str) and bool(re.fullmatch(r"[0-9a-f]{40}", value))
 
 
 def _parse_native_report(
@@ -1999,17 +2042,24 @@ def paired_rounds(
             raise RunError(
                 f"{workload.workload_id}: proof byte length changed between rounds"
             )
-        if group.report_schema == "riscv_proof_v2":
+        stable_binding = STABLE_MECHANISM_FIELDS_BY_SCHEMA.get(group.report_schema)
+        if stable_binding is not None:
+            label, stable_fields = stable_binding
             if a.mechanism is None or b.mechanism is None:
                 raise RunError(
-                    f"{workload.workload_id}: RISC-V mechanism telemetry is absent"
+                    f"{workload.workload_id}: {label} mechanism telemetry is absent"
                 )
-            stable_a = {
-                key: a.mechanism.get(key) for key in RISCV_STABLE_MECHANISM_FIELDS
-            }
-            stable_b = {
-                key: b.mechanism.get(key) for key in RISCV_STABLE_MECHANISM_FIELDS
-            }
+            missing = sorted(
+                key for key in stable_fields
+                if key not in a.mechanism or key not in b.mechanism
+            )
+            if missing:
+                raise RunError(
+                    f"{workload.workload_id}: {label} mechanism telemetry omits "
+                    "stable field(s): " + ", ".join(missing)
+                )
+            stable_a = {key: a.mechanism.get(key) for key in stable_fields}
+            stable_b = {key: b.mechanism.get(key) for key in stable_fields}
             if stable_a != stable_b:
                 raise RunError(
                     f"{workload.workload_id}: semantic mechanism telemetry differs "
@@ -2022,6 +2072,7 @@ def paired_rounds(
                 )
             mechanism_reference = stable_b
             mechanism_verified = True
+        if group.report_schema == "riscv_proof_v2":
             if a.resources_complete is not b.resources_complete:
                 raise RunError(
                     f"{workload.workload_id}: RISC-V resource availability differs "
@@ -2903,6 +2954,10 @@ def rust_oracle_check(candidate_root: Path, manifest: Manifest,
         return _cuda_rust_oracle_check(
             candidate_root, group, workload, out_dir,
         )
+    if group.report_schema == "cairo_proof_v1":
+        return _cairo_official_verifier_check(
+            candidate_root, group, workload, out_dir,
+        )
     raise RunError(
         f"{workload.workload_id}: no correctness oracle for "
         f"{group.report_schema!r}"
@@ -3248,6 +3303,309 @@ def _validate_riscv_verify_receipt(
         if receipt.get(field_name) != value or type(receipt.get(field_name)) is not type(value):
             raise ValueError(f"verification receipt {field_name} differs")
     return receipt
+
+
+def _latest_cairo_candidate_artifact(
+    out_dir: Path, workload: Workload,
+) -> tuple[Path, Path]:
+    """The last candidate-arm envelope and the proof bytes it scored.
+
+    `_bench_cairo` writes `<workload>.b<round>.json` plus one retained
+    `<workload>.b<round>.i<index>.proof` per measured sample. The oracle
+    verifies the LAST measured sample of the LAST candidate round, so the bytes
+    the official verifier accepts are bytes that were actually scored.
+    """
+    pattern = re.compile(rf"^{re.escape(workload.workload_id)}\.b([1-9][0-9]*)\.json$")
+    envelopes = []
+    if out_dir.is_dir():
+        for path in out_dir.iterdir():
+            match = pattern.fullmatch(path.name)
+            if match and path.is_file():
+                envelopes.append((int(match.group(1)), path.resolve()))
+    if not envelopes:
+        raise ValueError("no retained candidate Cairo measurement envelope")
+    round_no, envelope_path = max(envelopes)
+    proof_pattern = re.compile(
+        rf"^{re.escape(workload.workload_id)}\.b{round_no}\.i([0-9]+)\.proof$"
+    )
+    proofs = []
+    for path in out_dir.iterdir():
+        match = proof_pattern.fullmatch(path.name)
+        if match and path.is_file():
+            proofs.append((int(match.group(1)), path.resolve()))
+    if not proofs:
+        raise ValueError(
+            f"no retained candidate Cairo proof for round {round_no}"
+        )
+    _index, proof_path = max(proofs)
+    return envelope_path, proof_path
+
+
+def _cairo_oracle_binary(candidate_root: Path, adapter: str) -> Path:
+    return (
+        candidate_root / adapter / "target" / "release" / CAIRO_ORACLE_EXECUTABLE
+    )
+
+
+def _validate_cairo_oracle_identity(
+    raw: str, oracle_policy: dict, binary: Path, adapter_lock: Path,
+) -> dict:
+    """Bind the built adapter to the manifest pins and the committed lockfile."""
+    identity = _load_json_object(raw, "official Cairo verifier identity")
+    _exact_object(
+        identity, _CAIRO_ORACLE_IDENTITY_KEYS, "official Cairo verifier identity",
+    )
+    if identity["schema_version"] != CAIRO_ORACLE_IDENTITY_SCHEMA_VERSION:
+        raise ValueError("official Cairo verifier identity schema is unsupported")
+    if identity["adapter_version"] != CAIRO_ORACLE_ADAPTER_VERSION:
+        raise ValueError("official Cairo verifier adapter version is unsupported")
+    for key, repository_key, commit_key in (
+        ("stwo_cairo", "repository", "commit"),
+        ("stwo", "stwo_repository", "stwo_commit"),
+    ):
+        source = _exact_object(
+            identity[key], {"repository", "revision"},
+            f"official Cairo verifier identity.{key}",
+        )
+        if source["repository"] != oracle_policy.get(repository_key):
+            raise ValueError(
+                f"official Cairo verifier {key} repository is not the "
+                "manifest-pinned repository"
+            )
+        if source["revision"] != oracle_policy.get(commit_key):
+            raise ValueError(
+                f"official Cairo verifier {key} revision is not the "
+                "manifest-pinned commit"
+            )
+    expected_lock = hashlib.sha256(adapter_lock.read_bytes()).hexdigest()
+    if _sha256_hex(
+        identity["cargo_lock_sha256"], "identity.cargo_lock_sha256",
+    ) != expected_lock:
+        raise ValueError(
+            "official Cairo verifier was not built from the committed lockfile"
+        )
+    expected_binary = hashlib.sha256(binary.read_bytes()).hexdigest()
+    if _sha256_hex(
+        identity["executable_sha256"], "identity.executable_sha256",
+    ) != expected_binary:
+        raise ValueError(
+            "official Cairo verifier identity does not bind the executed binary"
+        )
+    if CAIRO_ORACLE_CHANNEL not in identity["channels"]:
+        raise ValueError(
+            f"official Cairo verifier does not support the {CAIRO_ORACLE_CHANNEL} channel"
+        )
+    return identity
+
+
+def _validate_cairo_verdict(
+    raw: str,
+    oracle_policy: dict,
+    transport: str,
+    proof_sha256: str,
+) -> dict:
+    verdict = _load_json_object(raw, "official Cairo verifier verdict")
+    _exact_object(
+        verdict, _CAIRO_ORACLE_VERDICT_KEYS, "official Cairo verifier verdict",
+    )
+    expected = {
+        "schema_version": CAIRO_ORACLE_VERDICT_SCHEMA_VERSION,
+        "adapter_version": CAIRO_ORACLE_ADAPTER_VERSION,
+        "stwo_cairo_revision": oracle_policy.get("commit"),
+        "stwo_revision": oracle_policy.get("stwo_commit"),
+        "proof_sha256": proof_sha256,
+        "channel": CAIRO_ORACLE_CHANNEL,
+        "proof_format": transport,
+        "verified": True,
+        "error": None,
+    }
+    for field_name, value in expected.items():
+        actual = verdict.get(field_name)
+        if actual != value or type(actual) is not type(value):
+            raise ValueError(
+                f"official Cairo verifier verdict {field_name} differs "
+                f"(expected {value!r}, got {actual!r})"
+            )
+    _nonnegative_integer(verdict["wall_time_ns"], "verdict.wall_time_ns")
+    return verdict
+
+
+def _cairo_official_verifier_check(
+    candidate_root: Path,
+    group: WorkloadGroup,
+    workload: Workload,
+    out_dir: Path,
+) -> dict:
+    """Independently verify the scored Cairo proof with the pinned oracle.
+
+    TRACKS §8 wave 1: the official-verifier oracle the build gates already run
+    is wired into the judged harness path. Every step fails closed — a missing
+    adapter, a build that does not produce the binary, an identity that is not
+    bound to the manifest pins and the committed lockfile, a retained proof
+    whose bytes do not match what was scored, a rejected proof (adapter exit
+    3), or an adapter failure (exit 2). There is no skip.
+    """
+    oracle_policy = group.correctness_oracle
+    adapter = oracle_policy.get("adapter")
+    if (
+        oracle_policy.get("authority") != CAIRO_ORACLE_AUTHORITY
+        or adapter != CAIRO_ORACLE_ADAPTER
+        or oracle_policy.get("final_validator") is not True
+        or not _commit_like(oracle_policy.get("commit"))
+        or not _commit_like(oracle_policy.get("stwo_commit"))
+    ):
+        raise RunError(
+            f"{workload.workload_id}: Cairo group is not bound to the pinned "
+            "official Stwo-Cairo verifier as final validator"
+        )
+    build_command = oracle_policy.get("build_command")
+    adapter_manifest = f"{adapter}/Cargo.toml"
+    if (
+        not isinstance(build_command, str)
+        or "--locked" not in build_command
+        or "--release" not in build_command
+        or adapter_manifest not in build_command
+    ):
+        raise RunError(
+            f"{workload.workload_id}: the Cairo oracle build_command must be a "
+            f"locked release build of {adapter_manifest}"
+        )
+    adapter_lock = candidate_root / adapter / "Cargo.lock"
+    if not adapter_lock.is_file():
+        raise RunError(
+            f"{workload.workload_id}: the pinned Cairo verifier lockfile is "
+            f"missing at {adapter_lock}"
+        )
+    binary = _cairo_oracle_binary(candidate_root, adapter)
+    if not binary.is_file():
+        try:
+            _run(build_command, candidate_root, timeout=CAIRO_ORACLE_BUILD_TIMEOUT)
+        except RunError as exc:
+            # A judged Cairo run that cannot build its final validator fails —
+            # it never degrades to an unverified pass. The adapter compiles the
+            # pinned upstream, which needs the Rust toolchain that upstream
+            # requires; provision the judge host's default toolchain for it.
+            raise RunError(
+                f"{workload.workload_id}: the pinned official Cairo verifier "
+                f"failed to build ({build_command}): {exc}"
+            ) from exc
+    if not binary.is_file():
+        raise RunError(
+            f"{workload.workload_id}: the pinned official Cairo verifier was "
+            f"not produced at {binary}; a judged Cairo run never proceeds "
+            "without its final validator"
+        )
+    binary_sha256 = hashlib.sha256(binary.read_bytes()).hexdigest()
+
+    try:
+        envelope_path, proof_path = _latest_cairo_candidate_artifact(out_dir, workload)
+        envelope = _load_json_object(
+            envelope_path.read_text(encoding="utf-8"),
+            "candidate Cairo measurement envelope",
+        )
+        if envelope.get("schema") != group.report_schema:
+            raise ValueError("candidate envelope is not a cairo_proof_v1 envelope")
+        if envelope.get("workload") != workload.workload_id:
+            raise ValueError("candidate envelope names a different workload")
+        mechanism = envelope.get("mechanism")
+        if not isinstance(mechanism, dict):
+            raise ValueError("candidate envelope carries no mechanism telemetry")
+        scored_digest = _sha256_hex(
+            mechanism.get("proof_sha256"), "envelope mechanism proof_sha256",
+        )
+        scored_bytes = _nonnegative_integer(
+            mechanism.get("proof_bytes"), "envelope mechanism proof_bytes",
+            positive=True,
+        )
+        proof_format = mechanism.get("proof_format")
+        transport = CAIRO_ORACLE_TRANSPORTS.get(proof_format)
+        if transport is None:
+            raise ValueError(
+                f"proof format {proof_format!r} has no official Rust verifier "
+                "transport; the Cairo-serde felt array targets the Cairo "
+                "verifier and is rejected by this adapter"
+            )
+        artifact_bytes = proof_path.read_bytes()
+        if len(artifact_bytes) != scored_bytes:
+            raise ValueError(
+                "retained candidate proof length differs from the scored proof"
+            )
+        if hashlib.sha256(artifact_bytes).hexdigest() != scored_digest:
+            raise ValueError(
+                "retained candidate proof bytes differ from the scored proof"
+            )
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+        raise RunError(
+            f"{workload.workload_id}: invalid retained Cairo candidate proof: {exc}"
+        ) from exc
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    identity_raw = _run(
+        shlex.join([str(binary), "identity"]),
+        candidate_root,
+        timeout=CAIRO_ORACLE_VERIFY_TIMEOUT,
+    )
+    try:
+        identity = _validate_cairo_oracle_identity(
+            identity_raw, oracle_policy, binary, adapter_lock,
+        )
+    except (json.JSONDecodeError, TypeError, ValueError) as exc:
+        raise RunError(
+            f"{workload.workload_id}: unpinned official Cairo verifier: {exc}"
+        ) from exc
+
+    verdict_path = (
+        out_dir / f"{workload.workload_id}.cairo-oracle-verdict.json"
+    ).resolve()
+    # The adapter publishes its verdict immutably and refuses an existing path.
+    verdict_path.unlink(missing_ok=True)
+    _run(
+        shlex.join([
+            str(binary), "verify",
+            "--proof", str(proof_path),
+            "--channel", CAIRO_ORACLE_CHANNEL,
+            "--proof-format", transport,
+            "--result", str(verdict_path),
+        ]),
+        candidate_root,
+        timeout=CAIRO_ORACLE_VERIFY_TIMEOUT,
+    )
+    try:
+        verdict = _validate_cairo_verdict(
+            verdict_path.read_text(encoding="utf-8"),
+            oracle_policy,
+            transport,
+            scored_digest,
+        )
+    except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
+        raise RunError(
+            f"{workload.workload_id}: invalid official Cairo verdict: {exc}"
+        ) from exc
+    if hashlib.sha256(binary.read_bytes()).hexdigest() != binary_sha256:
+        raise RunError(
+            f"{workload.workload_id}: the official Cairo verifier changed "
+            "during validation"
+        )
+    if proof_path.read_bytes() != artifact_bytes:
+        raise RunError(
+            f"{workload.workload_id}: the retained Cairo proof changed during "
+            "validation"
+        )
+    return {
+        "workload": workload.workload_id,
+        "verified": True,
+        "oracle": CAIRO_ORACLE_AUTHORITY,
+        "oracle_commit": oracle_policy["commit"],
+        "oracle_stwo_commit": oracle_policy["stwo_commit"],
+        "oracle_binary_sha256": binary_sha256,
+        "oracle_cargo_lock_sha256": identity["cargo_lock_sha256"],
+        "channel": CAIRO_ORACLE_CHANNEL,
+        "proof_format": transport,
+        "proof_sha256": scored_digest,
+        "proof_bytes": scored_bytes,
+        "verdict_path": str(verdict_path),
+        "verdict_wall_time_ns": verdict["wall_time_ns"],
+    }
 
 
 def guard_registry(manifest: Manifest) -> dict:

--- a/autoresearch/schema/cairo-proof-v1.md
+++ b/autoresearch/schema/cairo-proof-v1.md
@@ -284,6 +284,95 @@ Those revisions are the ones declared by
 scalar, SIMD, Metal, trace-oracle, or Zig-verifier agreement never overrides an
 official-verifier rejection.
 
+### How the judged path runs it
+
+`runner.rust_oracle_check` dispatches `cairo_proof_v1` to
+`_cairo_official_verifier_check`, which is the same authority the Cairo build
+gates run (`build_support/products/cairo_cpu/oracle_gate.zig`) — the harness
+just runs the release profile instead of the gate's debug one.
+
+It verifies the **retained candidate proof**, not a freshly minted one:
+`_latest_cairo_candidate_artifact` picks the last measured sample of the last
+candidate round (`<workload>.b<round>.i<index>.proof`) and requires its bytes to
+hash to the `proof_sha256` and match the `proof_bytes` recorded in that round's
+`cairo_proof_v1` envelope. The bytes the official verifier accepts are exactly
+the bytes that were scored.
+
+```sh
+# 1. only if the release binary is absent — the manifest owns the flags, and
+#    the harness refuses a build_command that is not a locked release build of
+#    the pinned adapter manifest.
+cargo build --locked --release \
+  --manifest-path tools/stwo-cairo-official-verifier-rs/Cargo.toml
+
+# 2. bind the built adapter to the pins and the committed lockfile
+tools/stwo-cairo-official-verifier-rs/target/release/stwo-cairo-official-verifier identity
+
+# 3. verify the retained scored proof
+tools/stwo-cairo-official-verifier-rs/target/release/stwo-cairo-official-verifier verify \
+  --proof   <out_dir>/<workload>.b<round>.i<index>.proof \
+  --channel  blake2s \
+  --proof-format json \
+  --result  <out_dir>/<workload>.cairo-oracle-verdict.json
+```
+
+The `identity` response must be `schema_version: 1`, `adapter_version:
+stwo-cairo-official-verifier/1`, carry `stwo_cairo` / `stwo` repository and
+revision equal to the manifest pins, a `cargo_lock_sha256` equal to the
+committed `Cargo.lock` (proving the adapter was built from the pinned
+dependency graph), an `executable_sha256` equal to the binary the harness just
+ran, and the `blake2s` channel among its supported channels.
+
+The verdict is validated field-for-field against an exact key set:
+`verified: true`, `error: null`, `schema_version: 1`, both revisions equal to
+the manifest pins, `channel` and `proof_format` equal to what was requested, and
+`proof_sha256` equal to the scored proof digest. The adapter binary is re-hashed
+afterwards and the retained proof is re-read, so neither can change during
+validation.
+
+**Judge-host provisioning.** The adapter package pins no toolchain of its own,
+so the manifest's `build_command` runs under the host's *default* toolchain and
+that default must be able to compile the pinned upstream. Measured on
+2026-07-29: `stable` fails (`stwo-cairo-common` uses the unstable `lazy_get`
+feature) and `nightly-2025-07-14` — the toolchain the Native/CUDA oracle pins —
+fails on a `ruint` const-fn that is too new for it; `nightly-2026-01-29` builds
+it. The judged path treats a build failure as a hard failure with the command in
+the message, never as a skip. The same constraint already applies to the
+`test-cairo-cpu-oracle` build gate, which invokes plain `cargo build --locked`.
+
+Adapter exit codes are load-bearing: `0` accepted, `3` rejected, `2` adapter or
+invocation failure. `_run` raises on any non-zero status, so a rejection and an
+adapter failure both fail the judged run. **There is no skip**: an absent
+adapter, a build that produces no binary, a missing lockfile, an unpinned oracle
+block, or an unverifiable transport all raise instead of returning a pass.
+
+Transport mapping: `json` → `json`, `binary` → `binary`. The `cairo-serde` proof
+format has no Rust-verifier transport — the felt array targets the Cairo
+verifier and this adapter deliberately rejects it — so a `cairo-serde` workload
+fails closed rather than going unverified.
+
+### Cross-arm mechanism drift
+
+`paired_rounds` compares `manifest.CAIRO_STABLE_MECHANISM_FIELDS` between the A
+and B arms of every round and against the first round's values:
+
+| field | what it pins |
+|---|---|
+| `input_sha256` | the statement — both arms proved the same prover input |
+| `proof_sha256`, `proof_bytes`, `proof_format` | the proof identity and transport |
+| `stwo_cairo_revision`, `stwo_revision` | both arms are the same pinned official lane |
+| `profile` | the same proving-profile manifest and preprocessed variant |
+
+Backend identity does not need a separate stable field: `_parse_cairo_report`
+already requires `report.backend == product.backend` and `product.name ==
+basename(group.binary)` per sample, so an arm cannot silently be a different
+product. Counters that a legitimate optimization may move — `metal_dispatches`
+— are reported but deliberately not stable-compared; `cpu_fallbacks` is pinned
+to zero at parse time.
+
+An absent mechanism, a mechanism missing any stable field, an A/B divergence, or
+a between-round change all raise `RunError`, exactly as on the RISC-V track.
+
 ## Promotion
 
 Neither Cairo board is promotion eligible. `cairo_cpu` runs and records

--- a/autoresearch/tests/test_cairo_boards.py
+++ b/autoresearch/tests/test_cairo_boards.py
@@ -12,6 +12,7 @@ import stat
 import sys
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "cli"))
@@ -53,6 +54,54 @@ print(json.dumps(REPORT))
 '''
 
 
+FAKE_ORACLE = '''#!/usr/bin/env python3
+import hashlib
+import json
+import sys
+
+IDENTITY = json.loads(IDENTITY_JSON)
+IDENTITY_OVERRIDES = json.loads(IDENTITY_OVERRIDES_JSON)
+VERDICT_OVERRIDES = json.loads(VERDICT_OVERRIDES_JSON)
+REJECT = REJECT_FLAG
+
+
+def digest(path):
+    with open(path, "rb") as handle:
+        return hashlib.sha256(handle.read()).hexdigest()
+
+
+args = sys.argv[1:]
+if args and args[0] == "identity":
+    IDENTITY["executable_sha256"] = digest(sys.argv[0])
+    IDENTITY.update(IDENTITY_OVERRIDES)
+    print(json.dumps(IDENTITY))
+    sys.exit(0)
+if not args or args[0] != "verify":
+    sys.exit(2)
+proof = args[args.index("--proof") + 1]
+channel = args[args.index("--channel") + 1]
+proof_format = args[args.index("--proof-format") + 1]
+result = args[args.index("--result") + 1]
+verdict = {
+    "schema_version": 1,
+    "adapter_version": "stwo-cairo-official-verifier/1",
+    "stwo_cairo_revision": STWO_CAIRO_REV,
+    "stwo_revision": STWO_REV,
+    "proof_sha256": digest(proof),
+    "channel": channel,
+    "proof_format": proof_format,
+    "verified": not REJECT,
+    "wall_time_ns": 1234,
+    "error": "proof rejected by verify_cairo" if REJECT else None,
+}
+verdict.update(VERDICT_OVERRIDES)
+# The real adapter publishes immutably and refuses an existing result path.
+with open(result, "x") as handle:
+    json.dump(verdict, handle)
+sys.exit(3 if REJECT else 0)
+'''
+
+
 def load_report() -> dict:
     return json.loads((FIXTURES / "cairo_product_report_v2.json").read_text())
 
@@ -77,7 +126,10 @@ def cairo_group_spec(**overrides) -> dict:
             "stwo_repository": "https://github.com/starkware-libs/stwo",
             "stwo_commit": PINNED_STWO,
             "adapter": "tools/stwo-cairo-official-verifier-rs",
-            "build_command": "cargo build --locked --release",
+            "build_command": (
+                "cargo build --locked --release --manifest-path "
+                "tools/stwo-cairo-official-verifier-rs/Cargo.toml"
+            ),
             "final_validator": True,
         },
         "gates_policy": {
@@ -701,6 +753,438 @@ class CairoBenchOnceTest(unittest.TestCase):
             runner.bench_once(
                 self.root, self.manifest, self.workload, 1, 1, self.out_dir, "a1",
             )
+
+
+class CairoOfficialVerifierOracleTest(unittest.TestCase):
+    """The judged path independently verifies the scored proof, or it fails.
+
+    TRACKS §8 wave 1: the official-verifier oracle the Cairo build gates run is
+    wired into the harness. Every negative below must fail closed — there is no
+    configuration in which a judged Cairo run silently skips its final
+    validator.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.out_dir = self.root / "runs"
+        self.raw = raw_manifest()
+        manifest_mod._validate(self.raw)
+        self.manifest = Manifest(root=self.root, raw=self.raw)
+        self.group = self.manifest.group("cairo_cpu")
+        self.workload = self.manifest.workloads(board="cairo_cpu")[0]
+        self._install_product()
+        self._install_oracle()
+        self._measure()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    # -- fixtures ---------------------------------------------------------
+
+    def _install_product(self, payload: bytes = b"proof-bytes"):
+        binary = self.root / "bin" / "stwo-cairo-cpu"
+        binary.parent.mkdir(parents=True, exist_ok=True)
+        binary.write_text(
+            FAKE_PRODUCT
+            .replace("REPORT_JSON", repr(json.dumps(load_report())))
+            .replace("PROFILE_JSON", repr(json.dumps(load_profile())))
+            .replace("PROOF_PAYLOAD", repr(payload))
+            .replace("MUTATE", "pass")
+        )
+        binary.chmod(binary.stat().st_mode | stat.S_IEXEC)
+
+    def _adapter_dir(self) -> Path:
+        return self.root / "tools" / "stwo-cairo-official-verifier-rs"
+
+    def _install_oracle(self, *, identity_overrides=None, verdict_overrides=None,
+                        reject=False, install=True) -> Path:
+        adapter = self._adapter_dir()
+        (adapter / "target" / "release").mkdir(parents=True, exist_ok=True)
+        lock = adapter / "Cargo.lock"
+        if not lock.exists():
+            lock.write_bytes(b"# pinned official verifier lockfile fixture\n")
+        binary = adapter / "target" / "release" / "stwo-cairo-official-verifier"
+        if not install:
+            binary.unlink(missing_ok=True)
+            return binary
+        identity = {
+            "schema_version": 1,
+            "adapter_version": "stwo-cairo-official-verifier/1",
+            "stwo_cairo": {
+                "repository": "https://github.com/starkware-libs/stwo-cairo",
+                "revision": PINNED_STWO_CAIRO,
+            },
+            "stwo": {
+                "repository": "https://github.com/starkware-libs/stwo",
+                "revision": PINNED_STWO,
+            },
+            "cargo_lock_sha256": hashlib.sha256(lock.read_bytes()).hexdigest(),
+            "executable_sha256": None,
+            "channels": ["blake2s", "blake2s_m31", "poseidon252"],
+            "proof_formats": ["json", "binary", "extended_binary"],
+            "max_proof_bytes": 2 << 30,
+            "prover_input_schema": "stwo_cairo_adapter::ProverInput@1.2.2",
+            "claim_summary_schema": "stwo_cairo_official_claim_summary_v1",
+            "max_input_bytes": 1 << 30,
+        }
+        source = (
+            FAKE_ORACLE
+            .replace("IDENTITY_JSON", repr(json.dumps(identity)))
+            .replace("IDENTITY_OVERRIDES_JSON",
+                     repr(json.dumps(identity_overrides or {})))
+            .replace("VERDICT_OVERRIDES_JSON",
+                     repr(json.dumps(verdict_overrides or {})))
+            .replace("REJECT_FLAG", repr(bool(reject)))
+            .replace("STWO_CAIRO_REV", repr(PINNED_STWO_CAIRO))
+            .replace("STWO_REV", repr(PINNED_STWO))
+        )
+        binary.write_text(source)
+        binary.chmod(binary.stat().st_mode | stat.S_IEXEC)
+        return binary
+
+    def _measure(self, tag: str = "b1"):
+        """Produce a retained candidate-arm envelope + proof, as a round would."""
+        return runner.bench_once(
+            self.root, self.manifest, self.workload, 1, 1, self.out_dir, tag,
+        )
+
+    def _check(self):
+        return runner.rust_oracle_check(
+            self.root, self.manifest, self.workload, self.out_dir,
+        )
+
+    def _reload(self):
+        manifest_mod._validate(self.raw)
+        self.manifest = Manifest(root=self.root, raw=self.raw)
+        self.group = self.manifest.group("cairo_cpu")
+
+    def _oracle_block(self) -> dict:
+        return self.raw["workload_registry"]["groups"]["cairo_cpu"][
+            "correctness_oracle"]
+
+    # -- retained artifact selection ---------------------------------------
+
+    def test_latest_candidate_artifact_is_the_last_scored_sample(self):
+        self._measure(tag="b2")
+        envelope, proof = runner._latest_cairo_candidate_artifact(
+            self.out_dir, self.workload,
+        )
+        self.assertEqual(envelope.name, "cairo_all_opcodes.b2.json")
+        self.assertEqual(proof.name, "cairo_all_opcodes.b2.i1.proof")
+
+    def test_no_retained_candidate_artifact_fails_closed(self):
+        for path in self.out_dir.iterdir():
+            path.unlink()
+        with self.assertRaisesRegex(
+            runner.RunError, "invalid retained Cairo candidate proof",
+        ):
+            self._check()
+
+    # -- happy path --------------------------------------------------------
+
+    def test_oracle_dispatch_verifies_the_scored_proof(self):
+        receipt = self._check()
+        self.assertIs(receipt["verified"], True)
+        self.assertEqual(receipt["oracle"], "official-stwo-cairo-verifier")
+        self.assertEqual(receipt["oracle_commit"], PINNED_STWO_CAIRO)
+        self.assertEqual(receipt["oracle_stwo_commit"], PINNED_STWO)
+        self.assertEqual(receipt["channel"], "blake2s")
+        self.assertEqual(receipt["proof_format"], "json")
+        self.assertEqual(receipt["workload"], "cairo_all_opcodes")
+        expected = hashlib.sha256(b"proof-bytes").hexdigest()
+        self.assertEqual(receipt["proof_sha256"], expected)
+        self.assertEqual(receipt["proof_bytes"], len(b"proof-bytes"))
+        lock = (self._adapter_dir() / "Cargo.lock").read_bytes()
+        self.assertEqual(
+            receipt["oracle_cargo_lock_sha256"],
+            hashlib.sha256(lock).hexdigest(),
+        )
+        verdict = json.loads(Path(receipt["verdict_path"]).read_text())
+        self.assertIs(verdict["verified"], True)
+        self.assertEqual(verdict["proof_sha256"], expected)
+
+    def test_verdict_path_is_republished_on_a_second_judged_pass(self):
+        first = self._check()
+        second = self._check()
+        self.assertEqual(first["verdict_path"], second["verdict_path"])
+        self.assertIs(second["verified"], True)
+
+    # -- fail-closed: the adapter itself -----------------------------------
+
+    def test_absent_adapter_that_cannot_build_fails_closed(self):
+        self._install_oracle(install=False)
+        self._oracle_block()["build_command"] = (
+            "true --locked --release --manifest-path "
+            "tools/stwo-cairo-official-verifier-rs/Cargo.toml"
+        )
+        self._reload()
+        with self.assertRaisesRegex(runner.RunError, "was not produced"):
+            self._check()
+
+    def test_failing_adapter_build_fails_closed(self):
+        self._install_oracle(install=False)
+        self._oracle_block()["build_command"] = (
+            "false --locked --release --manifest-path "
+            "tools/stwo-cairo-official-verifier-rs/Cargo.toml"
+        )
+        self._reload()
+        with self.assertRaisesRegex(runner.RunError, "failed to build"):
+            self._check()
+
+    def test_missing_lockfile_fails_closed(self):
+        (self._adapter_dir() / "Cargo.lock").unlink()
+        with self.assertRaisesRegex(runner.RunError, "lockfile is missing"):
+            self._check()
+
+    def test_unlocked_or_debug_build_command_is_refused(self):
+        for command in (
+            "cargo build --release --manifest-path "
+            "tools/stwo-cairo-official-verifier-rs/Cargo.toml",
+            "cargo build --locked --manifest-path "
+            "tools/stwo-cairo-official-verifier-rs/Cargo.toml",
+            "cargo build --locked --release --manifest-path other/Cargo.toml",
+        ):
+            self._oracle_block()["build_command"] = command
+            self._reload()
+            with self.assertRaisesRegex(runner.RunError, "locked release build"):
+                self._check()
+
+    def test_unpinned_oracle_block_is_refused(self):
+        for mutation in (
+            {"authority": "pinned-rust-stwo"},
+            {"adapter": "tools/stwo-interop-rs"},
+            {"final_validator": False},
+            {"commit": "82f21252"},
+            {"stwo_commit": "7b211edd"},
+        ):
+            raw = raw_manifest()
+            raw["workload_registry"]["groups"]["cairo_cpu"][
+                "correctness_oracle"].update(mutation)
+            group = Manifest(self.root, raw).group("cairo_cpu")
+            with self.assertRaisesRegex(runner.RunError, "final validator"):
+                runner._cairo_official_verifier_check(
+                    self.root, group, self.workload, self.out_dir,
+                )
+
+    # -- fail-closed: adapter identity -------------------------------------
+
+    def test_identity_must_bind_the_committed_lockfile(self):
+        self._install_oracle(identity_overrides={"cargo_lock_sha256": "a" * 64})
+        with self.assertRaisesRegex(runner.RunError, "committed lockfile"):
+            self._check()
+
+    def test_identity_must_bind_the_executed_binary(self):
+        self._install_oracle(identity_overrides={"executable_sha256": "b" * 64})
+        with self.assertRaisesRegex(runner.RunError, "bind the executed binary"):
+            self._check()
+
+    def test_identity_must_carry_the_manifest_pins(self):
+        self._install_oracle(identity_overrides={
+            "stwo_cairo": {
+                "repository": "https://github.com/starkware-libs/stwo-cairo",
+                "revision": "c" * 40,
+            },
+        })
+        with self.assertRaisesRegex(runner.RunError, "manifest-pinned commit"):
+            self._check()
+        self._install_oracle(identity_overrides={
+            "stwo": {
+                "repository": "https://github.com/example/fork",
+                "revision": PINNED_STWO,
+            },
+        })
+        with self.assertRaisesRegex(runner.RunError, "manifest-pinned repository"):
+            self._check()
+
+    def test_identity_schema_and_adapter_version_are_pinned(self):
+        self._install_oracle(identity_overrides={"schema_version": 2})
+        with self.assertRaisesRegex(runner.RunError, "identity schema is unsupported"):
+            self._check()
+        self._install_oracle(
+            identity_overrides={"adapter_version": "stwo-cairo-official-verifier/2"},
+        )
+        with self.assertRaisesRegex(runner.RunError, "adapter version is unsupported"):
+            self._check()
+
+    def test_identity_without_the_scored_channel_is_refused(self):
+        self._install_oracle(identity_overrides={"channels": ["poseidon252"]})
+        with self.assertRaisesRegex(runner.RunError, "blake2s channel"):
+            self._check()
+
+    # -- fail-closed: the proof bytes --------------------------------------
+
+    def test_tampered_retained_proof_is_refused(self):
+        _envelope, proof = runner._latest_cairo_candidate_artifact(
+            self.out_dir, self.workload,
+        )
+        proof.write_bytes(b"tampered!!!")
+        with self.assertRaisesRegex(runner.RunError, "differ from the scored proof"):
+            self._check()
+
+    def test_truncated_retained_proof_is_refused(self):
+        _envelope, proof = runner._latest_cairo_candidate_artifact(
+            self.out_dir, self.workload,
+        )
+        proof.write_bytes(b"short")
+        with self.assertRaisesRegex(runner.RunError, "length differs"):
+            self._check()
+
+    def test_cairo_serde_transport_has_no_rust_verifier(self):
+        envelope_path, _proof = runner._latest_cairo_candidate_artifact(
+            self.out_dir, self.workload,
+        )
+        envelope = json.loads(envelope_path.read_text())
+        envelope["mechanism"]["proof_format"] = "cairo-serde"
+        envelope_path.write_text(json.dumps(envelope))
+        with self.assertRaisesRegex(runner.RunError, "targets the Cairo"):
+            self._check()
+
+    def test_foreign_envelope_is_refused(self):
+        envelope_path, _proof = runner._latest_cairo_candidate_artifact(
+            self.out_dir, self.workload,
+        )
+        envelope = json.loads(envelope_path.read_text())
+        envelope["schema"] = "riscv_proof_v2"
+        envelope_path.write_text(json.dumps(envelope))
+        with self.assertRaisesRegex(runner.RunError, "not a cairo_proof_v1 envelope"):
+            self._check()
+
+    # -- fail-closed: the verdict ------------------------------------------
+
+    def test_rejected_proof_fails_the_run(self):
+        self._install_oracle(reject=True)
+        with self.assertRaises(runner.RunError):
+            self._check()
+
+    def test_verdict_claiming_success_for_other_bytes_is_refused(self):
+        self._install_oracle(verdict_overrides={"proof_sha256": "d" * 64})
+        with self.assertRaisesRegex(runner.RunError, "verdict proof_sha256 differs"):
+            self._check()
+
+    def test_verdict_from_an_unpinned_revision_is_refused(self):
+        self._install_oracle(verdict_overrides={"stwo_cairo_revision": "e" * 40})
+        with self.assertRaisesRegex(
+            runner.RunError, "verdict stwo_cairo_revision differs",
+        ):
+            self._check()
+
+    def test_verdict_with_an_error_is_refused(self):
+        self._install_oracle(verdict_overrides={"error": "soft failure"})
+        with self.assertRaisesRegex(runner.RunError, "verdict error differs"):
+            self._check()
+
+    def test_verdict_field_set_is_exact(self):
+        self._install_oracle(verdict_overrides={"extra": 1})
+        with self.assertRaisesRegex(runner.RunError, "invalid official Cairo verdict"):
+            self._check()
+
+
+class CairoMechanismDriftTest(unittest.TestCase):
+    """A/B pairs with diverging Cairo mechanisms fail closed, like RISC-V."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.out_dir = self.root / "runs"
+        raw = raw_manifest()
+        manifest_mod._validate(raw)
+        self.manifest = Manifest(root=self.root, raw=raw)
+        self.workload = self.manifest.workloads(board="cairo_cpu")[0]
+        self.policy = self.manifest.gates_for_workload("cairo_cpu", "small")
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+        self.a_report = self.out_dir / "a.json"
+        self.b_report = self.out_dir / "b.json"
+        self.a_report.write_text('{"arm": "a"}')
+        self.b_report.write_text('{"arm": "b"}')
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    @staticmethod
+    def _mechanism(**overrides) -> dict:
+        stable = {
+            "profile": "official-live-cairo-canonical-small",
+            "input_sha256": "1" * 64,
+            "proof_format": "json",
+            "proof_bytes": 4096,
+            "proof_sha256": "2" * 64,
+            "stwo_cairo_revision": PINNED_STWO_CAIRO,
+            "stwo_revision": PINNED_STWO,
+        }
+        stable.update(overrides)
+        return stable
+
+    def _arms(self, a_mechanism, b_mechanism):
+        a = runner.ArmResult(
+            1.0, 1, True, None, str(self.a_report), proof_digest="3" * 64,
+            proof_bytes=4096, request_ms=2.0, mechanism=a_mechanism,
+        )
+        b = runner.ArmResult(
+            1.0, 1, True, None, str(self.b_report), proof_digest="3" * 64,
+            proof_bytes=4096, request_ms=2.0, mechanism=b_mechanism,
+        )
+        return a, b
+
+    def _run_pair(self, a, b):
+        with mock.patch.object(runner, "bench_once", side_effect=[a, b] * 8):
+            return runner.paired_rounds(
+                self.root, self.root, self.manifest, self.workload,
+                self.policy, self.out_dir,
+            )
+
+    def test_cairo_is_bound_to_a_stable_mechanism_contract(self):
+        label, fields = runner.STABLE_MECHANISM_FIELDS_BY_SCHEMA["cairo_proof_v1"]
+        self.assertEqual(label, "Cairo")
+        self.assertEqual(fields, manifest_mod.CAIRO_STABLE_MECHANISM_FIELDS)
+
+    def test_matching_mechanisms_verify(self):
+        a, b = self._arms(self._mechanism(), self._mechanism())
+        score = self._run_pair(a, b)
+        self.assertIs(score.mechanism_verified, True)
+
+    def test_diverging_statement_identity_fails_closed(self):
+        a, b = self._arms(
+            self._mechanism(), self._mechanism(input_sha256="9" * 64),
+        )
+        with self.assertRaisesRegex(
+            runner.RunError, "semantic mechanism telemetry differs",
+        ):
+            self._run_pair(a, b)
+
+    def test_diverging_proof_identity_fails_closed(self):
+        a, b = self._arms(
+            self._mechanism(), self._mechanism(proof_sha256="9" * 64),
+        )
+        with self.assertRaisesRegex(
+            runner.RunError, "semantic mechanism telemetry differs",
+        ):
+            self._run_pair(a, b)
+
+    def test_diverging_upstream_revision_fails_closed(self):
+        a, b = self._arms(
+            self._mechanism(), self._mechanism(stwo_revision="a" * 40),
+        )
+        with self.assertRaisesRegex(
+            runner.RunError, "semantic mechanism telemetry differs",
+        ):
+            self._run_pair(a, b)
+
+    def test_absent_mechanism_fails_closed(self):
+        a, b = self._arms(None, None)
+        with self.assertRaisesRegex(
+            runner.RunError, "Cairo mechanism telemetry is absent",
+        ):
+            self._run_pair(a, b)
+
+    def test_incomplete_mechanism_fails_closed(self):
+        partial = self._mechanism()
+        partial.pop("proof_sha256")
+        a, b = self._arms(partial, dict(partial))
+        with self.assertRaisesRegex(
+            runner.RunError, "omits stable field\\(s\\): proof_sha256",
+        ):
+            self._run_pair(a, b)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The two items PR #145 deliberately deferred. `runner.py` + tests only, plus the `cairo_proof_v1` schema doc.

## 1. Official-verifier oracle on the judged path

TRACKS §8 wave 1: *"wire the official-verifier oracle from build gates into the harness."* `rust_oracle_check` now dispatches `cairo_proof_v1` to `_cairo_official_verifier_check` — the same authority `build_support/products/cairo_cpu/oracle_gate.zig` runs, at the release profile instead of the gate's debug one.

It verifies the **retained candidate proof**, not a freshly minted one. `_latest_cairo_candidate_artifact` picks the last measured sample of the last candidate round (`<workload>.b<round>.i<index>.proof`) and requires its bytes to hash to the `proof_sha256` and match the `proof_bytes` recorded in that round's `cairo_proof_v1` envelope — so the bytes the official verifier accepts are the bytes that were scored.

```sh
# only when the release binary is absent; the manifest owns the flags
cargo build --locked --release \
  --manifest-path tools/stwo-cairo-official-verifier-rs/Cargo.toml

tools/.../target/release/stwo-cairo-official-verifier identity

tools/.../target/release/stwo-cairo-official-verifier verify \
  --proof   <out_dir>/<workload>.b<round>.i<index>.proof \
  --channel  blake2s \
  --proof-format json \
  --result  <out_dir>/<workload>.cairo-oracle-verdict.json
```

`identity` must bind the manifest pins (`stwo_cairo` / `stwo` repository + revision), the committed `Cargo.lock` (`cargo_lock_sha256`), and the binary just executed (`executable_sha256`), and must offer the `blake2s` channel. The verdict is validated field-for-field against an exact key set: `verified: true`, `error: null`, both revisions, the requested channel/format, and `proof_sha256` equal to the scored digest. The adapter is re-hashed and the proof re-read afterwards.

**No skip exists.** Unpinned oracle block, a `build_command` that is not a locked release build of the pinned adapter manifest, a missing lockfile, a build that fails or produces no binary, an unpinned identity, a transport with no Rust verifier (`cairo-serde` targets the Cairo verifier and is refused), a rejection (exit 3), an adapter failure (exit 2), a mismatched verdict, or an adapter/proof that changes mid-validation — all raise `RunError`.

## 2. Cross-arm mechanism drift for Cairo

`paired_rounds` compares stable mechanism telemetry for `cairo_proof_v1` exactly as it already did for `riscv_proof_v2`, via a `schema -> (label, fields)` table (`STABLE_MECHANISM_FIELDS_BY_SCHEMA`). RISC-V behaviour is unchanged; the riscv-only resource-availability block stays riscv-only.

Cairo's stable set is `manifest.CAIRO_STABLE_MECHANISM_FIELDS`:

| field | what it pins |
|---|---|
| `input_sha256` | the statement — both arms proved the same prover input |
| `proof_sha256`, `proof_bytes`, `proof_format` | proof identity and transport |
| `stwo_cairo_revision`, `stwo_revision` | both arms are the same pinned official lane |
| `profile` | same proving profile and preprocessed variant |

Backend identity needs no separate field: `_parse_cairo_report` already requires `report.backend == product.backend` and `product.name == basename(group.binary)` per sample, and pins `cpu_fallbacks` to zero. `metal_dispatches` is reported but deliberately not stable-compared — a legitimate optimization may move it.

The guard now also rejects an *incomplete* mechanism dict instead of comparing two identical `None`s.

## Verified

- **Real end-to-end**, not just fakes: built the pinned adapter and it accepted a genuine Zig-produced all-opcodes proof (`verified: true`, verdict wall time 19.76 ms, proof `79ae76e1…cb310`), then rejected the same proof with one byte flipped. The adapter's real `identity` output matches the exact key set the parser requires, field for field.
- `python3 -m unittest discover -s autoresearch/tests` → **536 OK** (506 baseline + 30 new).

## Judge-host provisioning (recorded in the schema doc)

The adapter package pins no toolchain of its own, so the manifest's `build_command` runs under the host's **default** toolchain and that default must compile the pinned upstream. Measured today: `stable` fails (`stwo-cairo-common` uses the unstable `lazy_get`), `nightly-2025-07-14` (what the Native/CUDA oracle pins) fails on a `ruint` const-fn that is too new for it, `nightly-2026-01-29` builds it. The same constraint already applies to the `test-cairo-cpu-oracle` build gate, which also invokes plain `cargo build --locked`.

## Untouched

`__main__.py` (W4), `MANIFEST.json`, `manifest.py`, `ledger.py`, W2's ladder machinery, `conformance/performance-authority/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
