### PR TITLE
W3: per-board eras + native retire-and-complete + feed v4 (TRACKS §6/§7/§8/§9)

### DIFF
--- a/autoresearch/MANIFEST.json
+++ b/autoresearch/MANIFEST.json
@@ -278,7 +278,13 @@
     "groups": {
       "native": {
         "enabled": true,
-        "promotion_eligible": true,
+        "promotion_eligible": false,
+        "promotion_blocked_reason": "TRACKS §6 retire-and-complete: the native CPU era is banked. New promotions refuse; the board stays enabled so its history, final scores, guard workloads, and PR6-supremacy cells keep running.",
+        "retirement": {
+          "retired_at_utc": "2026-07-29T00:00:00Z",
+          "reason": "TRACKS §6 retire-and-complete: the native era is banked; history stays served; the native AIRs continue as PR6-supremacy cells and guard workloads",
+          "closing_audit": null
+        },
         "board": "core_cpu",
         "build_step": "zig build native-proof-bench-cpu -Doptimize=ReleaseFast",
         "binary": "zig-out/bin/native-proof-bench-cpu",
@@ -513,7 +519,13 @@
       },
       "metal": {
         "enabled": true,
-        "promotion_eligible": true,
+        "promotion_eligible": false,
+        "promotion_blocked_reason": "TRACKS §6 retire-and-complete: the native Metal era is banked. New promotions refuse; the board stays enabled so its history, final scores, guard workloads, and PR6-supremacy cells keep running.",
+        "retirement": {
+          "retired_at_utc": "2026-07-29T00:00:00Z",
+          "reason": "TRACKS §6 retire-and-complete: the native era is banked; history stays served; the native AIRs continue as PR6-supremacy cells and guard workloads",
+          "closing_audit": null
+        },
         "board": "core_metal",
         "build_step": "zig build native-proof-bench-metal -Doptimize=ReleaseFast",
         "binary": "zig-out/bin/native-proof-bench-metal",

--- a/autoresearch/cli/stwo_perf/audits.py
+++ b/autoresearch/cli/stwo_perf/audits.py
@@ -82,7 +82,9 @@ def _item(
     ledger_sha256: str,
     commit_resolver: Callable[[str], str],
 ) -> dict | None:
-    epoch_spec = ledger.known_epochs(manifest.root)[epoch]
+    # TRACKS §7: the board's era, when it declares one, owns its audit anchor;
+    # the global epoch's anchor stays the fallback.
+    epoch_spec = ledger.epoch_for_board(manifest.root, epoch, board)
     policy = metrics.policy_from_epoch(epoch_spec)
     due = metrics.due_state(
         rows, epoch, board, workload_class, policy=policy,
@@ -93,9 +95,17 @@ def _item(
     group = manifest.group_for_board(board)
     gate_policy = manifest.gates_for_workload(group.group_id, workload_class)
     blocked = None
-    if not group.enabled or not group.promotion_eligible:
+    retirement = group.retirement or None
+    if retirement is not None and group.enabled:
+        # TRACKS §6 retire-and-complete: a retired board refuses new promotions
+        # but still owes the closing audit that stamps its last audited score.
+        # Auditing is not promoting, so promotion ineligibility cannot block it
+        # — once the closing audit is recorded, nothing further is due.
+        if retirement.get("closing_audit") is not None:
+            blocked = "retired board has already recorded its closing audit"
+    elif not group.enabled or not group.promotion_eligible:
         blocked = "workload group is not enabled and promotion eligible"
-    elif gate_policy.get("require_rust_oracle") is not True:
+    if blocked is None and gate_policy.get("require_rust_oracle") is not True:
         blocked = "workload gate policy does not require the pinned oracle"
 
     if due.direct_audit_due:
@@ -537,10 +547,12 @@ def append_signed(repo: Path, bundle: dict) -> int:
     existing = ledger.ledger_path(repo).read_text()
     proposed = existing + "".join(ledger.serialize_row(row) + "\n" for row in rows)
     parsed = ledger.parse(proposed)
-    epoch_spec = ledger.known_epochs(repo)[int(bundle["epoch"])]
-    policy = metrics.policy_from_epoch(epoch_spec)
     touched = {(row["board"], row["workload_class"]) for row in rows}
-    for board, workload_class in touched:
+    for board, workload_class in sorted(touched):
+        # Replay each touched cell under ITS board's era policy (TRACKS §7).
+        policy = metrics.policy_from_epoch(
+            ledger.epoch_for_board(repo, int(bundle["epoch"]), board)
+        )
         metrics.score_class(
             parsed,
             int(bundle["epoch"]),

--- a/autoresearch/cli/stwo_perf/feed.py
+++ b/autoresearch/cli/stwo_perf/feed.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from . import frontier, ledger, metrics, search_health
 from .manifest import Manifest
 
-FEED_SCHEMA_VERSION = 3
+FEED_SCHEMA_VERSION = 4
 
 REQUEST_RESOURCE_KEYS = {
     "measurement_scope",
@@ -33,6 +33,29 @@ REQUEST_RESOURCE_KEYS = {
     "complete",
     "unavailable_reason",
 }
+
+# Reserved measurement-lane identities and the scoring board each one belongs
+# to, per schema/scoring.md Boards 3/4/5. This is the repository's own
+# normative lane contract, not an inference: `cpu_native` is Board 3,
+# `metal_resident` (zero fallback, AOT-admitted) is Board 4, and today's
+# best-effort `metal_hybrid` lane is Board 5. A lane whose backend identity is
+# not in this table gets a null board rather than a guess.
+LANE_BACKEND_BOARDS = {
+    "cpu_native": "core_cpu",
+    "metal_resident": "core_metal",
+    "metal_hybrid": "core_hybrid",
+}
+
+# TRACKS §3.2 phase telemetry. A phase-bearing artifact is COMMITTED evidence
+# with the named cutpoints already measured; the feed passes it through and
+# never derives, interpolates, or zero-fills one. Drop point and required
+# shape are documented in schema/site-feed.md.
+PHASE_TELEMETRY_DIR = ("autoresearch", "reference", "phase-telemetry")
+PHASE_TELEMETRY_REQUIRED = (
+    "board", "report_schema", "measurement_boundary", "phase_profile_source",
+    "phase_seconds",
+)
+PHASE_TELEMETRY_OPTIONAL = ("run_id", "workload", "workload_class", "mechanism")
 
 # Input roots whose uncommitted changes make a feed provenance-dishonest.
 INPUT_ROOTS = (
@@ -158,11 +181,20 @@ def _lane_summary(lane: dict) -> dict:
     prove_s = _median(metrics.get("prove_seconds"))
     request_s = _median(metrics.get("request_seconds"))
     rss_kib = _median(metrics.get("peak_rss_kib"))
+    backend = lane.get("backend")
     out = {
         "prove_ms": round(prove_s * 1000.0, 6) if prove_s is not None else None,
         "native_mhz": _median(metrics.get("native_mhz")),
         "request_ms": round(request_s * 1000.0, 6) if request_s is not None else None,
         "peak_rss_mib": round(rss_kib / 1024.0, 2) if rss_kib is not None else None,
+        # Backend identity verbatim from the committed report, plus the board
+        # the repository's own scoring contract assigns to it. Consumers must
+        # stop inferring tracks from lane KEY names ("cpu"/"metal"): the metal
+        # lane reports `metal_hybrid`, which is Board 5 (core_hybrid), NOT the
+        # zero-fallback Board 4 (core_metal). An unrecognised backend publishes
+        # a null board — never a guess.
+        "backend": backend if isinstance(backend, str) else None,
+        "board": LANE_BACKEND_BOARDS.get(backend) if isinstance(backend, str) else None,
     }
     fallbacks = _sample_counter(telemetry, "cpu_fallbacks")
     if fallbacks is not None:
@@ -267,7 +299,9 @@ def _promotion_scope(manifest: Manifest) -> dict:
             "enabled": group.enabled,
             "promotion_eligible": group.promotion_eligible,
             "disabled_reason": group.disabled_reason,
+            "promotion_blocked_reason": group.promotion_blocked_reason,
             "report_schema": group.report_schema,
+            "retirement": dict(group.retirement) or None,
             "workloads": {
                 w.workload_id: {"class": w.workload_class, "native_unit": w.native_unit}
                 for w in group.workloads
@@ -275,6 +309,11 @@ def _promotion_scope(manifest: Manifest) -> dict:
         }
     owned = sorted({g.board for g in manifest.groups() if g.promotion_eligible})
     staged = sorted({g.board for g in manifest.groups() if not g.promotion_eligible})
+    # TRACKS §6: a retired board is completed, not future. It must never fall
+    # into `future_boards`, whose contract is "out of scope, never live" — that
+    # would erase the banked native era exactly the way removing it from
+    # ledger.BOARDS would.
+    retired = sorted({g.board for g in manifest.groups() if g.retirement})
     return {
         "class_registry": {
             cls.name: {
@@ -289,7 +328,8 @@ def _promotion_scope(manifest: Manifest) -> dict:
         "groups": groups,
         "owned_boards": owned,
         "staged_boards": staged,
-        "future_boards": sorted(set(ledger.BOARDS) - set(owned)),
+        "retired_boards": retired,
+        "future_boards": sorted(set(ledger.BOARDS) - set(owned) - set(retired)),
         "baselines": {
             "riscv": "vectors/reports/riscv_baselines/",
             "core_cpu": "vectors/reports/benchmark_history/",
@@ -372,17 +412,131 @@ def _audit_state(
     }
 
 
+def _phase_telemetry_files(repo: Path) -> list[Path]:
+    directory = repo.joinpath(*PHASE_TELEMETRY_DIR)
+    return sorted(directory.glob("*.json")) if directory.is_dir() else []
+
+
+def _phase_telemetry(repo: Path) -> dict[str, dict]:
+    """Board-keyed phase-cutpoint telemetry from committed artifacts only.
+
+    TRACKS §3.2 makes the named cutpoints mandatory telemetry and forbids
+    scoring them. The feed therefore publishes them verbatim from committed,
+    digest-bound artifacts and publishes NOTHING for a board that has none —
+    an absent board is an honest "not yet measured", never a zero-filled
+    decomposition. Every field is validated before publication, so a malformed
+    artifact fails the feed rather than reaching a consumer.
+    """
+    out: dict[str, dict] = {}
+    for path in _phase_telemetry_files(repo):
+        try:
+            document = json.loads(path.read_text())
+        except json.JSONDecodeError as exc:
+            raise FeedError(f"phase telemetry {path.name} is not valid JSON: {exc}")
+        if not isinstance(document, dict):
+            raise FeedError(f"phase telemetry {path.name} must be an object")
+        missing = [key for key in PHASE_TELEMETRY_REQUIRED if key not in document]
+        if missing:
+            raise FeedError(
+                f"phase telemetry {path.name} is missing {sorted(missing)}"
+            )
+        board = document["board"]
+        if board not in ledger.BOARDS:
+            raise FeedError(
+                f"phase telemetry {path.name} names an unregistered board: {board!r}"
+            )
+        if board in out:
+            raise FeedError(f"phase telemetry for board {board} is declared twice")
+        phases = document["phase_seconds"]
+        if not isinstance(phases, dict) or not phases:
+            raise FeedError(
+                f"phase telemetry {path.name} phase_seconds must be a non-empty object"
+            )
+        for name, value in phases.items():
+            if value is None:
+                continue  # a documented, explicitly unmeasured cutpoint
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or value < 0
+            ):
+                raise FeedError(
+                    f"phase telemetry {path.name} phase {name} is not a "
+                    "nonnegative number or null"
+                )
+        if not isinstance(document["phase_profile_source"], dict):
+            raise FeedError(
+                f"phase telemetry {path.name} phase_profile_source must be an object"
+            )
+        out[board] = {
+            "report_schema": document["report_schema"],
+            "run_id": document.get("run_id"),
+            "workload": document.get("workload"),
+            "workload_class": document.get("workload_class"),
+            "measurement_boundary": document["measurement_boundary"],
+            "phase_profile_source": document["phase_profile_source"],
+            "mechanism": document.get("mechanism"),
+            "stages": {"phase_seconds": phases},
+        }
+    return out
+
+
+def _era(board_spec: dict) -> dict:
+    """TRACKS §9 per-board era metadata.
+
+    Sourced from `epochs.json`: either the board's own era sequence or, when it
+    declares none, the global epoch it falls back to — which the site used to
+    have to infer from the suite-score epoch. `banked` is the retired/frozen
+    flag: a banked era's scores are final and are never compared with a live
+    track's. Nothing here is invented; a missing field is published as null.
+    """
+    era = board_spec.get("era")
+    if era is None:
+        return {
+            "number": int(board_spec["epoch"]),
+            "epoch": int(board_spec["epoch"]),
+            "opened_utc": board_spec.get("opened_utc"),
+            "reason": board_spec.get("reason"),
+            "status": "open",
+            "banked": False,
+            "closed_utc": None,
+            "scored_dimension": board_spec.get(
+                "scored_dimension", ledger.DEFAULT_SCORED_DIMENSION
+            ),
+            "note": None,
+            "source": "global_epoch",
+        }
+    return {
+        "number": int(era["era"]),
+        "epoch": int(era["epoch_ref"]),
+        "opened_utc": era["opened_utc"],
+        "reason": era["reason"],
+        "status": era["status"],
+        "banked": era["status"] == "banked",
+        "closed_utc": era["closed_utc"],
+        "scored_dimension": era["scored_dimension"],
+        "note": era.get("note"),
+        "source": "board_era",
+    }
+
+
 def _boards(
     repo: Path,
     manifest: Manifest,
     rows: list[ledger.Row],
     epoch_spec: dict,
 ) -> dict:
-    epoch = int(epoch_spec["epoch"])
-    metrics_policy = metrics.policy_from_epoch(epoch_spec)
     boards: dict = {}
-    owned_boards = {group.board for group in manifest.groups()}
+    groups_by_board = {group.board: group for group in manifest.groups()}
+    phase_telemetry = _phase_telemetry(repo)
     for board in ledger.BOARDS:
+        # TRACKS §7: every board is scored under ITS OWN current era. Boards
+        # without an era sequence resolve to the newest global epoch, which is
+        # byte-for-byte the pre-era behaviour.
+        board_spec = ledger.current_epoch(repo, board=board)
+        epoch = int(board_spec["epoch"])
+        metrics_policy = metrics.policy_from_epoch(board_spec)
+        group = groups_by_board.get(board)
         board_rows = [r for r in rows if r.values.get("board") == board]
         entries = [r.values for r in board_rows]
         board_frontier = {}
@@ -390,7 +544,7 @@ def _boards(
             manifest.class_names(
                 board=board, scored_only=True, include_disabled=True,
             )
-            if board in owned_boards else []
+            if group is not None else []
         )
         for cls in classes:
             view = frontier.view(board_rows, board, cls)
@@ -398,12 +552,17 @@ def _boards(
                 "head": view.head.values if view.head else None,
                 "frontier": [r.values for r in view.frontier],
                 "audit": _audit_state(
-                    repo, rows, epoch_spec, board, cls,
+                    repo, rows, board_spec, board, cls,
                 ),
             }
         boards[board] = {
             "entries": entries,
             "scored_classes": classes,
+            "era": _era(board_spec),
+            "retirement": (
+                dict(group.retirement) or None if group is not None else None
+            ),
+            "phase_telemetry": phase_telemetry.get(board),
             "suite_score": (
                 metrics.board_suite_score(
                     rows, epoch, board, classes, policy=metrics_policy,
@@ -621,6 +780,7 @@ def _reference_input_files(repo: Path) -> list[Path]:
         return []
     paths = sorted(ref_dir.glob("*.json"))
     paths.extend(sorted((ref_dir / "peer-series" / "runs").glob("*.json")))
+    paths.extend(_phase_telemetry_files(repo))
     return paths
 
 
@@ -733,6 +893,8 @@ def build_feed(manifest: Manifest, allow_dirty: bool = False) -> dict:
         },
         "epoch": {
             "number": epoch["epoch"],
+            "opened_utc": epoch.get("opened_utc"),
+            "reason": epoch.get("reason"),
             "aa_dispersion": epoch.get("aa_dispersion"),
         },
         "promotion_scope": _promotion_scope(manifest),

--- a/autoresearch/cli/stwo_perf/ledger.py
+++ b/autoresearch/cli/stwo_perf/ledger.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import hashlib
 import math
@@ -453,27 +454,320 @@ def known_epochs(repo_root: Path) -> dict[int, dict]:
     return {int(e["epoch"]): e for e in data["epochs"]}
 
 
-def current_epoch(repo_root: Path) -> dict:
+# --- TRACKS §7 per-board eras -------------------------------------------------
+#
+# Global epochs stay authoritative and unchanged; a board may additionally own
+# an era sequence in ``board_eras.boards``. Every resolver below falls back to
+# the newest global epoch when a board declares no eras, so absent per-board
+# data reproduces the pre-era behaviour exactly.
+
+ERA_STATUSES = ("open", "banked")
+
+# The scored boundary a board's era declares. ``prove_ms`` is today's behaviour
+# everywhere; ``request_ms`` is the TRACKS §3.1 verified-request boundary that
+# the RISC-V board adopts at its next era. Declaring it is gated on that era
+# carrying its own recalibrated A/A dispersion (see ``_validate_era``).
+SCORED_DIMENSIONS = ("prove_ms", "request_ms")
+DEFAULT_SCORED_DIMENSION = "prove_ms"
+
+RESOURCE_BUDGET_DIMENSIONS = ("peak_rss_mib", "energy_j", "proof_bytes")
+
+_ERA_REQUIRED_KEYS = ("era", "epoch_ref", "opened_utc", "reason")
+_ERA_KNOWN_KEYS = {
+    *_ERA_REQUIRED_KEYS,
+    "status", "closed_utc", "audit_anchor_commit", "aa_dispersion",
+    "resource_budgets", "scored_dimension", "note",
+}
+_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+_COMMIT40_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _epochs_document(repo_root: Path) -> dict:
+    document = json.loads(epochs_path(repo_root).read_text())
+    if not isinstance(document, dict) or not isinstance(document.get("epochs"), list):
+        raise LedgerError("epochs.json must declare a list of global epochs")
+    return document
+
+
+def _era_block(document: dict) -> dict[str, list]:
+    """Return the validated ``board -> era list`` map (``{}`` when absent)."""
+    block = document.get("board_eras")
+    if block is None:
+        return {}
+    if not isinstance(block, dict) or not set(block) <= {"note", "boards"}:
+        raise LedgerError(
+            "epochs.json board_eras must be an object with only 'note' and 'boards'"
+        )
+    if "note" in block and not isinstance(block["note"], str):
+        raise LedgerError("epochs.json board_eras.note must be a string")
+    boards = block.get("boards")
+    if boards is None:
+        return {}
+    if not isinstance(boards, dict):
+        raise LedgerError("epochs.json board_eras.boards must be an object")
+    return boards
+
+
+def _positive_finite(value: object) -> bool:
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, (int, float))
+        and math.isfinite(float(value))
+        and float(value) > 0
+    )
+
+
+def _validate_era(board: str, era: dict, epochs: dict[int, dict]) -> dict:
+    """Fail closed on one era record; never invent a missing field."""
+    where = f"board era {board}/{era.get('era')!r}"
+    if not isinstance(era, dict):
+        raise LedgerError(f"board eras for {board} must be objects")
+    unknown = sorted(set(era) - _ERA_KNOWN_KEYS)
+    if unknown:
+        raise LedgerError(f"{where}: unknown key(s) {unknown}")
+    for key in _ERA_REQUIRED_KEYS:
+        if key not in era:
+            raise LedgerError(f"{where}: missing required key {key}")
+    if type(era["era"]) is not int or era["era"] < 1:
+        raise LedgerError(f"{where}: 'era' must be a positive integer")
+    if type(era["epoch_ref"]) is not int or era["epoch_ref"] not in epochs:
+        raise LedgerError(
+            f"{where}: 'epoch_ref' must name a global epoch declared in epochs.json"
+        )
+    for key in ("opened_utc", "closed_utc"):
+        value = era.get(key)
+        if key == "closed_utc" and value is None:
+            continue
+        if not isinstance(value, str) or not _UTC_RE.fullmatch(value):
+            raise LedgerError(f"{where}: '{key}' must be ISO-8601 UTC (…T…Z)")
+    if era["opened_utc"] < str(epochs[era["epoch_ref"]].get("opened_utc") or ""):
+        raise LedgerError(
+            f"{where}: 'opened_utc' precedes the global epoch it inherits"
+        )
+    if not str(era.get("reason") or "").strip():
+        raise LedgerError(f"{where}: 'reason' must be a non-empty string")
+    status = era.get("status", "open")
+    if status not in ERA_STATUSES:
+        raise LedgerError(f"{where}: 'status' must be one of {ERA_STATUSES}")
+    if status == "banked" and era.get("closed_utc") is None:
+        raise LedgerError(f"{where}: a banked era must record 'closed_utc'")
+    if status == "open" and era.get("closed_utc") is not None:
+        raise LedgerError(f"{where}: an open era must not record 'closed_utc'")
+    if era.get("closed_utc") is not None and era["closed_utc"] < era["opened_utc"]:
+        raise LedgerError(f"{where}: 'closed_utc' precedes 'opened_utc'")
+    anchor = era.get("audit_anchor_commit")
+    if anchor is not None and (
+        not isinstance(anchor, str) or not _COMMIT40_RE.fullmatch(anchor)
+    ):
+        raise LedgerError(
+            f"{where}: 'audit_anchor_commit' must be a 40-hex commit"
+        )
+    dispersion = era.get("aa_dispersion")
+    if dispersion is not None:
+        if not isinstance(dispersion, dict) or not dispersion:
+            raise LedgerError(f"{where}: 'aa_dispersion' must be a non-empty object")
+        for name, value in dispersion.items():
+            if value is not None and not _positive_finite(value):
+                raise LedgerError(
+                    f"{where}: aa_dispersion/{name} must be positive and finite, or null"
+                )
+    budgets = era.get("resource_budgets")
+    if budgets is not None:
+        if not isinstance(budgets, dict) or not budgets:
+            raise LedgerError(
+                f"{where}: 'resource_budgets' must be a non-empty object"
+            )
+        for name, vector in budgets.items():
+            if not isinstance(vector, dict) or set(vector) != set(
+                RESOURCE_BUDGET_DIMENSIONS
+            ):
+                raise LedgerError(
+                    f"{where}: resource_budgets/{name} must contain exactly "
+                    f"{sorted(RESOURCE_BUDGET_DIMENSIONS)}"
+                )
+            for dimension, value in vector.items():
+                if not _positive_finite(value):
+                    raise LedgerError(
+                        f"{where}: resource_budgets/{name}/{dimension} must be "
+                        "positive and finite"
+                    )
+    dimension = era.get("scored_dimension", DEFAULT_SCORED_DIMENSION)
+    if dimension not in SCORED_DIMENSIONS:
+        raise LedgerError(
+            f"{where}: 'scored_dimension' must be one of {SCORED_DIMENSIONS}"
+        )
+    if dimension != DEFAULT_SCORED_DIMENSION and era.get("aa_dispersion") is None:
+        # TRACKS §3.1/§7: a boundary switch invalidates the inherited A/A
+        # dispersion, so the era that switches must carry its own measured
+        # recalibration. Nothing may be inherited across a boundary change.
+        raise LedgerError(
+            f"{where}: an era that scores {dimension} must declare its own measured "
+            "aa_dispersion; boundary switches never inherit calibration"
+        )
+    return era
+
+
+def board_eras(repo_root: Path, board: str) -> tuple[dict, ...]:
+    """Return one board's validated era sequence; empty when it declares none."""
+    boards = _era_block(_epochs_document(repo_root))
+    raw = boards.get(board)
+    if raw is None:
+        return ()
+    if not isinstance(raw, list) or not raw:
+        raise LedgerError(f"board eras for {board} must be a non-empty list")
+    if board not in BOARDS:
+        raise LedgerError(
+            f"board eras name {board}, which is not a registered scoring board"
+        )
     epochs = known_epochs(repo_root)
-    return epochs[max(epochs)]
+    eras = [_validate_era(board, era, epochs) for era in raw]
+    if [era["era"] for era in eras] != list(range(1, len(eras) + 1)):
+        raise LedgerError(
+            f"board eras for {board} must be numbered 1..n in ascending order"
+        )
+    for previous, era in zip(eras, eras[1:]):
+        if era["epoch_ref"] < previous["epoch_ref"]:
+            raise LedgerError(
+                f"board eras for {board}: epoch_ref must never decrease"
+            )
+        if era["opened_utc"] <= previous["opened_utc"]:
+            raise LedgerError(
+                f"board eras for {board}: opened_utc must strictly increase"
+            )
+        if previous.get("status", "open") != "banked":
+            raise LedgerError(
+                f"board eras for {board}: only the newest era may stay open"
+            )
+        if previous["closed_utc"] > era["opened_utc"]:
+            raise LedgerError(
+                f"board eras for {board}: era {previous['era']} closes after "
+                f"era {era['era']} opens"
+            )
+    return tuple(eras)
+
+
+def current_era(repo_root: Path, board: str) -> dict | None:
+    """The board's newest era as a normalized view, banked or open.
+
+    ``None`` when the board declares no era sequence. The view fills declared
+    defaults (``status``, ``scored_dimension``) and always carries every key,
+    so consumers never have to distinguish "absent" from "defaulted"; the raw
+    override blocks stay available through :func:`board_eras`.
+    """
+    eras = board_eras(repo_root, board)
+    return _era_view(eras[-1], board) if eras else None
+
+
+def _era_view(era: dict, board: str) -> dict:
+    return {
+        "board": board,
+        "era": int(era["era"]),
+        "epoch_ref": int(era["epoch_ref"]),
+        "opened_utc": era["opened_utc"],
+        "reason": era["reason"],
+        "status": era.get("status", "open"),
+        "closed_utc": era.get("closed_utc"),
+        "scored_dimension": era.get("scored_dimension", DEFAULT_SCORED_DIMENSION),
+        "note": era.get("note"),
+    }
+
+
+def _apply_era(epochs: dict[int, dict], era: dict, board: str) -> dict:
+    """Resolve one era into a complete, board-effective epoch specification."""
+    reference = int(era["epoch_ref"])
+    spec = copy.deepcopy(epochs[reference])
+    anchor = era.get("audit_anchor_commit")
+    overrides_metrics = anchor is not None or era.get("resource_budgets") is not None
+    metrics_v2 = spec.get("metrics_v2")
+    if overrides_metrics and not isinstance(metrics_v2, dict):
+        raise LedgerError(
+            f"board era {board}/{era['era']} overrides Metrics v2 policy but epoch "
+            f"{reference} declares none"
+        )
+    if anchor is not None:
+        metrics_v2["audit_anchor_commit"] = anchor
+    budgets = era.get("resource_budgets")
+    if budgets is not None:
+        by_class = dict(metrics_v2.get("resource_budgets") or {})
+        for name, vector in budgets.items():
+            by_class[name] = dict(vector)
+        metrics_v2["resource_budgets"] = by_class
+    dispersion = era.get("aa_dispersion")
+    if dispersion is not None:
+        by_board = spec.setdefault("aa_dispersion", {})
+        merged = dict(by_board.get(board) or {})
+        merged.update(dispersion)
+        by_board[board] = merged
+    spec["scored_dimension"] = era.get("scored_dimension", DEFAULT_SCORED_DIMENSION)
+    spec["era"] = _era_view(era, board)
+    return spec
+
+
+def epoch_for_board(
+    repo_root: Path, epoch: int, board: str | None = None,
+) -> dict:
+    """The board-effective specification of one named global epoch.
+
+    ``board=None``, or a board with no era covering ``epoch``, returns the
+    global epoch record unchanged.
+    """
+    epochs = known_epochs(repo_root)
+    if int(epoch) not in epochs:
+        raise LedgerError(f"unknown epoch {epoch}")
+    if board is None:
+        return epochs[int(epoch)]
+    covering = [
+        era for era in board_eras(repo_root, board)
+        if int(era["epoch_ref"]) == int(epoch)
+    ]
+    if not covering:
+        return epochs[int(epoch)]
+    return _apply_era(epochs, covering[-1], board)
+
+
+def current_epoch(repo_root: Path, board: str | None = None) -> dict:
+    """The newest global epoch, or one board's current era resolved against it.
+
+    A board whose newest era is banked stays pinned to that era's epoch even
+    after later global epochs open — that is what retiring a board means
+    (TRACKS §6): its history keeps being served and its scoring never drifts.
+    """
+    epochs = known_epochs(repo_root)
+    if board is None:
+        return epochs[max(epochs)]
+    eras = board_eras(repo_root, board)
+    if not eras:
+        return epochs[max(epochs)]
+    return _apply_era(epochs, eras[-1], board)
+
+
+def scored_dimension(repo_root: Path, board: str | None = None) -> str:
+    """The boundary a board's current era scores; ``prove_ms`` by default."""
+    return str(
+        current_epoch(repo_root, board=board).get(
+            "scored_dimension", DEFAULT_SCORED_DIMENSION
+        )
+    )
 
 
 def aa_dispersion(repo_root: Path, board: str, workload_class: str) -> float | None:
-    by_board = current_epoch(repo_root).get("aa_dispersion", {})
+    by_board = current_epoch(repo_root, board=board).get("aa_dispersion", {})
     value = by_board.get(board, {}).get(workload_class)
     return float(value) if value is not None else None
 
 
 def resource_budgets(
-    repo_root: Path, workload_class: str,
+    repo_root: Path, workload_class: str, board: str | None = None,
 ) -> dict[str, float] | None:
     """Return the current epoch's complete resource budget vector.
 
     Legacy epochs predate Metrics v2 and return ``None``. Once Metrics v2 is
     declared, every class used by an evaluation must have an exact, positive,
-    finite three-dimensional budget.
+    finite three-dimensional budget. TRACKS §8 keys budgets by (board, class):
+    a board era may pin its own class vectors, and anything it does not pin
+    falls back to the epoch's class-only vector.
     """
-    metrics = current_epoch(repo_root).get("metrics_v2")
+    metrics = current_epoch(repo_root, board=board).get("metrics_v2")
     if metrics is None:
         return None
     if not isinstance(metrics, dict):

--- a/autoresearch/cli/stwo_perf/manifest.py
+++ b/autoresearch/cli/stwo_perf/manifest.py
@@ -9,6 +9,9 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
+_UTC_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+_SHA256_ID_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
 RUNGS = ("s1", "s2", "s3", "s4", "s5")
 ACCEPTANCE_FLOOR = "s3"
 REPORT_SCHEMA_VERSIONS = {
@@ -37,6 +40,22 @@ SEARCH_HEALTH_POLICY_KEYS = frozenset({
 })
 MAX_GROUP_WALL_CLOCK_SECONDS = 7200
 MAX_COMMAND_TIMEOUT_SECONDS = 7200
+
+# TRACKS §6 retire-and-complete. A retired group flips to
+# `promotion_eligible: false`, keeps every name in `ledger.BOARDS`, and carries
+# exactly this block. `closing_audit` stays null until the M5 judge host runs
+# the final closing audit that stamps the board's last audited score.
+RETIREMENT_KEYS = frozenset({"retired_at_utc", "reason", "closing_audit"})
+CLOSING_AUDIT_KEYS = frozenset({"completed_utc", "bundle_sha256", "row_ids"})
+
+# TRACKS §3.1: the scored boundary a workload group's board reports. The whole
+# harness scores `prove_ms` today; `request_ms` is the verified-request
+# boundary the RISC-V board adopts at its NEXT era, and declaring it is gated
+# on that era carrying its own recalibration (see ledger.SCORED_DIMENSIONS and
+# schema/scoring.md). Nothing in this repository declares it yet — the runner
+# refuses to score a board whose era declares a boundary it cannot measure.
+SCORED_DIMENSIONS = ("prove_ms", "request_ms")
+DEFAULT_SCORED_DIMENSION = "prove_ms"
 RESOURCE_PROFILES = frozenset(("standard", "large", "extreme"))
 METAL_CALIBRATION_SCHEMA = "stwo_perf_metal_calibration_freeze_v2"
 METAL_CALIBRATION_FIELDS = frozenset({
@@ -244,6 +263,11 @@ class WorkloadGroup:
     promotion_blocked_reason: str | None = None
     acceptance_corpus: dict = field(default_factory=dict)
     workload_provisioning: dict = field(default_factory=dict)
+    # TRACKS §6: a retired-and-completed track. Present only on retired groups.
+    retirement: dict = field(default_factory=dict)
+    # TRACKS §3.1: the boundary this group's board scores. Defaults to today's
+    # behaviour everywhere; see SCORED_DIMENSIONS.
+    scored_dimension: str = DEFAULT_SCORED_DIMENSION
 
 
 @dataclass(frozen=True)
@@ -419,6 +443,10 @@ class Manifest:
                 promotion_blocked_reason=spec.get("promotion_blocked_reason"),
                 acceptance_corpus=dict(spec.get("acceptance_corpus", {})),
                 workload_provisioning=dict(spec.get("workload_provisioning", {})),
+                retirement=dict(spec.get("retirement", {})),
+                scored_dimension=str(
+                    spec.get("scored_dimension", DEFAULT_SCORED_DIMENSION)
+                ),
             ))
         return out
 
@@ -678,6 +706,8 @@ def _validate(raw: dict) -> None:
         _validate_group_resource_telemetry(
             gid, report_schema, spec.get("resource_telemetry", {})
         )
+        _validate_group_retirement(gid, spec)
+        _validate_group_scored_dimension(gid, spec)
         _validate_group_acceptance_corpus(gid, spec.get("acceptance_corpus", {}))
         _validate_group_workload_provisioning(
             gid, spec.get("workload_provisioning", {}), spec.get("workloads", {})
@@ -827,6 +857,76 @@ def _validate_cairo_mechanism_telemetry(gid: str, telemetry: object) -> None:
         raise ManifestError(
             f"workload group {gid}: Cairo mechanism telemetry must require "
             "phase_seconds; TRACKS §3.2 makes the named phase cutpoints mandatory"
+        )
+
+
+def _validate_group_retirement(gid: str, spec: dict) -> None:
+    """TRACKS §6: retirement is explicit, dated, reasoned, and unpromotable."""
+    retirement = spec.get("retirement")
+    if retirement is None:
+        return
+    if not isinstance(retirement, dict) or set(retirement) != RETIREMENT_KEYS:
+        raise ManifestError(
+            f"workload group {gid}: 'retirement' must contain exactly "
+            + ", ".join(sorted(RETIREMENT_KEYS))
+        )
+    retired_at = retirement["retired_at_utc"]
+    if not isinstance(retired_at, str) or not _UTC_TIMESTAMP_RE.fullmatch(retired_at):
+        raise ManifestError(
+            f"workload group {gid}: retirement.retired_at_utc must be ISO-8601 UTC"
+        )
+    if not str(retirement["reason"] or "").strip():
+        raise ManifestError(
+            f"workload group {gid}: retirement.reason must be a non-empty string"
+        )
+    if spec.get("promotion_eligible"):
+        raise ManifestError(
+            f"workload group {gid}: a retired group cannot be promotion eligible; "
+            "TRACKS §6 retires by refusing new promotions while history stays served"
+        )
+    if not str(spec.get("promotion_blocked_reason") or "").strip():
+        raise ManifestError(
+            f"workload group {gid}: a retired group must state a "
+            "promotion_blocked_reason so its refusal is legible"
+        )
+    closing = retirement["closing_audit"]
+    if closing is None:
+        return
+    if not isinstance(closing, dict) or set(closing) != CLOSING_AUDIT_KEYS:
+        raise ManifestError(
+            f"workload group {gid}: retirement.closing_audit must be null or "
+            "contain exactly " + ", ".join(sorted(CLOSING_AUDIT_KEYS))
+        )
+    if not _UTC_TIMESTAMP_RE.fullmatch(str(closing["completed_utc"])):
+        raise ManifestError(
+            f"workload group {gid}: closing_audit.completed_utc must be ISO-8601 UTC"
+        )
+    if not _SHA256_ID_RE.fullmatch(str(closing["bundle_sha256"])):
+        raise ManifestError(
+            f"workload group {gid}: closing_audit.bundle_sha256 must be sha256:<hex>"
+        )
+    row_ids = closing["row_ids"]
+    if (
+        not isinstance(row_ids, list)
+        or not row_ids
+        or any(not _SHA256_ID_RE.fullmatch(str(value)) for value in row_ids)
+        or len(row_ids) != len(set(row_ids))
+    ):
+        raise ManifestError(
+            f"workload group {gid}: closing_audit.row_ids must be a unique "
+            "non-empty list of sha256:<hex> ledger row IDs"
+        )
+
+
+def _validate_group_scored_dimension(gid: str, spec: dict) -> None:
+    """TRACKS §3.1: the scored boundary is declared, never inferred."""
+    if "scored_dimension" not in spec:
+        return
+    dimension = spec["scored_dimension"]
+    if dimension not in SCORED_DIMENSIONS:
+        raise ManifestError(
+            f"workload group {gid}: 'scored_dimension' must be one of "
+            f"{SCORED_DIMENSIONS}"
         )
 
 

--- a/autoresearch/cli/stwo_perf/metrics.py
+++ b/autoresearch/cli/stwo_perf/metrics.py
@@ -27,6 +27,12 @@ class AuditPolicy:
     direct_every: int
     span_effect_theta: float
     audit_anchor_commit: str
+    # TRACKS §7 era provenance. Populated only when the policy was resolved
+    # from a board-effective epoch specification (``ledger.epoch_for_board`` /
+    # ``ledger.current_epoch(board=...)``); a global epoch leaves both None and
+    # behaves exactly as before.
+    board: str | None = None
+    era: int | None = None
 
 
 @dataclass(frozen=True)
@@ -106,9 +112,19 @@ def _validate_policy(policy: AuditPolicy) -> None:
 
 
 def policy_from_epoch(epoch: dict) -> AuditPolicy:
+    """Build the audit policy of one epoch, global or board-effective.
+
+    A board-effective specification carries an ``era`` view whose per-board
+    ``audit_anchor_commit`` override is already merged into ``metrics_v2``
+    (TRACKS §7: audit anchors are per board, the global epoch's anchor is the
+    fallback). The era's identity is retained here purely as provenance.
+    """
     spec = epoch.get("metrics_v2")
     if not isinstance(spec, dict) or spec.get("schema_version") != 2:
         raise MetricsError("epoch does not declare metrics_v2 schema 2")
+    era = epoch.get("era")
+    if era is not None and not isinstance(era, dict):
+        raise MetricsError("epoch era view must be an object")
     try:
         policy = AuditPolicy(
             shrinkage_lambda=float(spec["shrinkage_lambda"]),
@@ -116,6 +132,8 @@ def policy_from_epoch(epoch: dict) -> AuditPolicy:
             direct_every=int(spec["direct_audit_every_landed"]),
             span_effect_theta=float(spec["span_effect_theta"]),
             audit_anchor_commit=str(spec["audit_anchor_commit"]),
+            board=str(era["board"]) if era else None,
+            era=int(era["era"]) if era else None,
         )
     except (KeyError, TypeError, ValueError) as exc:
         raise MetricsError("epoch metrics_v2 policy is incomplete") from exc

--- a/autoresearch/cli/stwo_perf/promotion.py
+++ b/autoresearch/cli/stwo_perf/promotion.py
@@ -39,6 +39,16 @@ def require_board_promotion_eligible(
     group_spec = manifest.raw["workload_registry"]["groups"].get(group.group_id, {})
     if group_spec.get("enabled") is not True:
         raise PromotionError(f"board workload group is disabled: {board}")
+    retirement = group_spec.get("retirement")
+    if isinstance(retirement, dict) and group_spec.get("promotion_eligible") is not True:
+        # TRACKS §6 retire-and-complete: a retired board is not "not yet live",
+        # it is finished. Say so, so nobody re-opens it by flipping a flag.
+        raise PromotionError(
+            f"board is retired and is not promotion eligible: {board} "
+            f"(retired {retirement.get('retired_at_utc')}: {retirement.get('reason')}); "
+            "its era is banked and its history stays served — new promotions "
+            "belong on a live track (TRACKS §6)"
+        )
     if group_spec.get("promotion_eligible") is not True:
         raise PromotionError(f"board is not promotion eligible: {board}")
 

--- a/autoresearch/cli/stwo_perf/runner.py
+++ b/autoresearch/cli/stwo_perf/runner.py
@@ -3626,11 +3626,26 @@ def evaluate(
         raise RunError(f"board {board} selected workloads from multiple groups")
     policy = manifest.gates_for_workload(next(iter(group_ids)), workload_class)
     try:
-        epoch_resource_budgets = ledger.resource_budgets(repo_root, workload_class)
+        # TRACKS §8: resource budgets are keyed (board, class); a board era
+        # that pins none falls back to the epoch's class-only vector.
+        epoch_resource_budgets = ledger.resource_budgets(
+            repo_root, workload_class, board=board,
+        )
+        era_scored_dimension = ledger.scored_dimension(repo_root, board)
     except ledger.LedgerError as exc:
         raise RunError(f"invalid epoch resource budgets: {exc}") from exc
     if epoch_resource_budgets is not None:
         policy["resource_budgets"] = epoch_resource_budgets
+    if era_scored_dimension != ledger.DEFAULT_SCORED_DIMENSION:
+        # TRACKS §3.1 fail-closed gate: a board whose era declares the
+        # verified-request boundary must not be scored by a harness that still
+        # measures the prove boundary. Opening such an era therefore cannot
+        # silently produce prove-boundary rows labelled as request-boundary.
+        raise RunError(
+            f"board {board} scores {era_scored_dimension} in its current era, but this "
+            f"harness measures {ledger.DEFAULT_SCORED_DIMENSION}; the TRACKS §3.1 "
+            "boundary re-scoring must land in the runner before that era opens"
+        )
 
     dispersion = ledger.aa_dispersion(repo_root, board, workload_class)
     th = stats.theta(dispersion, float(policy["theta_floor"]), float(policy["dispersion_multiplier"]))

--- a/autoresearch/ledger/epochs.json
+++ b/autoresearch/ledger/epochs.json
@@ -147,5 +147,66 @@
         }
       }
     }
-  ]
+  ],
+  "board_eras": {
+    "note": "TRACKS §7 per-board eras. Global epochs above stay the fallback and are never rewritten: a board absent from `boards` resolves to the newest global epoch exactly as before, so every epoch-1/2 consumer and every ledger row referencing epoch 1 or 2 keeps working byte-for-byte. An era names the global epoch it inherits via `epoch_ref` and may override, for that board only, `aa_dispersion`, `resource_budgets` (the TRACKS §8 (board, class) key, falling back to the epoch's class-only vector), `audit_anchor_commit`, and `scored_dimension`. A board's newest era is its current era even when banked — a banked era freezes that board's scoring, which is how a retired board keeps serving history without drifting onto later global epochs. Scores are never compared across eras.",
+    "boards": {
+      "core_cpu": [
+        {
+          "era": 1,
+          "epoch_ref": 1,
+          "opened_utc": "2026-07-18T00:00:00Z",
+          "reason": "initial harness installation",
+          "status": "banked",
+          "closed_utc": "2026-07-21T16:00:00Z"
+        },
+        {
+          "era": 2,
+          "epoch_ref": 2,
+          "opened_utc": "2026-07-21T16:00:00Z",
+          "reason": "Metrics v2 opens audit-anchored scoring and the manifest-owned five-class native scoring universe",
+          "status": "banked",
+          "closed_utc": "2026-07-29T00:00:00Z",
+          "note": "TRACKS §6 retire-and-complete: the native CPU era is banked. New promotions refuse, the full ledger and final scores stay served, and the closing audit stamps the last audited score on the M5 judge host."
+        }
+      ],
+      "core_metal": [
+        {
+          "era": 1,
+          "epoch_ref": 1,
+          "opened_utc": "2026-07-18T00:00:00Z",
+          "reason": "initial harness installation",
+          "status": "banked",
+          "closed_utc": "2026-07-21T16:00:00Z"
+        },
+        {
+          "era": 2,
+          "epoch_ref": 2,
+          "opened_utc": "2026-07-21T16:00:00Z",
+          "reason": "Metrics v2 opens audit-anchored scoring and the manifest-owned five-class native scoring universe; the Metal calibration freeze for this era is pinned in epoch 2's metal_calibration block",
+          "status": "banked",
+          "closed_utc": "2026-07-29T00:00:00Z",
+          "note": "TRACKS §6 retire-and-complete: the native Metal era is banked. New promotions refuse, the full ledger and final scores stay served, and the closing audit stamps the last audited score on the M5 judge host."
+        }
+      ],
+      "riscv": [
+        {
+          "era": 1,
+          "epoch_ref": 1,
+          "opened_utc": "2026-07-18T00:00:00Z",
+          "reason": "initial harness installation; the RISC-V board carried no measured A/A dispersion in this era",
+          "status": "banked",
+          "closed_utc": "2026-07-21T16:00:00Z"
+        },
+        {
+          "era": 2,
+          "epoch_ref": 2,
+          "opened_utc": "2026-07-21T16:00:00Z",
+          "reason": "Metrics v2 opens audit-anchored scoring; the RISC-V board's frozen same-host M5 A/A dispersion enters with it",
+          "status": "open",
+          "note": "TRACKS §3.1 re-scores this board to the verified-request boundary at its NEXT era. Era 3 stays unopened until the M5 judge host recalibrates at that boundary; schema/scoring.md carries the exact era-3 record template and the operator commands."
+        }
+      ]
+    }
+  }
 }

--- a/autoresearch/schema/ledger.md
+++ b/autoresearch/schema/ledger.md
@@ -93,6 +93,85 @@ corrected history.
 The Pareto frontier and anchor-drift budgets are computed from this file by
 `stwo-perf frontier`; nothing else is authoritative.
 
+## Per-board eras (TRACKS §7)
+
+Global epochs are the wrong shape at 6+ tracks: one track's class change resets
+score compounding for all of them. `ledger/epochs.json` therefore carries an
+optional `board_eras` block beside the global `epochs` list.
+
+```json
+"board_eras": {
+  "note": "…why this block exists…",
+  "boards": {
+    "<board>": [
+      {
+        "era": 1,
+        "epoch_ref": 2,
+        "opened_utc": "2026-07-21T16:00:00Z",
+        "reason": "…why this era opened…",
+        "status": "open" | "banked",
+        "closed_utc": "2026-07-29T00:00:00Z",
+        "audit_anchor_commit": "<40-hex>",
+        "aa_dispersion": {"<class>": 0.0123, "<class>": null},
+        "resource_budgets": {
+          "<class>": {"peak_rss_mib": 1.05, "energy_j": 1.05, "proof_bytes": 1.0}
+        },
+        "scored_dimension": "prove_ms" | "request_ms",
+        "note": "…free-form operator note…"
+      }
+    ]
+  }
+}
+```
+
+`era`, `epoch_ref`, `opened_utc`, and `reason` are required; everything else is
+optional and defaults to inheritance. **The global epochs remain the fallback
+and are never rewritten**: a board absent from `boards` resolves to the newest
+global epoch exactly as it did before eras existed, and every ledger row
+referencing epoch 1 or 2 keeps parsing, scoring, and rendering unchanged. The
+`epoch` ledger column still names a **global** epoch — an era is a per-board
+*view* of one, never a competing numbering.
+
+Resolution API (`stwo_perf.ledger`):
+
+| function | behaviour |
+| --- | --- |
+| `board_eras(root, board)` | validated raw era sequence, `()` when none |
+| `current_era(root, board)` | newest era as a normalized view, or `None` |
+| `epoch_for_board(root, epoch, board)` | one named epoch resolved for a board |
+| `current_epoch(root, board=None)` | `board=None` is byte-for-byte the old behaviour |
+| `aa_dispersion(root, board, class)` | board-scoped, era override merged per class |
+| `resource_budgets(root, class, board=None)` | TRACKS §8 (board, class) key with class-only fallback |
+| `scored_dimension(root, board)` | the era's scored boundary; `prove_ms` by default |
+
+Invariants, all fail-closed:
+
+- A board named in `boards` must be in `ledger.BOARDS`; an unregistered name is
+  an error, never a silently ignored entry.
+- Eras are numbered `1..n` contiguously; `opened_utc` strictly increases;
+  `epoch_ref` never decreases and must name a declared global epoch.
+- An era may not open before the global epoch it inherits.
+- At most one era is `open`, and it must be the newest. Every other era is
+  `banked` with a `closed_utc` that does not fall after the next era opens.
+- **A banked newest era pins its board.** When a later global epoch opens, a
+  board whose newest era is banked stays on its own era — that is precisely
+  what retiring a board means (TRACKS §6): history keeps being served and the
+  frozen score never drifts onto a universe it was not measured in.
+- Overrides are merged, not substituted: a class the era does not pin inherits
+  the epoch's dispersion or budget. `audit_anchor_commit` is per board with the
+  epoch's anchor as fallback, so `metrics.policy_from_epoch` on a
+  board-effective specification yields that board's anchor and carries the
+  `board`/`era` identity as provenance.
+- An era declaring a `scored_dimension` other than `prove_ms` MUST declare its
+  own measured `aa_dispersion`: a boundary switch invalidates inherited
+  calibration and may never reuse it (TRACKS §3.1/§7). The runner additionally
+  refuses to evaluate any board whose era declares a boundary the harness does
+  not yet measure, so a declared-but-unimplemented boundary cannot produce a
+  mislabelled score.
+
+Scores are never compared across eras, exactly as they are never compared
+across epochs.
+
 ## Audit production protocol
 
 `python3 -m stwo_perf.audits plan` is the deterministic W2/W3 controller. It

--- a/autoresearch/schema/scoring.md
+++ b/autoresearch/schema/scoring.md
@@ -138,6 +138,80 @@ therefore never compounds raw ledger `judged_r` values independently of the
 audit engine. The feed publishes the audited-only board geomean beside the
 effective headline for provenance.
 
+## Retired boards (TRACKS §6 retire-and-complete)
+
+`core_cpu` and `core_metal` are **retired and complete** as of
+2026-07-29. Retirement is expressed with existing machinery and means exactly
+three things:
+
+1. The manifest group flips to `promotion_eligible: false` and carries a
+   `retirement` block (`retired_at_utc`, `reason`, `closing_audit`). New
+   promotions refuse with a retirement-specific message naming the date and
+   reason — a retired board is finished, not "not yet live".
+2. **History stays fully served.** The board keeps its name in `ledger.BOARDS`
+   forever (removing it silently drops its history from the feed), stays
+   `enabled` so its workloads keep running as guards and as PR6-supremacy
+   objective cells, and keeps its scored classes, ledger rows, suite score, and
+   frontier in the feed. The feed publishes retired boards in
+   `promotion_scope.retired_boards` and deliberately keeps them OUT of
+   `future_boards`, whose contract is "out of scope, never live".
+3. The board's era is `banked` in `epochs.json`, freezing its scoring at the
+   era it was measured in even after later global epochs open.
+
+The **closing audit** is the one piece of retirement that is not yet recorded.
+It runs on the designated M5 judge host through the normal audit controller —
+promotion ineligibility does not block it, because auditing is not promoting —
+and stamps each retired board's last audited score. Until then
+`retirement.closing_audit` is `null`; when the signed bundle lands it becomes
+`{completed_utc, bundle_sha256, row_ids}` and the audit cells close.
+
+## Per-track eras and the staged RISC-V boundary switch (TRACKS §3.1, §7)
+
+Each board may own an era sequence in `epochs.json` (`board_eras`; schema and
+invariants in schema/ledger.md). An era declares the boundary it scores via
+`scored_dimension`:
+
+| value | meaning |
+| --- | --- |
+| `prove_ms` | today's boundary everywhere: the commitment→composition→FRI→PoW island |
+| `request_ms` | the TRACKS §3.1 verified-request boundary — before input/trace/statement construction, after independent verification |
+
+**RISC-V re-scores to the request boundary at its NEXT era.** Era 2 is
+unchanged and still scores `prove_ms`; era 3 is deliberately NOT open, because
+the switch invalidates the frozen A/A dispersion and needs a fresh judge-host
+recalibration at the new boundary. Two gates enforce this:
+
+- `ledger` refuses any era that declares `scored_dimension: "request_ms"`
+  without its own measured `aa_dispersion` — a boundary switch never inherits
+  calibration;
+- the runner refuses to evaluate a board whose era declares a boundary the
+  harness does not yet measure, so opening the era before the runner change
+  lands fails closed instead of producing prove-boundary rows labelled as
+  request-boundary numbers.
+
+The era-3 record template (fill the measured values; invent nothing):
+
+```json
+{
+  "era": 3,
+  "epoch_ref": <global epoch open at the time>,
+  "opened_utc": "<UTC of the era open>",
+  "reason": "TRACKS §3.1: the RISC-V track re-scores to the verified-request boundary; prove_ms is demoted to diagnostic telemetry",
+  "scored_dimension": "request_ms",
+  "aa_dispersion": {
+    "small": <measured>, "wide": <measured>, "deep": <measured>
+  },
+  "audit_anchor_commit": "<40-hex commit the first era-3 direct audit chains from>",
+  "resource_budgets": {
+    "<class>": {"peak_rss_mib": <x>, "energy_j": <x>, "proof_bytes": <x>}
+  }
+}
+```
+
+The manifest side of the switch is the group's optional `scored_dimension`
+field (same allowlist, defaulting to `prove_ms`); no group declares a
+non-default value today.
+
 ## What is deliberately not scored
 
 - No blended CPU+Metal index within one basket (breaks backend identity).

--- a/autoresearch/schema/site-feed.md
+++ b/autoresearch/schema/site-feed.md
@@ -1,4 +1,4 @@
-# Site feed schema (v3) — the repo ↔ website contract
+# Site feed schema (v4) — the repo ↔ website contract
 
 `stwo-perf feed` compiles every checked-in evidence source into one JSON
 file: `autoresearch/site/feed.json`. The website renders feeds and nothing
@@ -38,12 +38,12 @@ Top-level keys:
 | `project` | slug, display name, harness name, contract pointer |
 | `provenance` | repo commit + commit time, input digests, determinism note |
 | `anchor` | frozen flag, anchor commit, per-class anchor prove-ms |
-| `epoch` | current measurement epoch and A/A dispersion (theta inputs) |
-| `promotion_scope` | v2: the decided benchmark set — manifest class registry (scored, resource, timeout, and sampling policy), workload groups (board, enabled, disabled_reason, per-workload class + native unit), `owned_boards`, `future_boards`, and committed baseline directories. A board in `future_boards` exists only as scoring universe; consumers render it as out-of-scope, never as empty-but-live |
-| `boards` | per scoring board (schema/scoring.md): ledger entries, manifest-owned `scored_classes`, canonical current-epoch Metrics-v2 `suite_score`, and per-class frontier. `suite_score` exposes effective and audited class ratios, their board geomeans, active credit-event counts, index, and speedup; it is aggregated after shrinkage and audit replacement, never from raw `judged_r`. Each live class also exposes its Metrics-v2 `audit` projection: effective/audited score, `audited_through`, deterministic commit/time age, unaudited tail, due/overdue state, span coverage, and claimed-versus-judged evidence share |
+| `epoch` | current global measurement epoch: `number`, `opened_utc`, `reason`, and A/A dispersion (theta inputs). v4 adds `opened_utc`/`reason` |
+| `promotion_scope` | v2: the decided benchmark set — manifest class registry (scored, resource, timeout, and sampling policy), workload groups (board, enabled, disabled_reason, `promotion_blocked_reason`, `retirement`, per-workload class + native unit), `owned_boards`, `staged_boards`, `retired_boards`, `future_boards`, and committed baseline directories. A board in `future_boards` exists only as scoring universe; consumers render it as out-of-scope, never as empty-but-live. **A retired board is never in `future_boards`** — see `retired_boards` below |
+| `boards` | per scoring board (schema/scoring.md): ledger entries, manifest-owned `scored_classes`, that board's **own current era** (`era`), `retirement`, `phase_telemetry`, canonical Metrics-v2 `suite_score` for its era's epoch, and per-class frontier. `suite_score` exposes effective and audited class ratios, their board geomeans, active credit-event counts, index, and speedup; it is aggregated after shrinkage and audit replacement, never from raw `judged_r`. Each live class also exposes its Metrics-v2 `audit` projection: effective/audited score, `audited_through`, deterministic commit/time age, unaudited tail, due/overdue state, span coverage, and claimed-versus-judged evidence share |
 | `search_health` | v3: manifest policy plus per board/class availability, trailing summary, latest configured/actual rounds and boost decision, complete-wall measurement hours, credited log-improvement/hour, immutable time series, and trailing decay series; classes come from the manifest and historical rows, not a fixed feed list |
 | `metal_resident_progress` | Board-4 progress metrics while the board is empty (fallbacks/proof, zero-fallback row count) |
-| `latest_matrix` | the newest benchmark-history matrix run: per-row workload identity, headline eligibility, proof parity, and per-lane medians (prove ms, native MHz with its unit, request ms, peak RSS, fallback/dispatch counts). New matrix lanes also retain the optional `request_resources` governed measurement vector verbatim; historical lanes omit it rather than fabricating zeros |
+| `latest_matrix` | the newest benchmark-history matrix run: per-row workload identity, headline eligibility, proof parity, and per-lane medians (prove ms, native MHz with its unit, request ms, peak RSS, fallback/dispatch counts). v4 adds per-lane `backend` (verbatim backend identity from the committed report) and `board` (the scoring board that identity belongs to). New matrix lanes also retain the optional `request_resources` governed measurement vector verbatim; historical lanes omit it rather than fabricating zeros |
 | `baseline_matrix` | the EARLIEST committed matrix run, same shape as `latest_matrix`: the fixed pre-optimization reference vector. Suite-level progress is the vector of per-workload time ratios (latest/baseline, paired by workload name, headline-eligible rows) aggregated by geometric mean — the only consistent mean for normalized ratios — with the worst component reported alongside so no single coordinate can be gamed |
 | `references` | committed external reference measurements from `autoresearch/reference/*.json`, plus immutable `peer-series/runs/*.json` audit points. `peer_rust_scalar` and `peer_rust_simd` are distinct backend-typed references; consumers MUST name the backend and render timing caveats. `peer_relative_series` defines the exact PR #6 wide-Fibonacci series, while discovered `peer_series_run_*` entries carry same-host four-lane points and proof-equivalence receipts. An empty series is uncalibrated, never parity. |
 | `history` | run index (ids, kinds, report digests) and comparison count |
@@ -55,11 +55,79 @@ display a lane and native unit beside a number; treat feeds from forks as
 untrusted until `provenance` digests are verified against the repository.
 
 Version history: v1 had no `promotion_scope`; v2 added it; v3 adds
-`search_health`. Consumers use `promotion_scope.owned_boards` to decide which
-boards are live. Search-health points with `available=false` remain part of the
-time series and must render their `unavailable_reason`, never a fabricated zero.
-Malformed or missing evidence on a v3 `judged` row prevents feed publication;
-legacy v1/v2 rows remain readable and explicitly unavailable.
+`search_health`; v4 adds per-board eras, retirement, phase telemetry, matrix
+lane board attribution, and `epoch.opened_utc`/`epoch.reason`. Consumers use
+`promotion_scope.owned_boards` to decide which boards accept new promotions and
+`promotion_scope.retired_boards` to decide which are completed contracts.
+Search-health points with `available=false` remain part of the time series and
+must render their `unavailable_reason`, never a fabricated zero. Malformed or
+missing evidence on a v3 `judged` row prevents feed publication; legacy v1/v2
+rows remain readable and explicitly unavailable.
+
+## v4: per-board era metadata (TRACKS §7, §9)
+
+Every entry in `boards` carries an `era` object. It is always present and every
+key is always set:
+
+| field | meaning |
+| --- | --- |
+| `number` | the board's era number (1-based, per board) |
+| `epoch` | the global epoch the era inherits — the epoch its `suite_score` is computed in |
+| `opened_utc` | when the era opened |
+| `reason` | why it opened |
+| `status` | `open` or `banked` |
+| `banked` | `status == "banked"`; **the retired/frozen flag** |
+| `closed_utc` | when a banked era closed, else null |
+| `scored_dimension` | the boundary the era scores (`prove_ms` today; `request_ms` is the TRACKS §3.1 verified-request boundary) |
+| `note` | free-form operator note, or null |
+| `source` | `board_era` when the board owns an era sequence, `global_epoch` when it falls back |
+
+A board that declares no era sequence falls back to the newest global epoch and
+reports `source: "global_epoch"` — the fallback is explicit, so consumers no
+longer have to infer an era from the suite-score epoch. **Scores are never
+compared across eras**, exactly as they are never compared across epochs; a
+banked era's numbers are final.
+
+`boards.<board>.retirement` is the TRACKS §6 block (`retired_at_utc`, `reason`,
+`closing_audit`) or null. A retired board renders as a **completed, frozen
+contract**: final scores, full ledger, banked-era banner, never silently
+compared with live tracks. Its history is served exactly as before — it keeps
+its ledger entries, scored classes, suite score, and frontier. `closing_audit`
+is null until the judge host records the final audit that stamps the board's
+last audited score, then becomes `{completed_utc, bundle_sha256, row_ids}`.
+
+## v4: phase telemetry (TRACKS §3.2)
+
+`boards.<board>.phase_telemetry` publishes the named phase cutpoints for a
+board, or **null when no committed artifact carries them**. Phase telemetry is
+mandatory diagnostic evidence and is never scored; an absent board means "not
+yet measured on committed evidence" and must render as an honest absence, never
+as zeros.
+
+Source contract: the producer reads committed JSON documents from
+`autoresearch/reference/phase-telemetry/*.json` only — never a local run, never
+a derived estimate. Each document declares `board` (a registered scoring
+board), `report_schema`, `measurement_boundary`, `phase_profile_source`, and
+`phase_seconds`, and may declare `run_id`, `workload`, `workload_class`, and
+`mechanism`. Every file is digested into `provenance.inputs_sha256`, and a
+malformed document fails the feed rather than reaching a consumer. Published
+shape:
+
+```json
+{
+  "report_schema": "cairo_proof_v1",
+  "run_id": "…", "workload": "…", "workload_class": "…",
+  "measurement_boundary": "cold_process",
+  "phase_profile_source": {"invocation_index": 4, "scored": false, "note": "…"},
+  "mechanism": {…},
+  "stages": {"phase_seconds": {"execute": 1.0, "witness": 2.0, "…": null}}
+}
+```
+
+A `phase_seconds` cutpoint may be `null` — a documented, explicitly unmeasured
+phase (e.g. Cairo's `serialize`, which happens outside the stage recorder). No
+board publishes phase telemetry at the time this schema version lands: the
+export machinery and its source contract are live, and the drop point is empty.
 
 Audit age is computed from committed Git timestamps and ancestry, never the feed
 producer's wall clock. A fork or generic consumer missing the audit commit

--- a/autoresearch/site/feed.json
+++ b/autoresearch/site/feed.json
@@ -34,12 +34,16 @@
     "headline_eligible": true,
     "lanes": {
      "cpu": {
+      "backend": "cpu_native",
+      "board": "core_cpu",
       "native_mhz": 0.41064023384036435,
       "peak_rss_mib": null,
       "prove_ms": 2.493667,
       "request_ms": 2.686417
      },
      "metal": {
+      "backend": "metal_hybrid",
+      "board": "core_hybrid",
       "cpu_fallbacks_per_proof": 13,
       "metal_dispatches_per_proof": 15,
       "native_mhz": 0.1439870636622491,
@@ -63,12 +67,16 @@
     "headline_eligible": true,
     "lanes": {
      "cpu": {
+      "backend": "cpu_native",
+      "board": "core_cpu",
       "native_mhz": 1.3797537142988516,
       "peak_rss_mib": null,
       "prove_ms": 11.874583,
       "request_ms": 12.82375
      },
      "metal": {
+      "backend": "metal_hybrid",
+      "board": "core_hybrid",
       "cpu_fallbacks_per_proof": 16,
       "metal_dispatches_per_proof": 20,
       "native_mhz": 1.1198013118160706,
@@ -92,12 +100,16 @@
     "headline_eligible": true,
     "lanes": {
      "cpu": {
+      "backend": "cpu_native",
+      "board": "core_cpu",
       "native_mhz": 0.38840607855512943,
       "peak_rss_mib": null,
       "prove_ms": 2.636416,
       "request_ms": 2.819417
      },
      "metal": {
+      "backend": "metal_hybrid",
+      "board": "core_hybrid",
       "cpu_fallbacks_per_proof": 13,
       "metal_dispatches_per_proof": 17,
       "native_mhz": 0.16360440965010387,
@@ -122,12 +134,16 @@
     "headline_eligible": true,
     "lanes": {
      "cpu": {
+      "backend": "cpu_native",
+      "board": "core_cpu",
       "native_mhz": 1.5327310678151174,
       "peak_rss_mib": null,
       "prove_ms": 10.689416,
       "request_ms": 10.957958
      },
      "metal": {
+      "backend": "metal_hybrid",
+      "board": "core_hybrid",
       "cpu_fallbacks_per_proof": 16,
       "metal_dispatches_per_proof": 22,
       "native_mhz": 1.1344394533447582,
@@ -152,12 +168,16 @@
     "headline_eligible": true,
     "lanes": {
      "cpu": {
+      "backend": "cpu_native",
+      "board": "core_cpu",
       "native_mhz": 0.37956980359116027,
       "peak_rss_mib": null,
       "prove_ms": 2.697791,
       "request_ms": 2.910584
      },
      "metal": {
+      "backend": "metal_hybrid",
+      "board": "core_hybrid",
       "cpu_fallbacks_per_proof": 13,
       "metal_dispatches_per_proof": 17,
       "native_mhz": 0.14603882522033465,
@@ -180,12 +200,16 @@
     "headline_eligible": true,
     "lanes": {
      "cpu": {
+      "backend": "cpu_native",
+      "board": "core_cpu",
       "native_mhz": 1.4718591384808875,
       "peak_rss_mib": null,
       "prove_ms": 11.1315,
       "request_ms": 11.451083
      },
      "metal": {
+      "backend": "metal_hybrid",
+      "board": "core_hybrid",
       "cpu_fallbacks_per_proof": 16,
       "metal_dispatches_per_proof": 22,
       "native_mhz": 1.0764517957014856,
@@ -208,12 +232,16 @@
     "headline_eligible": true,
     "lanes": {
      "cpu": {
+      "backend": "cpu_native",
+      "board": "core_cpu",
       "native_mhz": 0.4141975932854687,
       "peak_rss_mib": null,
       "prove_ms": 2.47225,
       "request_ms": 2.676834
      },
      "metal": {
+      "backend": "metal_hybrid",
+      "board": "core_hybrid",
       "cpu_fallbacks_per_proof": 13,
       "metal_dispatches_per_proof": 17,
       "native_mhz": 0.17557293529485796,
@@ -238,12 +266,16 @@
     "headline_eligible": true,
     "lanes": {
      "cpu": {
+      "backend": "cpu_native",
+      "board": "core_cpu",
       "native_mhz": 1.5681282526769156,
       "peak_rss_mib": null,
       "prove_ms": 10.448125,
       "request_ms": 10.704042
      },
      "metal": {
+      "backend": "metal_hybrid",
+      "board": "core_hybrid",
       "cpu_fallbacks_per_proof": 16,
       "metal_dispatches_per_proof": 22,
       "native_mhz": 1.1085218837673125,
@@ -268,12 +300,16 @@
     "headline_eligible": true,
     "lanes": {
      "cpu": {
+      "backend": "cpu_native",
+      "board": "core_cpu",
       "native_mhz": 0.22190919926319214,
       "peak_rss_mib": null,
       "prove_ms": 2.30725,
       "request_ms": 2.581792
      },
      "metal": {
+      "backend": "metal_hybrid",
+      "board": "core_hybrid",
       "cpu_fallbacks_per_proof": 11,
       "metal_dispatches_per_proof": 13,
       "native_mhz": 0.08967771021979096,
@@ -297,12 +333,16 @@
     "headline_eligible": true,
     "lanes": {
      "cpu": {
+      "backend": "cpu_native",
+      "board": "core_cpu",
       "native_mhz": 0.43092731686977764,
       "peak_rss_mib": null,
       "prove_ms": 23.762708,
       "request_ms": 27.437042
      },
      "metal": {
+      "backend": "metal_hybrid",
+      "board": "core_hybrid",
       "cpu_fallbacks_per_proof": 13,
       "metal_dispatches_per_proof": 15,
       "native_mhz": 0.5146256716392708,
@@ -327,13 +367,25 @@
  "boards": {
   "cairo_cpu": {
    "entries": [],
+   "era": {
+    "banked": false,
+    "closed_utc": null,
+    "epoch": 2,
+    "note": null,
+    "number": 2,
+    "opened_utc": "2026-07-21T16:00:00Z",
+    "reason": "Metrics v2 opens audit-anchored scoring and the manifest-owned five-class native scoring universe; the epoch boundary prevents pre-xlarge history from diluting the new geomean",
+    "scored_dimension": "prove_ms",
+    "source": "global_epoch",
+    "status": "open"
+   },
    "frontier_by_class": {
     "small": {
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -373,8 +425,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -411,6 +463,8 @@
      "head": null
     }
    },
+   "phase_telemetry": null,
+   "retirement": null,
    "scored_classes": [
     "small",
     "wide"
@@ -442,13 +496,25 @@
   },
   "cairo_metal": {
    "entries": [],
+   "era": {
+    "banked": false,
+    "closed_utc": null,
+    "epoch": 2,
+    "note": null,
+    "number": 2,
+    "opened_utc": "2026-07-21T16:00:00Z",
+    "reason": "Metrics v2 opens audit-anchored scoring and the manifest-owned five-class native scoring universe; the epoch boundary prevents pre-xlarge history from diluting the new geomean",
+    "scored_dimension": "prove_ms",
+    "source": "global_epoch",
+    "status": "open"
+   },
    "frontier_by_class": {
     "small": {
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -488,8 +554,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -526,6 +592,8 @@
      "head": null
     }
    },
+   "phase_telemetry": null,
+   "retirement": null,
    "scored_classes": [
     "small",
     "wide"
@@ -2553,13 +2621,25 @@
      "workload_class": "wide"
     }
    ],
+   "era": {
+    "banked": true,
+    "closed_utc": "2026-07-29T00:00:00Z",
+    "epoch": 2,
+    "note": "TRACKS \u00a76 retire-and-complete: the native CPU era is banked. New promotions refuse, the full ledger and final scores stay served, and the closing audit stamps the last audited score on the M5 judge host.",
+    "number": 2,
+    "opened_utc": "2026-07-21T16:00:00Z",
+    "reason": "Metrics v2 opens audit-anchored scoring and the manifest-owned five-class native scoring universe",
+    "scored_dimension": "prove_ms",
+    "source": "board_era",
+    "status": "banked"
+   },
    "frontier_by_class": {
     "deep": {
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -2882,8 +2962,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -3070,8 +3150,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -3288,8 +3368,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -3683,8 +3763,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -3829,6 +3909,12 @@
      }
     }
    },
+   "phase_telemetry": null,
+   "retirement": {
+    "closing_audit": null,
+    "reason": "TRACKS \u00a76 retire-and-complete: the native era is banked; history stays served; the native AIRs continue as PR6-supremacy cells and guard workloads",
+    "retired_at_utc": "2026-07-29T00:00:00Z"
+   },
    "scored_classes": [
     "small",
     "wide",
@@ -3875,13 +3961,25 @@
   },
   "core_cuda": {
    "entries": [],
+   "era": {
+    "banked": false,
+    "closed_utc": null,
+    "epoch": 2,
+    "note": null,
+    "number": 2,
+    "opened_utc": "2026-07-21T16:00:00Z",
+    "reason": "Metrics v2 opens audit-anchored scoring and the manifest-owned five-class native scoring universe; the epoch boundary prevents pre-xlarge history from diluting the new geomean",
+    "scored_dimension": "prove_ms",
+    "source": "global_epoch",
+    "status": "open"
+   },
    "frontier_by_class": {
     "deep": {
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -3921,8 +4019,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -3962,8 +4060,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -4003,8 +4101,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -4044,8 +4142,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -4082,6 +4180,8 @@
      "head": null
     }
    },
+   "phase_telemetry": null,
+   "retirement": null,
    "scored_classes": [
     "small",
     "wide",
@@ -4128,7 +4228,21 @@
   },
   "core_hybrid": {
    "entries": [],
+   "era": {
+    "banked": false,
+    "closed_utc": null,
+    "epoch": 2,
+    "note": null,
+    "number": 2,
+    "opened_utc": "2026-07-21T16:00:00Z",
+    "reason": "Metrics v2 opens audit-anchored scoring and the manifest-owned five-class native scoring universe; the epoch boundary prevents pre-xlarge history from diluting the new geomean",
+    "scored_dimension": "prove_ms",
+    "source": "global_epoch",
+    "status": "open"
+   },
    "frontier_by_class": {},
+   "phase_telemetry": null,
+   "retirement": null,
    "scored_classes": [],
    "suite_score": null
   },
@@ -6515,13 +6629,25 @@
      "workload_class": "deep"
     }
    ],
+   "era": {
+    "banked": true,
+    "closed_utc": "2026-07-29T00:00:00Z",
+    "epoch": 2,
+    "note": "TRACKS \u00a76 retire-and-complete: the native Metal era is banked. New promotions refuse, the full ledger and final scores stay served, and the closing audit stamps the last audited score on the M5 judge host.",
+    "number": 2,
+    "opened_utc": "2026-07-21T16:00:00Z",
+    "reason": "Metrics v2 opens audit-anchored scoring and the manifest-owned five-class native scoring universe; the Metal calibration freeze for this era is pinned in epoch 2's metal_calibration block",
+    "scored_dimension": "prove_ms",
+    "source": "board_era",
+    "status": "banked"
+   },
    "frontier_by_class": {
     "deep": {
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -6983,8 +7109,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -7103,8 +7229,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -7389,8 +7515,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -7924,8 +8050,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -8076,6 +8202,12 @@
      }
     }
    },
+   "phase_telemetry": null,
+   "retirement": {
+    "closing_audit": null,
+    "reason": "TRACKS \u00a76 retire-and-complete: the native era is banked; history stays served; the native AIRs continue as PR6-supremacy cells and guard workloads",
+    "retired_at_utc": "2026-07-29T00:00:00Z"
+   },
    "scored_classes": [
     "small",
     "wide",
@@ -8122,25 +8254,65 @@
   },
   "heavy_cairo": {
    "entries": [],
+   "era": {
+    "banked": false,
+    "closed_utc": null,
+    "epoch": 2,
+    "note": null,
+    "number": 2,
+    "opened_utc": "2026-07-21T16:00:00Z",
+    "reason": "Metrics v2 opens audit-anchored scoring and the manifest-owned five-class native scoring universe; the epoch boundary prevents pre-xlarge history from diluting the new geomean",
+    "scored_dimension": "prove_ms",
+    "source": "global_epoch",
+    "status": "open"
+   },
    "frontier_by_class": {},
+   "phase_telemetry": null,
+   "retirement": null,
    "scored_classes": [],
    "suite_score": null
   },
   "heavy_native": {
    "entries": [],
+   "era": {
+    "banked": false,
+    "closed_utc": null,
+    "epoch": 2,
+    "note": null,
+    "number": 2,
+    "opened_utc": "2026-07-21T16:00:00Z",
+    "reason": "Metrics v2 opens audit-anchored scoring and the manifest-owned five-class native scoring universe; the epoch boundary prevents pre-xlarge history from diluting the new geomean",
+    "scored_dimension": "prove_ms",
+    "source": "global_epoch",
+    "status": "open"
+   },
    "frontier_by_class": {},
+   "phase_telemetry": null,
+   "retirement": null,
    "scored_classes": [],
    "suite_score": null
   },
   "pr6_supremacy": {
    "entries": [],
+   "era": {
+    "banked": false,
+    "closed_utc": null,
+    "epoch": 2,
+    "note": null,
+    "number": 2,
+    "opened_utc": "2026-07-21T16:00:00Z",
+    "reason": "Metrics v2 opens audit-anchored scoring and the manifest-owned five-class native scoring universe; the epoch boundary prevents pre-xlarge history from diluting the new geomean",
+    "scored_dimension": "prove_ms",
+    "source": "global_epoch",
+    "status": "open"
+   },
    "frontier_by_class": {
     "deep": {
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -8180,8 +8352,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -8221,8 +8393,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -8262,8 +8434,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -8303,8 +8475,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -8341,6 +8513,8 @@
      "head": null
     }
    },
+   "phase_telemetry": null,
+   "retirement": null,
    "scored_classes": [
     "small",
     "wide",
@@ -8808,13 +8982,25 @@
      "workload_class": "wide"
     }
    ],
+   "era": {
+    "banked": false,
+    "closed_utc": null,
+    "epoch": 2,
+    "note": "TRACKS \u00a73.1 re-scores this board to the verified-request boundary at its NEXT era. Era 3 stays unopened until the M5 judge host recalibrates at that boundary; schema/scoring.md carries the exact era-3 record template and the operator commands.",
+    "number": 2,
+    "opened_utc": "2026-07-21T16:00:00Z",
+    "reason": "Metrics v2 opens audit-anchored scoring; the RISC-V board's frozen same-host M5 A/A dispersion enters with it",
+    "scored_dimension": "prove_ms",
+    "source": "board_era",
+    "status": "open"
+   },
    "frontier_by_class": {
     "deep": {
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -9004,8 +9190,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -9120,8 +9306,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1038,
-       "seconds": 690034
+       "commits": 1042,
+       "seconds": 691032
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -9234,6 +9420,8 @@
      }
     }
    },
+   "phase_telemetry": null,
+   "retirement": null,
    "scored_classes": [
     "small",
     "wide",
@@ -9270,7 +9458,21 @@
   },
   "stream": {
    "entries": [],
+   "era": {
+    "banked": false,
+    "closed_utc": null,
+    "epoch": 2,
+    "note": null,
+    "number": 2,
+    "opened_utc": "2026-07-21T16:00:00Z",
+    "reason": "Metrics v2 opens audit-anchored scoring and the manifest-owned five-class native scoring universe; the epoch boundary prevents pre-xlarge history from diluting the new geomean",
+    "scored_dimension": "prove_ms",
+    "source": "global_epoch",
+    "status": "open"
+   },
    "frontier_by_class": {},
+   "phase_telemetry": null,
+   "retirement": null,
    "scored_classes": [],
    "suite_score": null
   }
@@ -9298,9 +9500,11 @@
     "wide": 0.014801
    }
   },
-  "number": 2
+  "number": 2,
+  "opened_utc": "2026-07-21T16:00:00Z",
+  "reason": "Metrics v2 opens audit-anchored scoring and the manifest-owned five-class native scoring universe; the epoch boundary prevents pre-xlarge history from diluting the new geomean"
  },
- "feed_schema_version": 3,
+ "feed_schema_version": 4,
  "history": {
   "comparisons": 34,
   "runs": [
@@ -9472,6 +9676,8 @@
     "headline_eligible": true,
     "lanes": {
      "cpu": {
+      "backend": "cpu_native",
+      "board": "core_cpu",
       "native_mhz": 0.9651272384542884,
       "peak_rss_mib": 13.88,
       "prove_ms": 1.061,
@@ -9491,6 +9697,8 @@
       }
      },
      "metal": {
+      "backend": "metal_hybrid",
+      "board": "core_hybrid",
       "cpu_fallbacks_per_proof": 0,
       "metal_dispatches_per_proof": 18,
       "native_mhz": 0.4123973738664106,
@@ -9527,6 +9735,8 @@
     "headline_eligible": true,
     "lanes": {
      "cpu": {
+      "backend": "cpu_native",
+      "board": "core_cpu",
       "native_mhz": 3.2930459127057423,
       "peak_rss_mib": 34.36,
       "prove_ms": 4.975333,
@@ -9546,6 +9756,8 @@
       }
      },
      "metal": {
+      "backend": "metal_hybrid",
+      "board": "core_hybrid",
       "cpu_fallbacks_per_proof": 0,
       "metal_dispatches_per_proof": 22,
       "native_mhz": 3.546896141148455,
@@ -9582,6 +9794,8 @@
     "headline_eligible": true,
     "lanes": {
      "cpu": {
+      "backend": "cpu_native",
+      "board": "core_cpu",
       "native_mhz": 3.904486871210558,
       "peak_rss_mib": 113.45,
       "prove_ms": 16.784792,
@@ -9601,6 +9815,8 @@
       }
      },
      "metal": {
+      "backend": "metal_hybrid",
+      "board": "core_hybrid",
       "cpu_fallbacks_per_proof": 0,
       "metal_dispatches_per_proof": 25,
       "native_mhz": 4.764262217618087,
@@ -9637,6 +9853,8 @@
     "headline_eligible": true,
     "lanes": {
      "cpu": {
+      "backend": "cpu_native",
+      "board": "core_cpu",
       "native_mhz": 3.8839987265111593,
       "peak_rss_mib": 42.2,
       "prove_ms": 4.218333,
@@ -9656,6 +9874,8 @@
       }
      },
      "metal": {
+      "backend": "metal_hybrid",
+      "board": "core_hybrid",
       "cpu_fallbacks_per_proof": 0,
       "metal_dispatches_per_proof": 24,
       "native_mhz": 4.306337681111805,
@@ -9693,6 +9913,8 @@
     "headline_eligible": true,
     "lanes": {
      "cpu": {
+      "backend": "cpu_native",
+      "board": "core_cpu",
       "native_mhz": 5.718257502028212,
       "peak_rss_mib": 73.16,
       "prove_ms": 11.460834,
@@ -9712,6 +9934,8 @@
       }
      },
      "metal": {
+      "backend": "metal_hybrid",
+      "board": "core_hybrid",
       "cpu_fallbacks_per_proof": 0,
       "metal_dispatches_per_proof": 26,
       "native_mhz": 10.283315251962877,
@@ -9749,6 +9973,8 @@
     "headline_eligible": true,
     "lanes": {
      "cpu": {
+      "backend": "cpu_native",
+      "board": "core_cpu",
       "native_mhz": 3.778016619675894,
       "peak_rss_mib": 31.03,
       "prove_ms": 4.336667,
@@ -9768,6 +9994,8 @@
       }
      },
      "metal": {
+      "backend": "metal_hybrid",
+      "board": "core_hybrid",
       "cpu_fallbacks_per_proof": 0,
       "metal_dispatches_per_proof": 24,
       "native_mhz": 4.070516531256071,
@@ -9803,6 +10031,8 @@
     "headline_eligible": true,
     "lanes": {
      "cpu": {
+      "backend": "cpu_native",
+      "board": "core_cpu",
       "native_mhz": 5.638455061936453,
       "peak_rss_mib": 94.48,
       "prove_ms": 11.623042,
@@ -9822,6 +10052,8 @@
       }
      },
      "metal": {
+      "backend": "metal_hybrid",
+      "board": "core_hybrid",
       "cpu_fallbacks_per_proof": 0,
       "metal_dispatches_per_proof": 26,
       "native_mhz": 9.596836511558129,
@@ -9857,6 +10089,8 @@
     "headline_eligible": true,
     "lanes": {
      "cpu": {
+      "backend": "cpu_native",
+      "board": "core_cpu",
       "native_mhz": 3.8597513730222133,
       "peak_rss_mib": 28.48,
       "prove_ms": 4.244833,
@@ -9876,6 +10110,8 @@
       }
      },
      "metal": {
+      "backend": "metal_hybrid",
+      "board": "core_hybrid",
       "cpu_fallbacks_per_proof": 0,
       "metal_dispatches_per_proof": 24,
       "native_mhz": 4.3786998062403955,
@@ -9913,6 +10149,8 @@
     "headline_eligible": true,
     "lanes": {
      "cpu": {
+      "backend": "cpu_native",
+      "board": "core_cpu",
       "native_mhz": 5.582322260029606,
       "peak_rss_mib": 81.41,
       "prove_ms": 11.739917,
@@ -9932,6 +10170,8 @@
       }
      },
      "metal": {
+      "backend": "metal_hybrid",
+      "board": "core_hybrid",
       "cpu_fallbacks_per_proof": 0,
       "metal_dispatches_per_proof": 26,
       "native_mhz": 10.20485384555255,
@@ -9969,6 +10209,8 @@
     "headline_eligible": true,
     "lanes": {
      "cpu": {
+      "backend": "cpu_native",
+      "board": "core_cpu",
       "native_mhz": 1.0508087584499544,
       "peak_rss_mib": 39.11,
       "prove_ms": 9.744875,
@@ -9988,6 +10230,8 @@
       }
      },
      "metal": {
+      "backend": "metal_hybrid",
+      "board": "core_hybrid",
       "cpu_fallbacks_per_proof": 0,
       "metal_dispatches_per_proof": 18,
       "native_mhz": 1.4067141753241177,
@@ -10024,6 +10268,8 @@
     "headline_eligible": true,
     "lanes": {
      "cpu": {
+      "backend": "cpu_native",
+      "board": "core_cpu",
       "native_mhz": 4.235404363947749,
       "peak_rss_mib": 275.5,
       "prove_ms": 15.473375,
@@ -10043,6 +10289,8 @@
       }
      },
      "metal": {
+      "backend": "metal_hybrid",
+      "board": "core_hybrid",
       "cpu_fallbacks_per_proof": 0,
       "metal_dispatches_per_proof": 20,
       "native_mhz": 2.328544082573493,
@@ -10079,6 +10327,8 @@
     "headline_eligible": true,
     "lanes": {
      "cpu": {
+      "backend": "cpu_native",
+      "board": "core_cpu",
       "native_mhz": 0.35223294705808095,
       "peak_rss_mib": 31.92,
       "prove_ms": 2.907167,
@@ -10098,6 +10348,8 @@
       }
      },
      "metal": {
+      "backend": "metal_hybrid",
+      "board": "core_hybrid",
       "cpu_fallbacks_per_proof": 0,
       "metal_dispatches_per_proof": 15,
       "native_mhz": 0.21451576209028847,
@@ -10133,6 +10385,8 @@
     "headline_eligible": true,
     "lanes": {
      "cpu": {
+      "backend": "cpu_native",
+      "board": "core_cpu",
       "native_mhz": 0.6418239332478038,
       "peak_rss_mib": 40.81,
       "prove_ms": 12.763625,
@@ -10152,6 +10406,8 @@
       }
      },
      "metal": {
+      "backend": "metal_hybrid",
+      "board": "core_hybrid",
       "cpu_fallbacks_per_proof": 0,
       "metal_dispatches_per_proof": 18,
       "native_mhz": 0.9287981859410431,
@@ -10291,8 +10547,10 @@
     "board": "cairo_cpu",
     "disabled_reason": null,
     "enabled": true,
+    "promotion_blocked_reason": "TRACKS \u00a77: cairo_cpu records evidence but cannot promote until per-(board, class) A/A dispersion and anchors are measured on the designated Apple M5 Max judge host and frozen into harness.anchor_* plus a cairo calibration freeze for board cairo_cpu. No Cairo calibration exists yet, so promotion fails closed; the gate opens only after that M5 calibration is committed.",
     "promotion_eligible": false,
     "report_schema": "cairo_proof_v1",
+    "retirement": null,
     "workloads": {
      "cairo_all_builtins": {
       "class": "wide",
@@ -10308,8 +10566,10 @@
     "board": "cairo_metal",
     "disabled_reason": "cairo_metal is staged only: TRACKS \u00a72 records the Cairo + Metal product as parity_gated, not released. The product descriptor in build_support/products/cairo_metal.zig still carries state .parity_gated behind its test-cairo-metal-product and test-cairo-metal-oracle release gates, no Metal-lane Cairo calibration exists on the designated judge host, and the generalized per-board Metal calibration (TRACKS \u00a77) is not yet built. The group stays dark and fails closed.",
     "enabled": false,
+    "promotion_blocked_reason": "TRACKS \u00a77: no cairo_metal calibration exists on the designated Apple M5 Max judge host, and the product is parity_gated rather than released.",
     "promotion_eligible": false,
     "report_schema": "cairo_proof_v1",
+    "retirement": null,
     "workloads": {
      "mcairo_all_builtins": {
       "class": "wide",
@@ -10325,8 +10585,10 @@
     "board": "core_cuda",
     "disabled_reason": "core_cuda is staged only: all six Native AIR families are required, but only wide Fibonacci is exact and release-ready; exact family semantics, the stwo-perf CUDA report adapter, locked-host A/A calibration, pinned Rust verification, and complete structural coverage are not yet release-gated.",
     "enabled": false,
+    "promotion_blocked_reason": null,
     "promotion_eligible": false,
     "report_schema": "native_cuda_product_v6",
+    "retirement": null,
     "workloads": {
      "cuda_poseidon_log10": {
       "class": "small",
@@ -10374,8 +10636,14 @@
     "board": "core_metal",
     "disabled_reason": null,
     "enabled": true,
-    "promotion_eligible": true,
+    "promotion_blocked_reason": "TRACKS \u00a76 retire-and-complete: the native Metal era is banked. New promotions refuse; the board stays enabled so its history, final scores, guard workloads, and PR6-supremacy cells keep running.",
+    "promotion_eligible": false,
     "report_schema": "native_proof_v7",
+    "retirement": {
+     "closing_audit": null,
+     "reason": "TRACKS \u00a76 retire-and-complete: the native era is banked; history stays served; the native AIRs continue as PR6-supremacy cells and guard workloads",
+     "retired_at_utc": "2026-07-29T00:00:00Z"
+    },
     "workloads": {
      "mplonk_log14": {
       "class": "deep",
@@ -10403,8 +10671,14 @@
     "board": "core_cpu",
     "disabled_reason": null,
     "enabled": true,
-    "promotion_eligible": true,
+    "promotion_blocked_reason": "TRACKS \u00a76 retire-and-complete: the native CPU era is banked. New promotions refuse; the board stays enabled so its history, final scores, guard workloads, and PR6-supremacy cells keep running.",
+    "promotion_eligible": false,
     "report_schema": "native_proof_v7",
+    "retirement": {
+     "closing_audit": null,
+     "reason": "TRACKS \u00a76 retire-and-complete: the native era is banked; history stays served; the native AIRs continue as PR6-supremacy cells and guard workloads",
+     "retired_at_utc": "2026-07-29T00:00:00Z"
+    },
     "workloads": {
      "plonk_log14": {
       "class": "deep",
@@ -10432,8 +10706,10 @@
     "board": "pr6_supremacy",
     "disabled_reason": "PR6 Supremacy remains disabled until every exact workload port, log22 oracle vector, both timing boundaries, locked-M5 statistical gate, and authenticated judged verdict are complete.",
     "enabled": false,
+    "promotion_blocked_reason": null,
     "promotion_eligible": false,
     "report_schema": "pr6_supremacy_v1",
+    "retirement": null,
     "workloads": {
      "pr6_blake_log10": {
       "class": "deep",
@@ -10513,8 +10789,10 @@
     "board": "riscv",
     "disabled_reason": null,
     "enabled": true,
+    "promotion_blocked_reason": null,
     "promotion_eligible": true,
     "report_schema": "riscv_proof_v2",
+    "retirement": null,
     "workloads": {
      "riscv_alu_test": {
       "class": "small",
@@ -10600,14 +10878,18 @@
    }
   },
   "owned_boards": [
-   "core_cpu",
-   "core_metal",
    "riscv"
+  ],
+  "retired_boards": [
+   "core_cpu",
+   "core_metal"
   ],
   "staged_boards": [
    "cairo_cpu",
    "cairo_metal",
+   "core_cpu",
    "core_cuda",
+   "core_metal",
    "pr6_supremacy"
   ]
  },
@@ -10615,8 +10897,8 @@
   "determinism": "pure function of the named inputs; a committed feed names the commit it was generated FROM (one-commit lag by construction) \u2014 verify via inputs_sha256, not commit equality",
   "dirty_inputs": [],
   "inputs_sha256": {
-   "autoresearch/MANIFEST.json": "0fc90f339f5e8f41e87f0072e950d4312984fcf785663453852d56e16ca05f6b",
-   "autoresearch/ledger/epochs.json": "60162d440a812415d2943b1c1a2317b70be5fda727fae7eaa5c75ff408c4f7f5",
+   "autoresearch/MANIFEST.json": "7482fad7bfe07535b2acbbc4a7487b78275f61178ea494c6722c7b96b76d1fa5",
+   "autoresearch/ledger/epochs.json": "788378df0d2c39c52f905b9241e120d1b2b030bbf36e4e81dbc8c7e6b8c1a2f4",
    "autoresearch/ledger/promotions.tsv": "65ebaae10a028ea4dc7267a9cc8dc68b0c5bfc713218103047cb99054d64d676",
    "autoresearch/reference/metal-calibration-epoch-2.json": "e1a733f19dfe552389e25ff71d487cb889a3117b7fd71ea47c28cbc9000147df",
    "autoresearch/reference/peer-relative-series.json": "b85b4f079b69db227b120c16c965667070f40a67d1b37590a490b3ab514a3b2a",
@@ -10771,8 +11053,8 @@
    "vectors/reports/benchmark_history/index.json": "2df531dbefbd60f078b4c4a0b1c10c00a577832cd35520e065b430c61e6903f0",
    "vectors/reports/benchmark_history/runs/2026-07-23-110359-matrix-v6-e58b4d1e/report.json": "e772acbf9f58ff3916f2ffe91016ebc28bc6aadc75c6e68d5fd43ef3023d7be3"
   },
-  "repo_commit": "33a1a745a057",
-  "repo_commit_time": "2026-07-29T17:28:01+01:00"
+  "repo_commit": "08dc3f964e82",
+  "repo_commit_time": "2026-07-29T17:44:39+01:00"
  },
  "references": {
   "metal_calibration_epoch_2": {

--- a/autoresearch/tests/test_backend_server.py
+++ b/autoresearch/tests/test_backend_server.py
@@ -11,6 +11,7 @@ sys.path.insert(0, str(ROOT / "autoresearch" / "cli"))
 
 import server  # noqa: E402
 from store import Store  # noqa: E402
+from stwo_perf import feed as feed_mod  # noqa: E402
 
 
 IDENTITY = {
@@ -129,7 +130,7 @@ class BackendServerTest(unittest.TestCase):
             (ROOT / "autoresearch" / "site" / "feed.json").read_text()
         )
         self.assertEqual(feed, committed)
-        self.assertEqual(feed["feed_schema_version"], 3)
+        self.assertEqual(feed["feed_schema_version"], feed_mod.FEED_SCHEMA_VERSION)
         self.assertIn("promotion_scope", feed)
         self.assertIn("inputs_sha256", feed["provenance"])
 

--- a/autoresearch/tests/test_board_eras.py
+++ b/autoresearch/tests/test_board_eras.py
@@ -1,0 +1,476 @@
+"""TRACKS §7 per-board eras: bookkeeping, global fallback, and back-compat.
+
+The hard requirement these tests exist to defend: adding per-board eras changes
+NOTHING for a consumer that never asked for one. Every assertion below either
+pins the fallback to the pre-era behaviour or pins a per-board override to data
+that is explicitly declared — never inferred.
+"""
+
+import copy
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "autoresearch" / "cli"))
+
+from stwo_perf import ledger, metrics  # noqa: E402
+
+ANCHOR = "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc"
+OTHER_ANCHOR = "1" * 40
+
+
+def committed_document() -> dict:
+    return json.loads(ledger.epochs_path(ROOT).read_text())
+
+
+class _Repo:
+    """A throwaway repository root holding only ledger/epochs.json."""
+
+    def __init__(self, document: dict):
+        self._tmp = tempfile.TemporaryDirectory(prefix="stwo-eras-")
+        self.root = Path(self._tmp.name)
+        path = ledger.epochs_path(self.root)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(document, indent=2) + "\n")
+
+    def __enter__(self) -> Path:
+        return self.root
+
+    def __exit__(self, *exc) -> None:
+        self._tmp.cleanup()
+
+
+def with_eras(boards: dict) -> _Repo:
+    document = committed_document()
+    document["board_eras"] = {"note": "test fixture", "boards": boards}
+    return _Repo(document)
+
+
+def era(number: int, epoch_ref: int, opened: str, **extra) -> dict:
+    record = {
+        "era": number,
+        "epoch_ref": epoch_ref,
+        "opened_utc": opened,
+        "reason": f"test era {number}",
+    }
+    record.update(extra)
+    return record
+
+
+class CommittedEraSequenceTest(unittest.TestCase):
+    """The era sequences this PR commits, read back through the resolver."""
+
+    def test_native_boards_are_banked_at_era_two(self):
+        for board in ("core_cpu", "core_metal"):
+            current = ledger.current_era(ROOT, board)
+            self.assertIsNotNone(current, board)
+            self.assertEqual(current["era"], 2, board)
+            self.assertEqual(current["epoch_ref"], 2, board)
+            self.assertEqual(current["status"], "banked", board)
+            self.assertEqual(current["closed_utc"], "2026-07-29T00:00:00Z", board)
+            self.assertEqual(len(ledger.board_eras(ROOT, board)), 2, board)
+
+    def test_riscv_era_two_is_open_and_still_scores_prove_ms(self):
+        current = ledger.current_era(ROOT, "riscv")
+        self.assertEqual(current["era"], 2)
+        self.assertEqual(current["status"], "open")
+        self.assertIsNone(current["closed_utc"])
+        # TRACKS §3.1 re-scores RISC-V at its NEXT era; era 2 must not move.
+        self.assertEqual(ledger.scored_dimension(ROOT, "riscv"), "prove_ms")
+
+    def test_boards_without_an_era_sequence_declare_none(self):
+        for board in ("cairo_cpu", "cairo_metal", "stream", "heavy_native"):
+            self.assertEqual(ledger.board_eras(ROOT, board), (), board)
+            self.assertIsNone(ledger.current_era(ROOT, board), board)
+
+    def test_every_committed_era_sequence_names_a_registered_board(self):
+        declared = set(
+            json.loads(ledger.epochs_path(ROOT).read_text())["board_eras"]["boards"]
+        )
+        self.assertTrue(declared)
+        self.assertEqual(declared - set(ledger.BOARDS), set())
+
+
+class BackCompatGoldenTest(unittest.TestCase):
+    """Absent per-board data reproduces today's behaviour exactly."""
+
+    def setUp(self):
+        self.document = committed_document()
+        self.global_epoch = max(
+            int(spec["epoch"]) for spec in self.document["epochs"]
+        )
+
+    def test_global_epochs_one_and_two_are_readable_unchanged(self):
+        epochs = ledger.known_epochs(ROOT)
+        self.assertEqual(sorted(epochs), [1, 2])
+        self.assertEqual(epochs[1]["opened_utc"], "2026-07-18T00:00:00Z")
+        self.assertEqual(epochs[2]["metrics_v2"]["audit_anchor_commit"], ANCHOR)
+        self.assertEqual(ledger.current_epoch(ROOT)["epoch"], self.global_epoch)
+
+    def test_board_scoped_resolution_matches_the_global_epoch_today(self):
+        # Every committed era references the newest global epoch, so no board
+        # may resolve to anything else while that stays true.
+        global_spec = ledger.current_epoch(ROOT)
+        for board in ledger.BOARDS:
+            spec = ledger.current_epoch(ROOT, board=board)
+            self.assertEqual(int(spec["epoch"]), self.global_epoch, board)
+            self.assertEqual(
+                spec["metrics_v2"]["audit_anchor_commit"],
+                global_spec["metrics_v2"]["audit_anchor_commit"],
+                board,
+            )
+            self.assertEqual(
+                spec["aa_dispersion"].get(board),
+                global_spec["aa_dispersion"].get(board),
+                board,
+            )
+
+    def test_dispersion_and_budgets_are_unchanged_for_every_board_and_class(self):
+        epoch = ledger.known_epochs(ROOT)[self.global_epoch]
+        for board, classes in epoch["aa_dispersion"].items():
+            if board == "note":
+                continue
+            for workload_class, expected in classes.items():
+                self.assertEqual(
+                    ledger.aa_dispersion(ROOT, board, workload_class),
+                    float(expected) if expected is not None else None,
+                    f"{board}/{workload_class}",
+                )
+        for workload_class, expected in epoch["metrics_v2"]["resource_budgets"].items():
+            self.assertEqual(
+                ledger.resource_budgets(ROOT, workload_class),
+                {key: float(value) for key, value in expected.items()},
+                workload_class,
+            )
+
+    def test_a_document_without_board_eras_behaves_identically(self):
+        document = committed_document()
+        document.pop("board_eras", None)
+        with _Repo(document) as repo:
+            self.assertEqual(ledger.board_eras(repo, "core_cpu"), ())
+            self.assertIsNone(ledger.current_era(repo, "core_cpu"))
+            self.assertEqual(
+                ledger.current_epoch(repo, board="core_cpu"),
+                ledger.current_epoch(repo),
+            )
+            self.assertEqual(
+                ledger.aa_dispersion(repo, "core_cpu", "small"), 0.018654,
+            )
+            self.assertEqual(
+                ledger.resource_budgets(repo, "small", board="core_cpu"),
+                ledger.resource_budgets(repo, "small"),
+            )
+
+    def test_a_board_with_no_era_falls_back_to_the_newest_global_epoch(self):
+        with with_eras({"riscv": [era(1, 1, "2026-07-18T00:00:00Z")]}) as repo:
+            self.assertEqual(
+                ledger.current_epoch(repo, board="cairo_cpu"),
+                ledger.current_epoch(repo),
+            )
+            # An unknown board never invents an era; it falls back too.
+            self.assertEqual(ledger.board_eras(repo, "stream"), ())
+
+
+class EraResolutionTest(unittest.TestCase):
+    def test_a_banked_board_stays_pinned_when_a_later_epoch_opens(self):
+        document = committed_document()
+        document["epochs"].append({
+            "epoch": 3,
+            "opened_utc": "2026-08-01T00:00:00Z",
+            "reason": "a later global epoch that the retired board never joins",
+            "harness_commit": None,
+            "metrics_v2": copy.deepcopy(document["epochs"][1]["metrics_v2"]),
+            "aa_dispersion": {},
+        })
+        with _Repo(document) as repo:
+            # The global epoch advanced...
+            self.assertEqual(ledger.current_epoch(repo)["epoch"], 3)
+            # ...but a banked board's scoring is frozen at its own era.
+            self.assertEqual(
+                ledger.current_epoch(repo, board="core_cpu")["epoch"], 2,
+            )
+            self.assertEqual(
+                ledger.current_epoch(repo, board="core_cpu")["era"]["status"],
+                "banked",
+            )
+            # A board with no era sequence follows the global epoch.
+            self.assertEqual(
+                ledger.current_epoch(repo, board="cairo_cpu")["epoch"], 3,
+            )
+
+    def test_epoch_for_board_resolves_a_named_epoch_not_only_the_newest(self):
+        self.assertEqual(
+            ledger.epoch_for_board(ROOT, 1, "core_cpu")["era"]["era"], 1,
+        )
+        self.assertEqual(
+            ledger.epoch_for_board(ROOT, 2, "core_cpu")["era"]["era"], 2,
+        )
+        # No board argument, or no covering era, returns the global record.
+        self.assertEqual(
+            ledger.epoch_for_board(ROOT, 1), ledger.known_epochs(ROOT)[1],
+        )
+        self.assertEqual(
+            ledger.epoch_for_board(ROOT, 1, "cairo_cpu"),
+            ledger.known_epochs(ROOT)[1],
+        )
+        with self.assertRaises(ledger.LedgerError):
+            ledger.epoch_for_board(ROOT, 99, "core_cpu")
+
+    def test_per_board_audit_anchor_overrides_the_epoch_anchor(self):
+        boards = {
+            "riscv": [
+                era(1, 1, "2026-07-18T00:00:00Z", status="banked",
+                    closed_utc="2026-07-21T16:00:00Z"),
+                era(2, 2, "2026-07-21T16:00:00Z",
+                    audit_anchor_commit=OTHER_ANCHOR),
+            ],
+        }
+        with with_eras(boards) as repo:
+            board_policy = metrics.policy_from_epoch(
+                ledger.current_epoch(repo, board="riscv")
+            )
+            self.assertEqual(board_policy.audit_anchor_commit, OTHER_ANCHOR)
+            self.assertEqual(board_policy.board, "riscv")
+            self.assertEqual(board_policy.era, 2)
+            # The global epoch's anchor is untouched, and stays the fallback
+            # for every board that pins none.
+            self.assertEqual(
+                metrics.policy_from_epoch(
+                    ledger.current_epoch(repo)
+                ).audit_anchor_commit,
+                ANCHOR,
+            )
+            fallback = metrics.policy_from_epoch(
+                ledger.current_epoch(repo, board="cairo_cpu")
+            )
+            self.assertEqual(fallback.audit_anchor_commit, ANCHOR)
+            self.assertIsNone(fallback.board)
+            self.assertIsNone(fallback.era)
+
+    def test_per_board_dispersion_override_is_merged_not_replaced(self):
+        boards = {
+            "riscv": [
+                era(1, 1, "2026-07-18T00:00:00Z", status="banked",
+                    closed_utc="2026-07-21T16:00:00Z"),
+                era(2, 2, "2026-07-21T16:00:00Z",
+                    aa_dispersion={"small": 0.004, "deep": None}),
+            ],
+        }
+        with with_eras(boards) as repo:
+            self.assertEqual(ledger.aa_dispersion(repo, "riscv", "small"), 0.004)
+            self.assertIsNone(ledger.aa_dispersion(repo, "riscv", "deep"))
+            # A class the era does not pin still inherits the epoch value.
+            self.assertEqual(ledger.aa_dispersion(repo, "riscv", "wide"), 0.014801)
+            # Another board is untouched.
+            self.assertEqual(
+                ledger.aa_dispersion(repo, "core_cpu", "small"), 0.018654,
+            )
+
+
+class ResourceBudgetKeyTest(unittest.TestCase):
+    """TRACKS §8: budgets keyed (board, class), falling back to class-only."""
+
+    def setUp(self):
+        self.boards = {
+            "riscv": [
+                era(1, 1, "2026-07-18T00:00:00Z", status="banked",
+                    closed_utc="2026-07-21T16:00:00Z"),
+                era(2, 2, "2026-07-21T16:00:00Z", resource_budgets={
+                    "small": {
+                        "peak_rss_mib": 1.20,
+                        "energy_j": 1.10,
+                        "proof_bytes": 1.00,
+                    },
+                }),
+            ],
+        }
+
+    def test_board_keyed_budget_wins_for_that_board_and_class(self):
+        with with_eras(self.boards) as repo:
+            self.assertEqual(
+                ledger.resource_budgets(repo, "small", board="riscv"),
+                {"peak_rss_mib": 1.20, "energy_j": 1.10, "proof_bytes": 1.00},
+            )
+
+    def test_unpinned_class_falls_back_to_the_class_only_budget(self):
+        with with_eras(self.boards) as repo:
+            class_only = ledger.resource_budgets(repo, "wide")
+            self.assertEqual(
+                ledger.resource_budgets(repo, "wide", board="riscv"), class_only,
+            )
+
+    def test_other_boards_and_the_global_call_are_unaffected(self):
+        with with_eras(self.boards) as repo:
+            class_only = ledger.resource_budgets(repo, "small")
+            self.assertEqual(class_only["peak_rss_mib"], 1.05)
+            self.assertEqual(
+                ledger.resource_budgets(repo, "small", board="core_cpu"),
+                class_only,
+            )
+
+    def test_a_legacy_epoch_without_metrics_v2_still_returns_none(self):
+        document = {"epochs": [{"epoch": 1, "opened_utc": "2026-07-18T00:00:00Z",
+                                "reason": "legacy", "aa_dispersion": {}}]}
+        with _Repo(document) as repo:
+            self.assertIsNone(ledger.resource_budgets(repo, "small"))
+            self.assertIsNone(
+                ledger.resource_budgets(repo, "small", board="core_cpu")
+            )
+
+
+class EraValidationTest(unittest.TestCase):
+    """Fail closed: a malformed era is an error, never a silent default."""
+
+    def _rejects(self, boards: dict, needle: str, board: str = "riscv") -> None:
+        with with_eras(boards) as repo:
+            with self.assertRaises(ledger.LedgerError) as ctx:
+                ledger.board_eras(repo, board)
+            self.assertIn(needle, str(ctx.exception))
+
+    def test_unregistered_board_is_rejected(self):
+        self._rejects(
+            {"invented_board": [era(1, 1, "2026-07-18T00:00:00Z")]},
+            "not a registered scoring board",
+            board="invented_board",
+        )
+
+    def test_unknown_epoch_reference_is_rejected(self):
+        self._rejects(
+            {"riscv": [era(1, 9, "2026-07-18T00:00:00Z")]},
+            "must name a global epoch",
+        )
+
+    def test_era_numbers_must_be_contiguous_and_ascending(self):
+        self._rejects(
+            {"riscv": [
+                era(1, 1, "2026-07-18T00:00:00Z", status="banked",
+                    closed_utc="2026-07-21T16:00:00Z"),
+                era(3, 2, "2026-07-21T16:00:00Z"),
+            ]},
+            "numbered 1..n",
+        )
+
+    def test_only_the_newest_era_may_stay_open(self):
+        self._rejects(
+            {"riscv": [
+                era(1, 1, "2026-07-18T00:00:00Z"),
+                era(2, 2, "2026-07-21T16:00:00Z"),
+            ]},
+            "only the newest era may stay open",
+        )
+
+    def test_banked_era_must_record_when_it_closed(self):
+        self._rejects(
+            {"riscv": [era(1, 1, "2026-07-18T00:00:00Z", status="banked")]},
+            "must record 'closed_utc'",
+        )
+
+    def test_open_era_must_not_record_a_close(self):
+        self._rejects(
+            {"riscv": [
+                era(1, 1, "2026-07-18T00:00:00Z", closed_utc="2026-07-19T00:00:00Z")
+            ]},
+            "must not record 'closed_utc'",
+        )
+
+    def test_unknown_status_and_unknown_keys_are_rejected(self):
+        self._rejects(
+            {"riscv": [era(1, 1, "2026-07-18T00:00:00Z", status="paused")]},
+            "'status' must be one of",
+        )
+        self._rejects(
+            {"riscv": [era(1, 1, "2026-07-18T00:00:00Z", smuggled=True)]},
+            "unknown key(s)",
+        )
+
+    def test_missing_reason_and_malformed_timestamps_are_rejected(self):
+        boards = {"riscv": [era(1, 1, "2026-07-18T00:00:00Z")]}
+        boards["riscv"][0]["reason"] = "  "
+        self._rejects(boards, "'reason' must be a non-empty string")
+        self._rejects(
+            {"riscv": [era(1, 1, "18 July 2026")]}, "must be ISO-8601 UTC",
+        )
+
+    def test_an_era_may_not_open_before_the_epoch_it_inherits(self):
+        self._rejects(
+            {"riscv": [era(1, 2, "2026-07-19T00:00:00Z")]},
+            "precedes the global epoch it inherits",
+        )
+
+    def test_opened_utc_must_strictly_increase(self):
+        self._rejects(
+            {"riscv": [
+                era(1, 1, "2026-07-21T16:00:00Z", status="banked",
+                    closed_utc="2026-07-21T16:00:00Z"),
+                era(2, 2, "2026-07-21T16:00:00Z"),
+            ]},
+            "opened_utc must strictly increase",
+        )
+
+    def test_malformed_overrides_are_rejected(self):
+        self._rejects(
+            {"riscv": [era(1, 1, "2026-07-18T00:00:00Z", audit_anchor_commit="abc")]},
+            "must be a 40-hex commit",
+        )
+        self._rejects(
+            {"riscv": [era(1, 1, "2026-07-18T00:00:00Z", aa_dispersion={"small": 0})]},
+            "must be positive and finite, or null",
+        )
+        self._rejects(
+            {"riscv": [era(1, 1, "2026-07-18T00:00:00Z", resource_budgets={
+                "small": {"peak_rss_mib": 1.0},
+            })]},
+            "must contain exactly",
+        )
+
+    def test_board_eras_block_shape_is_fail_closed(self):
+        document = committed_document()
+        document["board_eras"] = {"boards": {}, "unexpected": 1}
+        with _Repo(document) as repo:
+            with self.assertRaises(ledger.LedgerError):
+                ledger.board_eras(repo, "riscv")
+        document["board_eras"] = {"boards": {"riscv": []}}
+        with _Repo(document) as repo:
+            with self.assertRaises(ledger.LedgerError):
+                ledger.board_eras(repo, "riscv")
+
+
+class ScoredDimensionGateTest(unittest.TestCase):
+    """TRACKS §3.1 staging: the boundary switch cannot open uncalibrated."""
+
+    def test_default_is_todays_boundary_everywhere(self):
+        self.assertEqual(ledger.DEFAULT_SCORED_DIMENSION, "prove_ms")
+        for board in ledger.BOARDS:
+            self.assertEqual(ledger.scored_dimension(ROOT, board), "prove_ms", board)
+        self.assertEqual(ledger.scored_dimension(ROOT), "prove_ms")
+
+    def test_switching_the_boundary_requires_a_recalibrated_era(self):
+        with with_eras({"riscv": [
+            era(1, 1, "2026-07-18T00:00:00Z", scored_dimension="request_ms"),
+        ]}) as repo:
+            with self.assertRaises(ledger.LedgerError) as ctx:
+                ledger.board_eras(repo, "riscv")
+            self.assertIn("must declare its own measured aa_dispersion", str(ctx.exception))
+
+    def test_an_unknown_boundary_is_refused(self):
+        with with_eras({"riscv": [
+            era(1, 1, "2026-07-18T00:00:00Z", scored_dimension="vibes"),
+        ]}) as repo:
+            with self.assertRaises(ledger.LedgerError):
+                ledger.board_eras(repo, "riscv")
+
+    def test_a_recalibrated_era_may_declare_the_request_boundary(self):
+        with with_eras({"riscv": [
+            era(1, 1, "2026-07-18T00:00:00Z", scored_dimension="request_ms",
+                aa_dispersion={"small": 0.003, "wide": 0.009, "deep": 0.006}),
+        ]}) as repo:
+            self.assertEqual(ledger.scored_dimension(repo, "riscv"), "request_ms")
+            # Nothing else moves: other boards keep today's boundary.
+            self.assertEqual(ledger.scored_dimension(repo, "core_cpu"), "prove_ms")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/autoresearch/tests/test_feed.py
+++ b/autoresearch/tests/test_feed.py
@@ -72,12 +72,18 @@ class FeedTest(unittest.TestCase):
 
     def test_v3_promotion_scope_partitions_the_board_universe(self):
         from stwo_perf import ledger
-        self.assertEqual(self.feed["feed_schema_version"], 3)
+        self.assertEqual(self.feed["feed_schema_version"], 4)
         scope = self.feed["promotion_scope"]
         owned = set(scope["owned_boards"])
         future = set(scope["future_boards"])
-        self.assertEqual(owned | future, set(ledger.BOARDS))
+        # TRACKS §6: retired boards are completed, not future. They leave
+        # `owned_boards` with the retirement flip but must never be rendered
+        # out-of-scope, so they partition out separately.
+        retired = set(scope["retired_boards"])
+        self.assertEqual(owned | future | retired, set(ledger.BOARDS))
         self.assertEqual(owned & future, set())
+        self.assertEqual(retired & future, set())
+        self.assertEqual(retired & owned, set())
         # Promotion-ineligible dark boards are staged, not smuggled into the
         # live ledger universe.
         self.assertEqual(

--- a/autoresearch/tests/test_manifest.py
+++ b/autoresearch/tests/test_manifest.py
@@ -170,8 +170,12 @@ class ManifestTest(unittest.TestCase):
         self.assertIn("native", by_id)
         self.assertIn("riscv", by_id)
         native, riscv = by_id["native"], by_id["riscv"]
+        # TRACKS §6 retire-and-complete: the native board stays ENABLED — its
+        # history, guard workloads, and PR6-supremacy cells keep running — but
+        # it no longer accepts promotions.
         self.assertTrue(native.enabled)
-        self.assertTrue(native.promotion_eligible)
+        self.assertFalse(native.promotion_eligible)
+        self.assertTrue(native.retirement)
         self.assertEqual(native.board, "core_cpu")
         self.assertEqual(native.binary, "zig-out/bin/native-proof-bench-cpu")
         self.assertEqual(native.report_schema, "native_proof_v7")

--- a/autoresearch/tests/test_native_retirement.py
+++ b/autoresearch/tests/test_native_retirement.py
@@ -1,0 +1,329 @@
+"""TRACKS §6 retire-and-complete: the native era is banked, not deleted.
+
+Retirement means exactly three things, and each has a test here: new
+promotions refuse with a legible reason, the full history keeps being served
+(board names, ledger rows, scores, feed entries all survive), and the closing
+audit that stamps the final audited score is still runnable until it lands.
+"""
+
+import copy
+import json
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "autoresearch" / "cli"))
+sys.path.insert(0, str(ROOT))  # runner imports scripts.* from the repo root
+
+from stwo_perf import (  # noqa: E402
+    audits, feed, ledger, manifest as manifest_mod, promotion,
+)
+
+RETIRED = {"native": "core_cpu", "metal": "core_metal"}
+
+
+def raw_manifest() -> dict:
+    return json.loads((ROOT / "autoresearch" / "MANIFEST.json").read_text())
+
+
+class RetirementManifestTest(unittest.TestCase):
+    def setUp(self):
+        self.m = manifest_mod.load(ROOT)
+        self.groups = {group.group_id: group for group in self.m.groups()}
+
+    def test_native_groups_are_retired_but_stay_enabled(self):
+        for group_id, board in RETIRED.items():
+            group = self.groups[group_id]
+            self.assertEqual(group.board, board)
+            # Enabled: history, guard workloads, and the PR6-supremacy cells
+            # keep running. Not promotion eligible: the era is banked.
+            self.assertTrue(group.enabled, group_id)
+            self.assertFalse(group.promotion_eligible, group_id)
+            self.assertTrue(group.promotion_blocked_reason, group_id)
+            self.assertIsNone(group.disabled_reason, group_id)
+
+    def test_retirement_block_is_complete_and_the_closing_audit_is_pending(self):
+        for group_id in RETIRED:
+            retirement = self.groups[group_id].retirement
+            self.assertEqual(
+                set(retirement), set(manifest_mod.RETIREMENT_KEYS), group_id,
+            )
+            self.assertEqual(
+                retirement["retired_at_utc"], "2026-07-29T00:00:00Z", group_id,
+            )
+            self.assertIn("TRACKS §6", retirement["reason"], group_id)
+            # The closing audit runs on the M5 judge host; nothing may claim it
+            # happened before its evidence lands.
+            self.assertIsNone(retirement["closing_audit"], group_id)
+
+    def test_no_other_group_is_retired(self):
+        for group in self.m.groups():
+            if group.group_id not in RETIRED:
+                self.assertFalse(group.retirement, group.group_id)
+
+    def test_history_is_never_dropped_from_the_board_universe(self):
+        for board in RETIRED.values():
+            self.assertIn(board, ledger.BOARDS)
+        # And the retired boards still own their five scored classes, so their
+        # final scores stay computable.
+        for board in RETIRED.values():
+            self.assertEqual(
+                self.m.class_names(board=board, scored_only=True, include_disabled=True),
+                ["small", "wide", "deep", "xlarge", "huge"],
+            )
+
+
+class RetirementValidationTest(unittest.TestCase):
+    """A retirement block cannot be half-declared."""
+
+    def _rejects(self, mutate, needle: str) -> None:
+        raw = raw_manifest()
+        mutate(raw["workload_registry"]["groups"]["native"])
+        with self.assertRaises(manifest_mod.ManifestError) as ctx:
+            manifest_mod.Manifest(ROOT, manifest_mod._validate(raw) or raw)
+        self.assertIn(needle, str(ctx.exception))
+
+    def test_a_retired_group_cannot_be_promotion_eligible(self):
+        def mutate(group):
+            group["promotion_eligible"] = True
+        self._rejects(mutate, "retired group cannot be promotion eligible")
+
+    def test_a_retired_group_must_explain_its_refusal(self):
+        def mutate(group):
+            group["promotion_blocked_reason"] = "   "
+        self._rejects(mutate, "must state a promotion_blocked_reason")
+
+    def test_retirement_keys_are_exact(self):
+        def mutate(group):
+            group["retirement"].pop("closing_audit")
+        self._rejects(mutate, "'retirement' must contain exactly")
+
+        def extra(group):
+            group["retirement"]["celebrated"] = True
+        self._rejects(extra, "'retirement' must contain exactly")
+
+    def test_retirement_timestamp_and_reason_are_validated(self):
+        def mutate(group):
+            group["retirement"]["retired_at_utc"] = "yesterday"
+        self._rejects(mutate, "retired_at_utc must be ISO-8601 UTC")
+
+        def blank(group):
+            group["retirement"]["reason"] = ""
+        self._rejects(blank, "reason must be a non-empty string")
+
+    def test_a_recorded_closing_audit_must_name_its_evidence(self):
+        def mutate(group):
+            group["retirement"]["closing_audit"] = {"completed_utc": "2026-08-01T00:00:00Z"}
+        self._rejects(mutate, "closing_audit must be null or contain exactly")
+
+        def bad_ids(group):
+            group["retirement"]["closing_audit"] = {
+                "completed_utc": "2026-08-01T00:00:00Z",
+                "bundle_sha256": "sha256:" + "a" * 64,
+                "row_ids": [],
+            }
+        self._rejects(bad_ids, "row_ids must be a unique non-empty list")
+
+    def test_a_well_formed_closing_audit_is_accepted(self):
+        raw = raw_manifest()
+        raw["workload_registry"]["groups"]["native"]["retirement"]["closing_audit"] = {
+            "completed_utc": "2026-08-01T00:00:00Z",
+            "bundle_sha256": "sha256:" + "a" * 64,
+            "row_ids": ["sha256:" + "b" * 64],
+        }
+        manifest_mod._validate(raw)  # must not raise
+
+    def test_scored_dimension_is_validated_and_defaults_to_todays_boundary(self):
+        raw = raw_manifest()
+        self.assertEqual(
+            manifest_mod.load(ROOT).group("riscv").scored_dimension, "prove_ms",
+        )
+        raw["workload_registry"]["groups"]["riscv"]["scored_dimension"] = "vibes"
+        with self.assertRaises(manifest_mod.ManifestError) as ctx:
+            manifest_mod._validate(raw)
+        self.assertIn("'scored_dimension' must be one of", str(ctx.exception))
+        raw["workload_registry"]["groups"]["riscv"]["scored_dimension"] = "request_ms"
+        manifest_mod._validate(raw)  # the staged TRACKS §3.1 value is declarable
+
+
+class RetiredPromotionRefusalTest(unittest.TestCase):
+    def setUp(self):
+        self.m = manifest_mod.load(ROOT)
+
+    def test_promotion_on_a_retired_board_refuses_with_a_retirement_reason(self):
+        for board in RETIRED.values():
+            with self.assertRaises(promotion.PromotionError) as ctx:
+                promotion.require_board_promotion_eligible(self.m, board)
+            message = str(ctx.exception)
+            self.assertIn("retired", message, board)
+            self.assertIn("2026-07-29T00:00:00Z", message, board)
+            self.assertIn("history stays served", message, board)
+            # The generic contract still holds, so existing callers matching on
+            # the old text keep working.
+            self.assertIn("not promotion eligible", message, board)
+
+    def test_a_verdict_declaring_a_retired_board_is_refused(self):
+        verdict = {
+            "declared_objective": {"board": "core_cpu", "workload_class": "small"},
+        }
+        with self.assertRaises(promotion.PromotionError) as ctx:
+            promotion.require_verdict_promotion_eligible(ROOT, verdict)
+        self.assertIn("retired", str(ctx.exception))
+
+    def test_a_live_board_still_promotes(self):
+        promotion.require_board_promotion_eligible(self.m, "riscv")
+
+    def test_a_merely_staged_board_keeps_the_plain_refusal(self):
+        with self.assertRaises(promotion.PromotionError) as ctx:
+            promotion.require_board_promotion_eligible(self.m, "cairo_cpu")
+        self.assertNotIn("retired", str(ctx.exception))
+
+
+class ClosingAuditReachabilityTest(unittest.TestCase):
+    """A retired board still owes its closing audit (TRACKS §6)."""
+
+    def _item(self, manifest, retirement_state) -> dict:
+        from test_audits import ANCHOR, CANDIDATE, parsed, promotion as promo
+
+        rows = parsed(*[
+            promo(f"n-{index}", index, outcome="neutral",
+                  judged_r=0.999, ci_low=0.98, ci_high=1.01)
+            for index in range(1, 5)
+        ])
+        return audits._item(
+            manifest, rows, 2, "core_cpu", "small", CANDIDATE,
+            "sha256:" + "a" * 64,
+            lambda value: ANCHOR if value.endswith("^1") else value,
+        )
+
+    def test_a_retired_board_audit_is_still_runnable(self):
+        item = self._item(manifest_mod.load(ROOT), None)
+        self.assertIsNotNone(item)
+        self.assertTrue(
+            item["runnable"],
+            f"retired boards must keep their closing audit reachable: "
+            f"{item['blocked_reason']}",
+        )
+
+    def test_a_recorded_closing_audit_closes_the_cell(self):
+        raw = raw_manifest()
+        raw["workload_registry"]["groups"]["native"]["retirement"]["closing_audit"] = {
+            "completed_utc": "2026-08-01T00:00:00Z",
+            "bundle_sha256": "sha256:" + "a" * 64,
+            "row_ids": ["sha256:" + "b" * 64],
+        }
+        item = self._item(manifest_mod.Manifest(ROOT, raw), "recorded")
+        self.assertFalse(item["runnable"])
+        self.assertIn("already recorded its closing audit", item["blocked_reason"])
+
+    def test_a_staged_never_calibrated_board_stays_blocked(self):
+        raw = raw_manifest()
+        raw["workload_registry"]["groups"]["native"].pop("retirement")
+        item = self._item(manifest_mod.Manifest(ROOT, raw), None)
+        self.assertFalse(item["runnable"])
+        self.assertIn("promotion eligible", item["blocked_reason"])
+
+
+class RetirementFeedTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.feed = feed.build_feed(manifest_mod.load(ROOT), allow_dirty=True)
+
+    def test_feed_declares_schema_v4(self):
+        self.assertEqual(self.feed["feed_schema_version"], 4)
+        self.assertEqual(feed.FEED_SCHEMA_VERSION, 4)
+
+    def test_global_epoch_publishes_when_and_why_it_opened(self):
+        epoch = self.feed["epoch"]
+        self.assertEqual(epoch["number"], 2)
+        self.assertEqual(epoch["opened_utc"], "2026-07-21T16:00:00Z")
+        self.assertIn("Metrics v2", epoch["reason"])
+
+    def test_every_board_publishes_an_era(self):
+        for board, entry in self.feed["boards"].items():
+            era = entry["era"]
+            self.assertEqual(
+                set(era),
+                {
+                    "number", "epoch", "opened_utc", "reason", "status",
+                    "banked", "closed_utc", "scored_dimension", "note", "source",
+                },
+                board,
+            )
+            self.assertIsInstance(era["number"], int, board)
+            self.assertTrue(era["opened_utc"], board)
+            self.assertTrue(era["reason"], board)
+            self.assertIn(era["source"], ("board_era", "global_epoch"), board)
+            self.assertEqual(era["banked"], era["status"] == "banked", board)
+
+    def test_retired_boards_publish_a_banked_era_and_a_retirement_block(self):
+        for board in RETIRED.values():
+            entry = self.feed["boards"][board]
+            era = entry["era"]
+            self.assertEqual(era["source"], "board_era", board)
+            self.assertEqual(era["number"], 2, board)
+            self.assertEqual(era["status"], "banked", board)
+            self.assertTrue(era["banked"], board)
+            self.assertEqual(era["closed_utc"], "2026-07-29T00:00:00Z", board)
+            self.assertEqual(
+                entry["retirement"]["retired_at_utc"], "2026-07-29T00:00:00Z", board,
+            )
+            self.assertIsNone(entry["retirement"]["closing_audit"], board)
+            # History stays fully served.
+            self.assertTrue(entry["entries"], board)
+            self.assertIsNotNone(entry["suite_score"], board)
+
+    def test_live_boards_publish_an_open_era_and_no_retirement(self):
+        riscv = self.feed["boards"]["riscv"]
+        self.assertEqual(riscv["era"]["source"], "board_era")
+        self.assertFalse(riscv["era"]["banked"])
+        self.assertIsNone(riscv["era"]["closed_utc"])
+        self.assertIsNone(riscv["retirement"])
+
+    def test_a_board_without_an_era_sequence_falls_back_to_the_global_epoch(self):
+        cairo = self.feed["boards"]["cairo_cpu"]
+        self.assertEqual(cairo["era"]["source"], "global_epoch")
+        self.assertEqual(cairo["era"]["number"], self.feed["epoch"]["number"])
+        self.assertEqual(cairo["era"]["opened_utc"], self.feed["epoch"]["opened_utc"])
+
+    def test_retired_boards_are_never_rendered_out_of_scope(self):
+        scope = self.feed["promotion_scope"]
+        self.assertEqual(set(scope["retired_boards"]), set(RETIRED.values()))
+        for board in RETIRED.values():
+            self.assertNotIn(board, scope["future_boards"])
+            self.assertNotIn(board, scope["owned_boards"])
+            self.assertIn(board, scope["staged_boards"])
+        self.assertEqual(
+            scope["groups"]["native"]["retirement"]["retired_at_utc"],
+            "2026-07-29T00:00:00Z",
+        )
+        self.assertIsNone(scope["groups"]["riscv"]["retirement"])
+
+    def test_phase_telemetry_is_exported_only_from_committed_evidence(self):
+        # TRACKS §3.2 machinery lands with the drop point empty: no committed
+        # artifact carries per-phase cutpoints yet, so every board is honestly
+        # absent rather than zero-filled.
+        for board, entry in self.feed["boards"].items():
+            self.assertIn("phase_telemetry", entry, board)
+        self.assertEqual(feed._phase_telemetry(ROOT), {})
+
+    def test_matrix_lanes_carry_their_backend_identity_and_board(self):
+        rows = self.feed["latest_matrix"]["rows"]
+        self.assertTrue(rows)
+        lanes = rows[0]["lanes"]
+        self.assertEqual(lanes["cpu"]["backend"], "cpu_native")
+        self.assertEqual(lanes["cpu"]["board"], "core_cpu")
+        # schema/scoring.md Board 5: today's metal lane is hybrid, and it must
+        # never be attributed to the zero-fallback Board 4.
+        self.assertEqual(lanes["metal"]["backend"], "metal_hybrid")
+        self.assertEqual(lanes["metal"]["board"], "core_hybrid")
+
+    def test_an_unknown_lane_backend_publishes_no_board(self):
+        summary = feed._lane_summary({"backend": "quantum_native", "metrics": {}})
+        self.assertEqual(summary["backend"], "quantum_native")
+        self.assertIsNone(summary["board"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Wave-1 era bookkeeping and the native era's retirement. Full suite green: **575 tests OK** (baseline 428 + W2's ladder + 61 new here), `validate_action.py` clean.

## 1. Per-board eras (TRACKS §7)

`ledger/epochs.json` gains an optional `board_eras` block **beside** the untouched global `epochs` list:

```json
"board_eras": {
  "note": "…",
  "boards": {
    "<board>": [{
      "era": 2, "epoch_ref": 2,
      "opened_utc": "…Z", "reason": "…",
      "status": "open" | "banked", "closed_utc": "…Z",
      "audit_anchor_commit": "<40-hex>",
      "aa_dispersion": {"<class>": 0.0123},
      "resource_budgets": {"<class>": {"peak_rss_mib": 1.05, "energy_j": 1.05, "proof_bytes": 1.0}},
      "scored_dimension": "prove_ms" | "request_ms",
      "note": "…"
    }]
  }
}
```

`era`/`epoch_ref`/`opened_utc`/`reason` required; the rest is inheritance. **An era is a per-board *view* of a global epoch, never a competing numbering** — the ledger's `epoch` column still names a global epoch, so every existing row keeps parsing and scoring unchanged. `core_cpu`, `core_metal`, and `riscv` get era 1/2 sequences referencing epochs 1/2; no measurement is invented.

New in `ledger`: `board_eras`, `current_era`, `epoch_for_board`, `current_epoch(board=None)`, board-aware `aa_dispersion`, `resource_budgets(class, board=None)` keyed (board, class) with class-only fallback (TRACKS §8), and `scored_dimension`. `metrics.policy_from_epoch` carries `board`/`era` provenance; `audits` resolves each board's own audit anchor (global epoch's anchor stays the fallback) and replays each touched cell under its board's policy.

Validation is fail-closed: contiguous `1..n`, strictly increasing `opened_utc`, non-decreasing `epoch_ref`, at most one `open` era and only as the newest, banked eras carry `closed_utc`, unregistered boards refused. **A banked newest era pins its board** — later global epochs do not drag a retired board along.

## 2. Native retire-and-complete (TRACKS §6)

`native`/`metal` flip to `promotion_eligible: false` with a validated `retirement` block; `closing_audit` stays `null` pending the M5 run. Both stay `enabled` so history, guard workloads, and PR6-supremacy cells keep running; both keep their `ledger.BOARDS` entries forever.

- Promotion refuses with a **retirement-specific** message naming the date and reason (still contains "not promotion eligible", so existing callers matching the old text keep working).
- Audits are deliberately **not** blocked by promotion ineligibility on a retired board — the closing audit that stamps the final audited score must stay reachable. It blocks only once `closing_audit` is recorded.

## 3. RISC-V request-boundary re-score — staged, NOT opened (TRACKS §3.1)

Era 3 is not open. The mechanism ships gated by two independent locks:

- `ledger` refuses any era declaring `scored_dimension: "request_ms"` without its **own measured** `aa_dispersion` — a boundary switch never inherits calibration;
- the runner refuses to evaluate a board whose era declares a boundary the harness cannot measure, so opening the era early fails closed instead of emitting prove-boundary rows labelled as request-boundary numbers.

Manifest gains an optional per-group `scored_dimension` (same allowlist, default `prove_ms`), declared by no group. Era-3 template + operator commands are in `schema/scoring.md`.

## 4. Feed v4 (TRACKS §9)

- `boards.<board>.era` — `number`, `epoch`, `opened_utc`, `reason`, `status`, `banked`, `closed_utc`, `scored_dimension`, `note`, `source` (`board_era` | `global_epoch`). The fallback is now explicit; the site no longer infers an era from the suite-score epoch.
- `boards.<board>.retirement` — the TRACKS §6 block or null.
- `epoch.opened_utc` / `epoch.reason` — the fields the site flagged as missing.
- `promotion_scope.retired_boards` + `groups.*.retirement`/`promotion_blocked_reason`. **Retired boards are kept OUT of `future_boards`**, whose contract is "out of scope, never live" — otherwise the retirement flip would have silently hidden the flagship native era.
- Each board is scored under its own era's epoch.
- `boards.<board>.phase_telemetry` (TRACKS §3.2) — export machinery reading **only** committed artifacts from `autoresearch/reference/phase-telemetry/*.json`, digest-bound and strictly validated. No committed artifact carries per-phase cutpoints today, so every board is honestly absent rather than zero-filled.
- `latest_matrix.rows[].lanes.<lane>.backend` / `.board` — verbatim backend identity from the committed report plus the board `schema/scoring.md` assigns it. Note the metal lane reports `metal_hybrid` -> **`core_hybrid`** (Board 5), not `core_metal` (Board 4); row-level board attribution would be wrong because a matrix row spans both lanes.

The committed `site/feed.json` is regenerated so the live site actually receives v4.

## Existing tests changed (all legitimate consequences)

| test | change |
|---|---|
| `test_manifest.test_native_and_riscv_groups_are_enabled` | `native.promotion_eligible` True -> False, plus retirement assertions (the retirement flip) |
| `test_feed.test_v3_promotion_scope_partitions_the_board_universe` | schema 3 -> 4; board partition now accounts for `retired_boards` |
| `test_backend_server.test_feed_route_serves_the_committed_contract_document` | hardcoded `3` -> `feed.FEED_SCHEMA_VERSION`, so transport parity tracks the schema instead of re-breaking on every bump |

## M5 judge-host handoff

**Closing audits** (per retired board, `core_cpu` then `core_metal`), on the judge host:

```
python3 -m stwo_perf.audits plan --repo . --board core_cpu --out /tmp/plan-core_cpu.json
python3 -m stwo_perf.audits run  --repo . --plan /tmp/plan-core_cpu.json \
    --out /tmp/unsigned-core_cpu.json --runs-dir /tmp/audit-runs --max-items 1
python3 -m stwo_perf.audits finalize --repo . --unsigned /tmp/unsigned-core_cpu.json \
    --out /tmp/bundle-core_cpu.json          # hosted signing job
python3 -m stwo_perf.audits append --repo . --bundle /tmp/bundle-core_cpu.json
```

Repeat per due class, then set `retirement.closing_audit` to `{completed_utc, bundle_sha256, row_ids}` in MANIFEST.json and regenerate the feed. Planning refuses a dirty tree and binds to exact HEAD/manifest/epoch/ledger bytes.

**RISC-V era 3** (do NOT open before the runner implements the request boundary):

```
python3 -m stwo_perf run --aa --board riscv --class small   # then wide, deep
```

Record the measured dispersions into an era-3 record built from the `schema/scoring.md` template (`scored_dimension: "request_ms"` + its own `aa_dispersion`), append it to `board_eras.boards.riscv`, and flip the riscv group's `scored_dimension`. The two gates above will reject the era until the harness change lands.

Do not merge — the orchestrator serializes merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
