### PR TITLE
Fix RISC-V harness for Sail proof artifacts

### DIFF
--- a/autoresearch/cli/stwo_perf/runner.py
+++ b/autoresearch/cli/stwo_perf/runner.py
@@ -1173,11 +1173,11 @@ def _parse_riscv_report(
         )
     required = {
         "artifact_kind": "stwo_riscv_proof",
-        "schema_version": 3,
-        "exchange_mode": "riscv_proof_json_wire_v3",
+        "schema_version": 4,
+        "exchange_mode": "riscv_proof_json_wire_v4",
         "release_status": expected_status,
         "generator": "zig",
-        "air": "stark_v_rv32im",
+        "air": "sail_rv32im_zkvm_v1",
         "backend": "cpu",
     }
     for field_name, expected in required.items():
@@ -1200,8 +1200,8 @@ def _parse_riscv_report(
     if not isinstance(provenance, dict) or set(provenance) != provenance_fields:
         raise ValueError("retained artifact provenance is not canonical")
     if (
-        provenance.get("oracle_repository") != "https://github.com/ClementWalter/stark-v"
-        or provenance.get("oracle_commit") != "d478f783055aa0d73a93768a433a3c6c31c91d1c"
+        provenance.get("oracle_repository") != "https://github.com/riscv/sail-riscv"
+        or provenance.get("oracle_commit") != "8c7f2da58de0ba5e4457e4de07e0046f0439f35f"
         or provenance.get("implementation_repository")
         != "https://github.com/teddyjfpender/stwo-zig"
         or provenance.get("implementation_commit") != report["implementation_commit"]

--- a/autoresearch/schema/riscv-proof-v2.md
+++ b/autoresearch/schema/riscv-proof-v2.md
@@ -5,9 +5,16 @@
 interpret a v1 report as v2.
 
 The canonical proof remains the lowercase `proof_bytes_hex` value in the
-retained `stwo_riscv_proof` schema-v3 artifact. The v2 report does not change
-the artifact wire format, statement binding, transcript binding, independent
-verification receipt, pinned Stark-V oracle, or release-admission state.
+retained `stwo_riscv_proof` schema-v4 artifact. The retained artifact is bound
+to exchange mode `riscv_proof_json_wire_v4`, AIR
+`sail_rv32im_zkvm_v1`, and the pinned
+[`riscv/sail-riscv`](https://github.com/riscv/sail-riscv) semantic authority at
+commit `8c7f2da58de0ba5e4457e4de07e0046f0439f35f`. Schema-v3/Stark-V artifacts
+are historical and must fail closed rather than being interpreted as v2
+benchmark evidence.
+
+The v2 report does not otherwise change statement binding, transcript binding,
+the independent verification receipt, or release-admission state.
 
 ## Resource usage
 

--- a/autoresearch/tests/test_runner_groups.py
+++ b/autoresearch/tests/test_runner_groups.py
@@ -213,17 +213,17 @@ class RunnerGroupTest(unittest.TestCase):
                         implementation_commit: str = "b" * 40) -> dict:
         return {
             "artifact_kind": "stwo_riscv_proof",
-            "schema_version": 3,
-            "exchange_mode": "riscv_proof_json_wire_v3",
+            "schema_version": 4,
+            "exchange_mode": "riscv_proof_json_wire_v4",
             "release_status": status,
             "generator": "zig",
-            "air": "stark_v_rv32im",
+            "air": "sail_rv32im_zkvm_v1",
             "backend": "cpu",
             "protocol": "functional",
             "source": {"elf_sha256": "1" * 64, "input_sha256": "2" * 64},
             "provenance": {
-                "oracle_repository": "https://github.com/ClementWalter/stark-v",
-                "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+                "oracle_repository": "https://github.com/riscv/sail-riscv",
+                "oracle_commit": "8c7f2da58de0ba5e4457e4de07e0046f0439f35f",
                 "implementation_repository": "https://github.com/teddyjfpender/stwo-zig",
                 "implementation_commit": implementation_commit,
                 "implementation_dirty": False,
@@ -237,7 +237,8 @@ class RunnerGroupTest(unittest.TestCase):
 
     def _riscv_run(self, status: str, experimental: bool,
                     proof_hex: str = "0102", mutate_report=None,
-                    implementation_commit: str = "b" * 40):
+                    implementation_commit: str = "b" * 40,
+                    mutate_artifact=None):
         commands = []
 
         def fake_run(command, _root, timeout):
@@ -248,6 +249,8 @@ class RunnerGroupTest(unittest.TestCase):
             artifact = self._riscv_artifact(
                 status, proof_hex, implementation_commit,
             )
+            if mutate_artifact:
+                mutate_artifact(artifact)
             encoded = json.dumps(artifact, separators=(",", ":")).encode()
             proof_path.write_bytes(encoded)
             report = {
@@ -582,6 +585,77 @@ class RunnerGroupTest(unittest.TestCase):
                 self.root, manifest, workload, 0, 1, self.out_dir, "a1",
             )
         self.assertNotIn("--experimental", shlex.split(commands[0]))
+
+    def test_riscv_bench_rejects_legacy_v3_artifact(self):
+        self._set_riscv_phase(promoted=True)
+        manifest = self._riscv_manifest()
+        workload = manifest.workloads("wide", board="riscv")[0]
+
+        def legacy_v3(artifact):
+            artifact.update({
+                "schema_version": 3,
+                "exchange_mode": "riscv_proof_json_wire_v3",
+                "air": "stark_v_rv32im",
+            })
+            artifact["provenance"].update({
+                "oracle_repository": "https://github.com/ClementWalter/stark-v",
+                "oracle_commit": "d478f783055aa0d73a93768a433a3c6c31c91d1c",
+            })
+
+        _commands, fake_run = self._riscv_run(
+            "release_gated", False, mutate_artifact=legacy_v3,
+        )
+        with mock.patch.object(runner, "_run", side_effect=fake_run), \
+                self.assertRaisesRegex(runner.RunError, "schema_version.*equal 4"):
+            runner.bench_once(
+                self.root, manifest, workload, 0, 1, self.out_dir, "legacy-v3",
+            )
+
+    def test_riscv_bench_rejects_non_sail_artifact_authority(self):
+        self._set_riscv_phase(promoted=True)
+        manifest = self._riscv_manifest()
+        workload = manifest.workloads("wide", board="riscv")[0]
+        mutations = {
+            "repository": lambda artifact: artifact["provenance"].update(
+                oracle_repository="https://github.com/ClementWalter/stark-v"
+            ),
+            "commit": lambda artifact: artifact["provenance"].update(
+                oracle_commit="d478f783055aa0d73a93768a433a3c6c31c91d1c"
+            ),
+        }
+        for name, mutate in mutations.items():
+            _commands, fake_run = self._riscv_run(
+                "release_gated", False, mutate_artifact=mutate,
+            )
+            with self.subTest(name=name), \
+                    mock.patch.object(runner, "_run", side_effect=fake_run), \
+                    self.assertRaisesRegex(
+                        runner.RunError, "provenance does not bind the report",
+                    ):
+                runner.bench_once(
+                    self.root, manifest, workload, 0, 1, self.out_dir,
+                    f"non-sail-{name}",
+                )
+
+    def test_riscv_bench_rejects_malformed_artifact_provenance(self):
+        self._set_riscv_phase(promoted=True)
+        manifest = self._riscv_manifest()
+        workload = manifest.workloads("wide", board="riscv")[0]
+        _commands, fake_run = self._riscv_run(
+            "release_gated",
+            False,
+            mutate_artifact=lambda artifact: artifact["provenance"].pop(
+                "witness_layout_sha256"
+            ),
+        )
+        with mock.patch.object(runner, "_run", side_effect=fake_run), \
+                self.assertRaisesRegex(
+                    runner.RunError, "provenance is not canonical",
+                ):
+            runner.bench_once(
+                self.root, manifest, workload, 0, 1, self.out_dir,
+                "malformed-provenance",
+            )
 
     def test_riscv_proof_digest_ignores_commit_bearing_artifact_fields(self):
         self._set_riscv_phase(promoted=True)


### PR DESCRIPTION
## What changed

- update the `riscv_proof_v2` retained-artifact parser from schema v3 / Stark-V to the canonical schema v4 / Sail contract
- bind the parser to `riscv_proof_json_wire_v4`, `sail_rv32im_zkvm_v1`, and the pinned `riscv/sail-riscv` revision
- migrate the parser fixture and add fail-closed tests for legacy v3, foreign Sail authority, and malformed provenance
- update the report-schema documentation so it no longer declares v3 / Stark-V canonical

## Root cause

The production RISC-V proof path now emits schema-v4 Sail artifacts, but the benchmark parser and its fixture still required schema-v3 Stark-V constants. A hash-bound hosted T0 therefore passed source policy, the locked harness, product closure, permanent identity tests, and the production Sail proof gate, then failed before any candidate timing with:

```text
riscv_alu_test: malformed riscv_proof_v2 report: retained artifact schema_version must equal 3
```

That run remains terminal `UNKNOWN`; this PR does not rerun or reclassify it.

## Validation

- `python3 -m unittest discover -s autoresearch/tests -p test_runner_groups.py -v` — 43/43 pass
- complete current-frontier harness — 721/721 pass after excluding one baseline-identical Python 3.14 temporary-directory cleanup race
- the excluded audit test passes its assertions on both untouched `72b01691` and this branch, then both raise `OSError 66` while removing a temporary `.git` directory
- `python3 scripts/check_source_conformance.py` — zero new violations
- Python compilation and `git diff --check` pass

No performance measurement, qualification, submission, or leaderboard claim is made by this repair.
