### PR TITLE
Fix retained RISC-V artifact verification ELF binding

### DIFF
--- a/autoresearch/cli/stwo_perf/runner.py
+++ b/autoresearch/cli/stwo_perf/runner.py
@@ -3397,9 +3397,39 @@ def _riscv_sail_oracle_check(
     binary = candidate_root / group.binary
     if not binary.is_file():
         raise RunError(f"missing RISC-V candidate verifier: {binary}")
+    formatted_args = shlex.split(
+        _format_workload_args(candidate_root, group, workload, 0, 1)
+    )
+    elf_positions = [
+        index for index, value in enumerate(formatted_args) if value == "--elf"
+    ]
+    if (
+        len(elf_positions) != 1
+        or elf_positions[0] + 1 >= len(formatted_args)
+        or formatted_args[elf_positions[0] + 1].startswith("-")
+    ):
+        raise RunError(
+            f"{workload.workload_id}: RISC-V workload must bind exactly one "
+            "--elf path for independent verification"
+        )
+    candidate_root_resolved = candidate_root.resolve()
+    elf_path = (
+        candidate_root_resolved / formatted_args[elf_positions[0] + 1]
+    ).resolve()
+    try:
+        elf_path.relative_to(candidate_root_resolved)
+    except ValueError as exc:
+        raise RunError(
+            f"{workload.workload_id}: RISC-V workload ELF escapes the repository"
+        ) from exc
+    if not elf_path.is_file():
+        raise RunError(
+            f"{workload.workload_id}: RISC-V workload ELF is missing: {elf_path}"
+        )
     verify_raw = _run(
         shlex.join([
             str(binary), "verify", "--artifact", str(proof_path),
+            "--elf", str(elf_path),
             "--protocol", str(artifact.get("protocol")),
             "--expect-statement-digest", statement_digest,
         ]),

--- a/autoresearch/tests/test_runner_groups.py
+++ b/autoresearch/tests/test_runner_groups.py
@@ -888,6 +888,9 @@ class RunnerGroupTest(unittest.TestCase):
         script = self.root / "scripts/riscv_sail_gate.py"
         script.parent.mkdir(parents=True)
         script.write_text("# fixture\n")
+        elf = self.root / "vectors/riscv_elfs/alu_test.elf"
+        elf.parent.mkdir(parents=True)
+        elf.write_bytes(b"ELF fixture")
         manifest = self._riscv_manifest()
         group = manifest.group("riscv")
         object.__setattr__(group, "correctness_oracle", {
@@ -944,7 +947,16 @@ class RunnerGroupTest(unittest.TestCase):
             "riscv_sail_gate.py" in command and command.endswith(" bind")
             for command in commands
         ))
-        self.assertTrue(any(" verify " in f" {command} " for command in commands))
+        verify_commands = [
+            shlex.split(command)
+            for command in commands
+            if " verify " in f" {command} "
+        ]
+        self.assertEqual(1, len(verify_commands))
+        self.assertEqual(
+            str(elf.resolve()),
+            verify_commands[0][verify_commands[0].index("--elf") + 1],
+        )
         self.assertFalse(any("build-and-compare" in command for command in commands))
         self.assertFalse(any("stwo-interop-rs" in command for command in commands))
 


### PR DESCRIPTION
## Summary

- recover the exact workload `--elf` path from the manifest command
- require one repository-contained, existing ELF before retained-artifact verification
- pass that ELF to the independent RISC-V verifier and pin the command in a regression test

## Why

The scored RISC-V bench path retained a valid proof artifact, but the post-run correctness oracle invoked `verify` without the source ELF. The focused verifier correctly rejected that call with `MissingElf`, turning otherwise completed objective/guard work into an infrastructure UNKNOWN.

## Tests

- focused RISC-V oracle tests: 4 passed
- full `autoresearch/tests`: 723 passed, 1 pre-existing error
- the lone error is `test_execute_finalize_and_replay_validated_append`, a Python 3.14 temporary-directory cleanup race (`Directory not empty: .../repo/.git`) that reproduces unchanged at base `93f2f621`
