### PR TITLE
fix(autoresearch): extend RISC-V small and wide qualifier walls

### DIFF
--- a/autoresearch/MANIFEST.json
+++ b/autoresearch/MANIFEST.json
@@ -362,7 +362,7 @@
           "min_rounds": 3,
           "max_rounds": 5,
           "wall_clock_cap_seconds": {
-            "small": 240,
+            "small": 600,
             "wide": 360,
             "deep": 600
           }

--- a/autoresearch/MANIFEST.json
+++ b/autoresearch/MANIFEST.json
@@ -363,7 +363,7 @@
           "max_rounds": 5,
           "wall_clock_cap_seconds": {
             "small": 600,
-            "wide": 360,
+            "wide": 900,
             "deep": 600
           }
         },

--- a/autoresearch/tests/test_manifest.py
+++ b/autoresearch/tests/test_manifest.py
@@ -47,6 +47,42 @@ class ManifestTest(unittest.TestCase):
         self.assertTrue(small)
         self.assertTrue(all(w.workload_class == "small" for w in small))
 
+    def test_riscv_small_wall_covers_public_qualifier_without_global_drift(self):
+        riscv_small = self.m.gates_for_workload("riscv", "small")
+        riscv_walls = {"small": 600, "wide": 360, "deep": 600}
+        self.assertEqual(
+            riscv_small["wall_clock_cap_seconds"],
+            riscv_walls,
+        )
+        self.assertEqual(riscv_small["command_timeout_seconds"], 1200)
+        self.assertEqual(
+            (
+                riscv_small["warmups"],
+                riscv_small["samples_per_round"],
+                riscv_small["min_rounds"],
+                riscv_small["max_rounds"],
+            ),
+            (1, 1, 3, 5),
+        )
+        self.assertEqual(
+            self.m.gates_for_workload("riscv", "wide")[
+                "wall_clock_cap_seconds"
+            ],
+            riscv_walls,
+        )
+        self.assertEqual(
+            self.m.gates_for_workload("riscv", "deep")[
+                "wall_clock_cap_seconds"
+            ],
+            riscv_walls,
+        )
+        self.assertEqual(
+            self.m.gates_for_workload("native", "small")[
+                "wall_clock_cap_seconds"
+            ],
+            {"small": 240},
+        )
+
     def test_manifest_owns_scored_class_order_and_board_exposure(self):
         self.assertEqual(
             self.m.class_names(scored_only=True),

--- a/autoresearch/tests/test_manifest.py
+++ b/autoresearch/tests/test_manifest.py
@@ -47,9 +47,9 @@ class ManifestTest(unittest.TestCase):
         self.assertTrue(small)
         self.assertTrue(all(w.workload_class == "small" for w in small))
 
-    def test_riscv_small_wall_covers_public_qualifier_without_global_drift(self):
+    def test_riscv_small_and_wide_walls_cover_qualifier_without_global_drift(self):
         riscv_small = self.m.gates_for_workload("riscv", "small")
-        riscv_walls = {"small": 600, "wide": 360, "deep": 600}
+        riscv_walls = {"small": 600, "wide": 900, "deep": 600}
         self.assertEqual(
             riscv_small["wall_clock_cap_seconds"],
             riscv_walls,
@@ -75,6 +75,12 @@ class ManifestTest(unittest.TestCase):
                 "wall_clock_cap_seconds"
             ],
             riscv_walls,
+        )
+        self.assertEqual(
+            self.m.gates_for_workload("riscv_metal", "wide")[
+                "wall_clock_cap_seconds"
+            ],
+            {"small": 240, "wide": 360, "deep": 600},
         )
         self.assertEqual(
             self.m.gates_for_workload("native", "small")[


### PR DESCRIPTION
## What changed

- raise the RISC-V `small` objective wall from 240 seconds to 600 seconds
- raise the RISC-V `wide` objective wall from 360 seconds to 900 seconds
- extend the resolved-policy regression to bind all RISC-V CPU walls while explicitly preserving the `riscv_metal` and native policies

The RISC-V deep wall remains 600 seconds, the per-command timeout remains 1200 seconds, sampling remains unchanged, `riscv_metal` remains `240/360/600`, and native small remains 240 seconds.

## Why

Public qualification run `30587401306` passed checkout, source policy, harness validation, release build, and frontier materialization, then hit the fixed 240-second RISC-V small-class wall at the `jal_jalr` arm before it could produce a verdict or receipt.

The later exact `c8c66437` versus `82a0bf69` contributor-host wide T2 hit the fixed 360-second wide-class wall during `riscv_sha2_256b.a4`, after 6 of 7 objective rows, 3 of 9 final-row pairs, and 0 of 6 guards. It exited without a terminal result. The 900-second wall gives the full wide objective-plus-guard path bounded capacity beneath the existing 2700-second T2 ceiling; it does not claim that the candidate will qualify.

## Validation

Small-wall change:

- `93/93` focused manifest, runner-group, search-health, and qualification tests passed
- audited original small-wall diff SHA-256: `271dc15fad06ba48a7b4c6a34dc24262f296fed27c39eb2171eafe01b7dfe75e`

Wide-wall change at commit `b5f46e28963af2372c1f6035954176ec6a476717`:

- exact two-file wide-only binary diff SHA-256: `a1d1e92a4209fdd0f240ac800124e21fbebb01fdd561c04e3a5e6a7484e85722`
- matched baseline and candidate audit targets: `1/1` each, with zero automatic-maintenance children in both traces
- matched focused manifest modules: `33/33` each
- matched full autoresearch suites: `725/725` each
- independent binding audits: `26/26` primary artifacts and `4/4` final artifacts
- decisive mutations rejected: restored wide wall, removed fixture repair, extra changed path, injected maintenance child, and reduced test count
- production runner and `qualify-fork` workflow remain byte-identical

The separately scoped macOS/Python 3.14 synthetic-repository cleanup fix is draft PR #164. It disables Git automatic maintenance only in the disposable audit-test repository; it does not change this policy patch or production audit behavior.

### Known base CI failure

The focused Linux/static lane is red, but the failure is outside this PR's policy diff. Merged PR #162, whose merge commit is this PR's exact base `82a0bf6913ebbb6104428365904c6c91f714029b`, ran the same `1626` script tests and ended with the same three failures and one error:

- `test_riscv_poseidon_table_uniqueness.RiscVPoseidonTableUniquenessTest`
- `test_riscv_crypto_benchmark.TraceProvenanceReachabilityTests.test_a_refused_trace_executable_aborts_before_any_sample`
- `test_riscv_csp_benchmark_provenance.HostArchitectureTests.test_default_path_refuses_a_rosetta_build_end_to_end`
- `test_script_reachability.ScriptReachabilityTest.test_every_script_is_reachable_or_declared`

Base run: `30570722921`; earlier PR run: `30595728750`.

## Scope

This PR repairs only bounded public qualification walls. It does not qualify, submit, promote, or score any performance candidate, and it does not establish leaderboard credit or rank.