### PR TITLE
fix(autoresearch): disable auto maintenance in audit fixtures

### DIFF
--- a/autoresearch/tests/test_audits.py
+++ b/autoresearch/tests/test_audits.py
@@ -242,6 +242,7 @@ class AuditExecutionTest(unittest.TestCase):
         repo = root / "repo"
         repo.mkdir()
         self._git(repo, "init", "-q")
+        self._git(repo, "config", "maintenance.auto", "false")
         self._git(repo, "config", "user.name", "Audit Test")
         self._git(repo, "config", "user.email", "audit@example.com")
         shutil.copytree(ROOT / "autoresearch", repo / "autoresearch")


### PR DESCRIPTION
## What changed

- set repository-local `maintenance.auto=false` immediately after `git init` in `AuditExecutionTest._audit_repo`
- keep production audit code, cleanup behavior, benchmark policy, runner logic, and workflows unchanged

## Why

The synthetic audit repository can trigger Git's detached automatic-maintenance process while the test is committing its fixture. On macOS with Python 3.14, that background writer can outlive the test and race `TemporaryDirectory` teardown, leaving Git maintenance residues and producing an `OSError: [Errno 66] Directory not empty` cleanup error.

This disables automatic maintenance only inside the disposable test repository. It does not suppress cleanup errors, add sleeps or retries, or change production behavior.

## Validation

- exact diff: one insertion in `autoresearch/tests/test_audits.py`; no other changed path
- binary diff SHA-256: `4c085329dd094a8aea64581eb42c20aa5734e964b0a769cd945fb55203c06505`
- fresh targeted replay on current `main`: `1/1` passed in `1.105s`
- fresh trace: expected foreground Git commands present; `0` `git maintenance run --auto --quiet --detach` children
- full current-base autoresearch suite: `724/724` passed in `65.007s`
- independently audited causal control: unpatched trace detects `2` detached maintenance children; three exact patched traces detect `0`; descendant suite passed `725/725`

## Scope

This is a test-fixture stability fix only. It does not validate or modify a performance candidate, qualification wall, judged record, submission, leaderboard credit, or rank.