### PR TITLE
fix: restore current-main static baseline

### DIFF
--- a/scripts/riscv_poseidon_table_uniqueness.py
+++ b/scripts/riscv_poseidon_table_uniqueness.py
@@ -113,7 +113,7 @@ SOURCE_BINDINGS: dict[str, str] = {
     "src/frontends/riscv/prover/preprocessed.zig":
         "703134062751202f3bae288cded347e5bd869aac787359c05c069d5a6b7812bc",
     "src/frontends/riscv/prover/opcode_trace.zig":
-        "5a2843e281c67d832a4c40906f2e41dd921be5f6d4c971d835e7f0036b16d7bb",
+        "3537cceac5bcbbb6c2d325bd6f0ad01c1d5d577a7df1ca6e21867912624ccbac",
     "src/frontends/riscv/infra_trace/permutation.zig":
         "2e6551f2c758b18f4a620d166b908a269297e9f1a74308c2ebd769dd8a474b98",
     "scripts/air_satisfaction_lib/poseidon2.py":

--- a/scripts/tests/test_riscv_crypto_benchmark.py
+++ b/scripts/tests/test_riscv_crypto_benchmark.py
@@ -147,8 +147,14 @@ class TraceProvenanceReachabilityTests(unittest.TestCase):
             source = Path(raw)
             (source / "target/release").mkdir(parents=True)
             (source / "target/release/stark-v-bench").write_bytes(b"")
+            zig_bench = source / "stwo-zig"
+            zig_trace = source / "riscv-trace-dump"
+            zig_bench.write_bytes(b"")
+            zig_trace.write_bytes(b"")
             with mock.patch.multiple(
                 crypto,
+                ZIG_BENCH=zig_bench,
+                ZIG_TRACE=zig_trace,
                 read_trace_provenance=mock.Mock(
                     side_effect=BenchmarkError("built at another commit"),
                 ),

--- a/scripts/tests/test_riscv_csp_benchmark_provenance.py
+++ b/scripts/tests/test_riscv_csp_benchmark_provenance.py
@@ -260,14 +260,12 @@ class HostArchitectureTests(unittest.TestCase):
             csp_host, "sysctl_value", lambda name: readings.get(name)
         ):
             with mock.patch.object(csp_host.platform, "machine", lambda: "x86_64"):
-                with self.assertRaisesRegex(
-                    csp.BenchmarkError,
-                    "targets x86_64-macos but this host is aarch64-macos",
-                ):
-                    csp_build_identity.validate_build_identity(
-                        identity,
-                        system="Darwin",
-                    )
+                with mock.patch.object(csp_host.platform, "system", lambda: "Darwin"):
+                    with self.assertRaisesRegex(
+                        csp.BenchmarkError,
+                        "targets x86_64-macos but this host is aarch64-macos",
+                    ):
+                        csp_build_identity.validate_build_identity(identity)
 
     def test_validation_reads_the_hardware_by_default(self) -> None:
         # Pins the wiring: the default comparison comes from

--- a/scripts/tests/test_script_reachability.py
+++ b/scripts/tests/test_script_reachability.py
@@ -80,6 +80,14 @@ TEST_MODULE_RE = re.compile(r"scripts\.tests\.test_([a-z_0-9]+)")
 IMPORT_RE = re.compile(
     r"^\s*(?:import|from)\s+(?:scripts\.)?([a-z_0-9]+)", re.MULTILINE
 )
+FROM_SCRIPTS_GROUP_RE = re.compile(
+    r"^\s*from\s+scripts\s+import\s*\((.*?)^\s*\)",
+    re.MULTILINE | re.DOTALL,
+)
+FROM_SCRIPTS_LINE_RE = re.compile(
+    r"^\s*from\s+scripts\s+import\s+([^\n(]+)$",
+    re.MULTILINE,
+)
 
 
 def _references(text: str, universe: set[str]) -> set[str]:
@@ -92,6 +100,16 @@ def _references(text: str, universe: set[str]) -> set[str]:
         name = f"{match.group(1)}.py"
         if name in universe:
             found.add(name)
+    for imports in FROM_SCRIPTS_GROUP_RE.findall(text):
+        for module in re.findall(r"\b([a-z_0-9]+)\b", imports):
+            name = f"{module}.py"
+            if name in universe:
+                found.add(name)
+    for imports in FROM_SCRIPTS_LINE_RE.findall(text):
+        for module in re.findall(r"\b([a-z_0-9]+)\b", imports):
+            name = f"{module}.py"
+            if name in universe:
+                found.add(name)
     return found
 
 


### PR DESCRIPTION
## What changed

- refresh the Poseidon/table uniqueness source binding after the merged RISC-V opcode prefilter hardening
- make the trace-provenance reachability test provide both prerequisite Zig executables before asserting the fail-closed trace gate
- make the Rosetta default-path regression simulate Darwin completely on Linux
- teach the anti-sprawl reachability ratchet to follow grouped and single-line `from scripts import ...` imports

## Root cause

PR #163 exposed four failures already present on its exact base `82a0bf6913ebbb6104428365904c6c91f714029b`:

1. the opcode-trace source changed in the issue-152 hardening merge, but its hash-bound uniqueness checker retained the old digest;
2. a newly activated trace-gate test reached an earlier missing-product precondition in clean CI;
3. a newly activated Rosetta test mocked `machine()` but not `system()`, so Linux CI computed a Linux host while the assertion supplied Darwin only to the later target check;
4. the script reachability ratchet did not parse the grouped import form used by the modularized refinement entry point.

The opcode-trace change only prefilters raw opcodes into `ProofOpcode` values before the existing family loops. The exhaustive uniqueness audit passes after rebinding and retains its mutation checks.

## Validation

Pinned Zig `0.15.2`:

- focused former failures and full uniqueness class: `13/13`
- toolchain-sensitive local regressions: `3/3`
- complete local-compatible static lane: `PASS` in `129.534s`
- script tests: `1636` passed, `57` intentionally skipped
- `zig fmt --check`
- build-monorepo baseline
- source conformance
- package workspace
- upstream pin ledger

The authoritative Linux/static result remains required before merge.

## Scope

This repairs the current-main CI baseline only. It does not alter benchmark policy, candidate code, timing data, qualification, submission, promotion, scoring, or leaderboard state. It unblocks the separately scoped wall-policy PR #163.