### PR TITLE
chore: integrate autoresearch qualifier and audit fixes

### DIFF
--- a/autoresearch/MANIFEST.json
+++ b/autoresearch/MANIFEST.json
@@ -362,7 +362,7 @@
           "min_rounds": 3,
           "max_rounds": 5,
           "wall_clock_cap_seconds": {
-            "small": 240,
+            "small": 600,
             "wide": 360,
             "deep": 600
           }

--- a/autoresearch/MANIFEST.json
+++ b/autoresearch/MANIFEST.json
@@ -363,7 +363,7 @@
           "max_rounds": 5,
           "wall_clock_cap_seconds": {
             "small": 600,
-            "wide": 360,
+            "wide": 900,
             "deep": 600
           }
         },

--- a/autoresearch/tests/test_audits.py
+++ b/autoresearch/tests/test_audits.py
@@ -242,6 +242,7 @@ class AuditExecutionTest(unittest.TestCase):
         repo = root / "repo"
         repo.mkdir()
         self._git(repo, "init", "-q")
+        self._git(repo, "config", "maintenance.auto", "false")
         self._git(repo, "config", "user.name", "Audit Test")
         self._git(repo, "config", "user.email", "audit@example.com")
         shutil.copytree(ROOT / "autoresearch", repo / "autoresearch")

--- a/autoresearch/tests/test_manifest.py
+++ b/autoresearch/tests/test_manifest.py
@@ -47,6 +47,42 @@ class ManifestTest(unittest.TestCase):
         self.assertTrue(small)
         self.assertTrue(all(w.workload_class == "small" for w in small))
 
+    def test_riscv_small_wall_covers_public_qualifier_without_global_drift(self):
+        riscv_small = self.m.gates_for_workload("riscv", "small")
+        riscv_walls = {"small": 600, "wide": 360, "deep": 600}
+        self.assertEqual(
+            riscv_small["wall_clock_cap_seconds"],
+            riscv_walls,
+        )
+        self.assertEqual(riscv_small["command_timeout_seconds"], 1200)
+        self.assertEqual(
+            (
+                riscv_small["warmups"],
+                riscv_small["samples_per_round"],
+                riscv_small["min_rounds"],
+                riscv_small["max_rounds"],
+            ),
+            (1, 1, 3, 5),
+        )
+        self.assertEqual(
+            self.m.gates_for_workload("riscv", "wide")[
+                "wall_clock_cap_seconds"
+            ],
+            riscv_walls,
+        )
+        self.assertEqual(
+            self.m.gates_for_workload("riscv", "deep")[
+                "wall_clock_cap_seconds"
+            ],
+            riscv_walls,
+        )
+        self.assertEqual(
+            self.m.gates_for_workload("native", "small")[
+                "wall_clock_cap_seconds"
+            ],
+            {"small": 240},
+        )
+
     def test_manifest_owns_scored_class_order_and_board_exposure(self):
         self.assertEqual(
             self.m.class_names(scored_only=True),

--- a/autoresearch/tests/test_manifest.py
+++ b/autoresearch/tests/test_manifest.py
@@ -47,9 +47,9 @@ class ManifestTest(unittest.TestCase):
         self.assertTrue(small)
         self.assertTrue(all(w.workload_class == "small" for w in small))
 
-    def test_riscv_small_wall_covers_public_qualifier_without_global_drift(self):
+    def test_riscv_small_and_wide_walls_cover_qualifier_without_global_drift(self):
         riscv_small = self.m.gates_for_workload("riscv", "small")
-        riscv_walls = {"small": 600, "wide": 360, "deep": 600}
+        riscv_walls = {"small": 600, "wide": 900, "deep": 600}
         self.assertEqual(
             riscv_small["wall_clock_cap_seconds"],
             riscv_walls,
@@ -75,6 +75,12 @@ class ManifestTest(unittest.TestCase):
                 "wall_clock_cap_seconds"
             ],
             riscv_walls,
+        )
+        self.assertEqual(
+            self.m.gates_for_workload("riscv_metal", "wide")[
+                "wall_clock_cap_seconds"
+            ],
+            {"small": 240, "wide": 360, "deep": 600},
         )
         self.assertEqual(
             self.m.gates_for_workload("native", "small")[


### PR DESCRIPTION
Integrates the reviewed work from #163 and #164 on top of the restored main baseline from #165, preserving the original author commits.\n\nChanges:\n- disable Git auto-maintenance only in disposable audit fixtures\n- raise RISC-V small/wide qualifier walls to 600s/900s with policy-bound regression coverage\n\nLocal validation:\n- `autoresearch.tests.test_manifest`: 33/33 passed\n- `autoresearch.tests.test_audits`: 11/11 passed (with its required test PYTHONPATH)\n- `git diff --check`: passed\n\nThis integration PR exists because the original cross-repository branches could not be updated to the now-current base. Supersedes #163 and #164 once merged.