### PR TITLE
Delist CUDA from the track surface; riscv_metal basket blocked honestly

### DIFF
--- a/autoresearch/MANIFEST.json
+++ b/autoresearch/MANIFEST.json
@@ -995,7 +995,9 @@
             "glob": "src/integrations/native/**",
             "min_rung": "s3"
           }
-        ]
+        ],
+        "delisted": true,
+        "delisted_reason": "Dropped from the track surface for now (no CUDA hardware in the campaign); the staged group, activation contract, and tests stay intact — flip this flag when hardware lands (TRACKS wave 3)."
       },
       "cairo_cpu": {
         "enabled": true,

--- a/autoresearch/cli/stwo_perf/feed.py
+++ b/autoresearch/cli/stwo_perf/feed.py
@@ -302,6 +302,13 @@ def _promotion_scope(manifest: Manifest) -> dict:
             "promotion_blocked_reason": group.promotion_blocked_reason,
             "report_schema": group.report_schema,
             "retirement": dict(group.retirement) or None,
+            # Delisted: dropped from the product surface without touching the
+            # group's contract, tests, or history — the site hides, never the
+            # harness (TRACKS §2; the CUDA "for now" case).
+            "delisted": bool(manifest.raw["workload_registry"]["groups"]
+                             .get(group.group_id, {}).get("delisted", False)),
+            "delisted_reason": manifest.raw["workload_registry"]["groups"]
+                               .get(group.group_id, {}).get("delisted_reason"),
             "workloads": {
                 w.workload_id: {"class": w.workload_class, "native_unit": w.native_unit}
                 for w in group.workloads

--- a/autoresearch/site/feed.json
+++ b/autoresearch/site/feed.json
@@ -384,8 +384,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -425,8 +425,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -602,8 +602,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -643,8 +643,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -2816,8 +2816,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -3140,8 +3140,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -3328,8 +3328,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -3546,8 +3546,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -3941,8 +3941,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -4241,8 +4241,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -4282,8 +4282,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -4323,8 +4323,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -4364,8 +4364,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -4405,8 +4405,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -6996,8 +6996,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -7459,8 +7459,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -7579,8 +7579,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -7865,8 +7865,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -8400,8 +8400,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -8750,8 +8750,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -8791,8 +8791,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -8832,8 +8832,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -8873,8 +8873,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -8914,8 +8914,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -9532,8 +9532,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -9723,8 +9723,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -9839,8 +9839,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -10101,8 +10101,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -10142,8 +10142,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -10183,8 +10183,8 @@
      "audit": {
       "audit_age": {
        "base_commit": "8e58d7015e28a312eddc6f1eacc10e0c08ea85cc",
-       "commits": 1229,
-       "seconds": 839906
+       "commits": 1231,
+       "seconds": 843856
       },
       "audited_score": 1.0,
       "audited_through": null,
@@ -11448,6 +11448,8 @@
   "groups": {
    "cairo_cpu": {
     "board": "cairo_cpu",
+    "delisted": false,
+    "delisted_reason": null,
     "disabled_reason": null,
     "enabled": true,
     "promotion_blocked_reason": "TRACKS \u00a77: cairo_cpu records evidence but cannot promote until per-(board, class) A/A dispersion and anchors are measured on the designated Apple M5 Max judge host and frozen into harness.anchor_* plus a cairo calibration freeze for board cairo_cpu. No Cairo calibration exists yet, so promotion fails closed; the gate opens only after that M5 calibration is committed.",
@@ -11467,6 +11469,8 @@
    },
    "cairo_metal": {
     "board": "cairo_metal",
+    "delisted": false,
+    "delisted_reason": null,
     "disabled_reason": "cairo_metal is staged only: TRACKS \u00a72 records the Cairo + Metal product as parity_gated, not released. The product descriptor in build_support/products/cairo_metal.zig still carries state .parity_gated behind its test-cairo-metal-product and test-cairo-metal-oracle release gates, no Metal-lane Cairo calibration exists on the designated judge host, and the generalized per-board Metal calibration (TRACKS \u00a77) is not yet built. The group stays dark and fails closed.",
     "enabled": false,
     "promotion_blocked_reason": "TRACKS \u00a77: no cairo_metal calibration exists on the designated Apple M5 Max judge host, and the product is parity_gated rather than released.",
@@ -11486,6 +11490,8 @@
    },
    "cuda": {
     "board": "core_cuda",
+    "delisted": true,
+    "delisted_reason": "Dropped from the track surface for now (no CUDA hardware in the campaign); the staged group, activation contract, and tests stay intact \u2014 flip this flag when hardware lands (TRACKS wave 3).",
     "disabled_reason": "core_cuda is staged only: all six Native AIR families are required, but only wide Fibonacci is exact and release-ready; exact family semantics, the stwo-perf CUDA report adapter, locked-host A/A calibration, pinned Rust verification, and complete structural coverage are not yet release-gated.",
     "enabled": false,
     "promotion_blocked_reason": null,
@@ -11537,6 +11543,8 @@
    },
    "metal": {
     "board": "core_metal",
+    "delisted": false,
+    "delisted_reason": null,
     "disabled_reason": null,
     "enabled": true,
     "promotion_blocked_reason": "TRACKS \u00a76 retire-and-complete: the native Metal era is banked. New promotions refuse; the board stays enabled so its history, final scores, guard workloads, and PR6-supremacy cells keep running.",
@@ -11572,6 +11580,8 @@
    },
    "native": {
     "board": "core_cpu",
+    "delisted": false,
+    "delisted_reason": null,
     "disabled_reason": null,
     "enabled": true,
     "promotion_blocked_reason": "TRACKS \u00a76 retire-and-complete: the native CPU era is banked. New promotions refuse; the board stays enabled so its history, final scores, guard workloads, and PR6-supremacy cells keep running.",
@@ -11607,6 +11617,8 @@
    },
    "pr6_supremacy": {
     "board": "pr6_supremacy",
+    "delisted": false,
+    "delisted_reason": null,
     "disabled_reason": "PR6 Supremacy remains disabled until every exact workload port, log22 oracle vector, both timing boundaries, locked-M5 statistical gate, and authenticated judged verdict are complete.",
     "enabled": false,
     "promotion_blocked_reason": null,
@@ -11690,6 +11702,8 @@
    },
    "riscv": {
     "board": "riscv",
+    "delisted": false,
+    "delisted_reason": null,
     "disabled_reason": null,
     "enabled": true,
     "promotion_blocked_reason": null,
@@ -11781,6 +11795,8 @@
    },
    "riscv_metal": {
     "board": "riscv_metal",
+    "delisted": false,
+    "delisted_reason": null,
     "disabled_reason": "riscv_metal is staged only: TRACKS \u00a72 records the RISC-V + Metal product as parity_gated, not released. Three independent things are missing and each of them alone keeps the group dark. (1) The product descriptor in build_support/products/riscv_metal.zig carries state .parity_gated behind its test-riscv-metal, metal-test, and riscv-release-gate release gates. (2) The installed riscv-metal-bench binary is the shared RISC-V bench runner (src/tools/riscv/bench/runner.zig): it prints a human-readable benchmark to stdout and emits no riscv_proof_v2 report, no retained proof artifact, and no resource telemetry, so there is nothing for the harness to parse \u2014 see this group's report_adapter block. (3) No RISC-V Metal-lane calibration exists on the designated Apple M5 Max judge host, and the generalized per-board Metal calibration TRACKS \u00a77 requires is not built yet. The RISC-V proof adapter is additionally recorded as CPU-only in vectors/riscv_elfs/crypto/provenance.json (metal_backend: gated_riscv_adapter_is_cpu_only). The group fails closed.",
     "enabled": false,
     "promotion_blocked_reason": "TRACKS \u00a77: no riscv_metal A/A dispersion or anchors exist on the designated Apple M5 Max judge host, the product is parity_gated rather than released, and no report adapter emits a scoreable row. Promotion fails closed; the gate opens only after the adapter lands and that M5 calibration is committed.",
@@ -11824,7 +11840,7 @@
   "determinism": "pure function of the named inputs; a committed feed names the commit it was generated FROM (one-commit lag by construction) \u2014 verify via inputs_sha256, not commit equality",
   "dirty_inputs": [],
   "inputs_sha256": {
-   "autoresearch/MANIFEST.json": "dc4837c10a26e82187c6857f462cb586cb7ffa13ccffb11d9bf8acc4d2073fe5",
+   "autoresearch/MANIFEST.json": "6dcd722ad54fc34407b0d8b18480feb5b847f4c28055bf53986f2b0c61785e89",
    "autoresearch/ledger/epochs.json": "788378df0d2c39c52f905b9241e120d1b2b030bbf36e4e81dbc8c7e6b8c1a2f4",
    "autoresearch/ledger/promotions.tsv": "65ebaae10a028ea4dc7267a9cc8dc68b0c5bfc713218103047cb99054d64d676",
    "autoresearch/reference/metal-calibration-epoch-2.json": "e1a733f19dfe552389e25ff71d487cb889a3117b7fd71ea47c28cbc9000147df",
@@ -11981,8 +11997,8 @@
    "vectors/reports/benchmark_history/index.json": "f8ef3c4aff34a2bedc21899c017521695d28f2fbb327b5fb2d09fb1dc5acd7b2",
    "vectors/reports/benchmark_history/runs/2026-07-23-190948-matrix-v6-467edbc9/report.json": "51cedc323c0a9fa12c17ad96ac34375013f276b2565778c6e61d8ef401837730"
   },
-  "repo_commit": "89aa6d6d57e7",
-  "repo_commit_time": "2026-07-31T11:05:53+01:00"
+  "repo_commit": "7d7e9a661cf2",
+  "repo_commit_time": "2026-07-31T12:11:43+01:00"
  },
  "references": {
   "metal_calibration_epoch_2": {


### PR DESCRIPTION
Two outcomes from the basket-quality pass:

1. **CUDA delisted, not deleted**: a first-class `delisted` flag + reason on the group, passed through the feed — the staged contract and its test architecture stay intact (deleting the group broke 21 tests that legitimately exercise it). The site hides delisted tracks; flip the flag when hardware lands.
2. **riscv_metal basket expansion reverted by its own smoke test**: every committed ELF — including the three already registered — fails `riscv-metal-bench` with `UnprovableCompletion` (the direct runner requires the halt sentinel; the corpus was built for the hosted CPU runner). The generated guest proves fine at 5.9 kHz, so the prover is healthy; the basket as registered has never proven a committed ELF and would fail at calibration. Blocker issue follows; no workloads were added to an unprovable invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)