### PR TITLE
cuda: stabilize native CuMetal qualification

### DIFF
--- a/build_support/products/catalog.zig
+++ b/build_support/products/catalog.zig
@@ -245,7 +245,12 @@ pub const configure = [_]Configure{
         .scope = .cuda_tools,
         .role = .backend_tools,
         .product_ids = &.{"stwo-native-cuda-tools"},
-        .module_roots = &.{"build_support/backends/cuda.zig"},
+        .module_roots = &.{
+            "build_support/backends/cuda.zig",
+            "src/tools/cairo_cuda_eval_aot/main.zig",
+            "src/tools/cairo_cuda_witness_aot/main.zig",
+            "src/tools/cairo_witness_cpu_codegen/model.zig",
+        },
         .dependency_module_roots = package_dependencies.frontend_cuda_metal_cpu_protocol_package_roots,
         .allowed_module_files = &.{
             "tests/cuda/cumetal/native_frontend_execution.zig",
@@ -261,8 +266,11 @@ pub const configure = [_]Configure{
         .allowed_module_prefixes = &.{
             "build_support/backends",
             "src/backends/cuda",
+            "src/tools/cairo_cuda_eval_aot",
+            "src/tools/cairo_cuda_witness_aot",
+            "src/tools/cairo_witness_cpu_codegen",
         },
-        .external_tools = &.{ "cargo", "python3" },
+        .external_tools = &.{"python3"},
         .constructors = &.{"backends/cuda_tools.addProducts"},
     },
     .{

--- a/build_support/products/riscv_cuda.zig
+++ b/build_support/products/riscv_cuda.zig
@@ -8,13 +8,11 @@ pub const descriptor = policy.Descriptor{
         .frontend = .riscv,
         .backend = .cuda,
         .role = .cli,
-        .protocol_features =
-            "rv32im-zkvm-v1+cuda-frontend-admission-v1+execution-unavailable",
+        .protocol_features = "rv32im-zkvm-v1+cuda-frontend-admission-v1+execution-unavailable",
     },
     .state = .unavailable,
     .target_support = .any,
-    .unavailable_reason =
-        "the structural RISC-V CUDA integration is present, but executable " ++
+    .unavailable_reason = "the structural RISC-V CUDA integration is present, but executable " ++
         "AOT and end-to-end proof parity evidence are incomplete",
     .build_step = "stwo-riscv-cuda",
     .test_step = null,

--- a/conformance/cuda-production-qualification-v1.md
+++ b/conformance/cuda-production-qualification-v1.md
@@ -84,6 +84,11 @@ cannot faithfully lower the PTX. The gate constructs the complete resident
 wide-Fibonacci proof, asserts zero fallback, and independently verifies it in
 Zig.
 
+The authenticated wide-Fibonacci kernel uses 32-bit size and stride arguments
+for the CUDA-to-Metal ABI. The Zig binding validates arena ownership, ranges,
+aliases, shapes, and capacities first, and rejects any geometry that cannot be
+represented as `u32`; no size or stride is truncated at launch.
+
 This tier provides early compiler-compatibility and numerical evidence. It is
 not evidence about NVIDIA occupancy, memory ordering, graph behavior,
 performance, or production readiness.

--- a/src/backends/cuda/aot/native/aot_manifest.json
+++ b/src/backends/cuda/aot/native/aot_manifest.json
@@ -79,14 +79,14 @@
   },
   {
     "abi_schema": "native_constraint_slab_v1",
-    "cache_key": "7a6ba68d80b91b07",
-    "file": "constraint_wide_fibonacci_7a6ba68d80b91b07.cu",
+    "cache_key": "77dc1ee9436bd636",
+    "file": "constraint_wide_fibonacci_77dc1ee9436bd636.cu",
     "identity_scheme": "sha256-source-and-contract-v1",
     "kernel_name": "stwo_native_constraint_wide_fibonacci_slab_v1_6f60dbf6e15716eb",
     "kind": "constraint",
     "label": "wide_fibonacci",
     "module_globals": "none",
-    "program_identity": "ef9f12d696c42b8f37120d2f876f1459872f171a6212d5b2b4f181c031267467",
+    "program_identity": "cc0e0c12a54052e0c505c304aa67e93b12facec0052d37b7b025da11be578c45",
     "semantic_contract": "stwo-zig/native/wide-fibonacci/constraint/v1;field=m31;rows=2^(log_n_rows+1);constraint[col]=trace[col]-trace[col-2]^2-trace[col-1]^2;coeff=qm31[random_coefficient_base+sequence_len-1-col];denom=denom[row>>log_n_rows];accumulate=coordinates+denom*sum(coeff*constraint)",
     "semantic_hash": "6f60dbf6e15716eb"
   },

--- a/src/backends/cuda/aot/native/constraint_wide_fibonacci_77dc1ee9436bd636.cu
+++ b/src/backends/cuda/aot/native/constraint_wide_fibonacci_77dc1ee9436bd636.cu
@@ -66,8 +66,8 @@ __device__ __forceinline__ StwoCudaQm31 stwo_qm31_mul_base(
 
 __device__ __forceinline__ StwoCudaQm31 stwo_load_qm31(
     const unsigned *values,
-    u64 index) {
-    const u64 base = index * 4ull;
+    unsigned index) {
+    const unsigned base = index * 4u;
     return StwoCudaQm31{
         values[base],
         values[base + 1u],
@@ -75,19 +75,20 @@ __device__ __forceinline__ StwoCudaQm31 stwo_load_qm31(
         values[base + 3u]};
 }
 
+// Shape admission rejects values above u32 before this authenticated ABI.
 extern "C" __global__ void __launch_bounds__(128)
 stwo_native_constraint_wide_fibonacci_slab_v1_6f60dbf6e15716eb(
     const unsigned *trace_slab,
-    u64 trace_slab_words,
-    u64 trace_column_stride_words,
+    unsigned trace_slab_words,
+    unsigned trace_column_stride_words,
     unsigned sequence_len,
     const unsigned *random_coeff_powers,
-    u64 random_coeff_words,
+    unsigned random_coeff_words,
     const unsigned *denom_inv,
-    u64 denominator_words,
+    unsigned denominator_words,
     unsigned *coordinate_slab,
-    u64 coordinate_slab_words,
-    u64 coordinate_stride_words,
+    unsigned coordinate_slab_words,
+    unsigned coordinate_stride_words,
     unsigned row_count,
     unsigned log_n_rows,
     unsigned rc_base) {
@@ -95,38 +96,36 @@ stwo_native_constraint_wide_fibonacci_slab_v1_6f60dbf6e15716eb(
     if (row_index >= row_count) return;
 
     if (sequence_len < 3u || sequence_len > 512u || log_n_rows >= 31u) return;
-    const u64 expected_rows = 1ull << (log_n_rows + 1u);
+    const unsigned expected_rows = 1u << (log_n_rows + 1u);
     if (trace_column_stride_words >
-        (~0ull - expected_rows) / (sequence_len - 1u)) {
+        (~0u - expected_rows) / (sequence_len - 1u)) {
         return;
     }
-    const u64 required_trace_words =
-        (u64)(sequence_len - 1u) * trace_column_stride_words + expected_rows;
-    const u64 required_random_words =
-        4ull * ((u64)rc_base + sequence_len - 2u);
+    const unsigned required_trace_words =
+        (sequence_len - 1u) * trace_column_stride_words + expected_rows;
+    if (rc_base > (~0u / 4u) - sequence_len + 2u) return;
+    const unsigned required_random_words =
+        4u * (rc_base + sequence_len - 2u);
     if (coordinate_stride_words >
-        (~0ull - expected_rows) / 3ull) {
+        (~0u - expected_rows) / 3u) {
         return;
     }
-    const u64 required_coordinate_words =
-        3ull * coordinate_stride_words + expected_rows;
-    if ((u64)row_count != expected_rows ||
-        trace_column_stride_words < expected_rows ||
-        required_trace_words > trace_slab_words ||
-        required_random_words > random_coeff_words ||
-        denominator_words < 2ull ||
-        coordinate_stride_words < expected_rows ||
-        required_coordinate_words > coordinate_slab_words) {
-        return;
-    }
-
+    const unsigned required_coordinate_words =
+        3u * coordinate_stride_words + expected_rows;
+    if (row_count != expected_rows) return;
+    if (trace_column_stride_words < expected_rows) return;
+    if (required_trace_words > trace_slab_words) return;
+    if (required_random_words > random_coeff_words) return;
+    if (denominator_words < 2u) return;
+    if (coordinate_stride_words < expected_rows) return;
+    if (required_coordinate_words > coordinate_slab_words) return;
     unsigned a = trace_slab[row_index];
     unsigned b = trace_slab[trace_column_stride_words + row_index];
     StwoCudaQm31 acc = StwoCudaQm31{0u, 0u, 0u, 0u};
 
     for (unsigned column = 2u; column < sequence_len; ++column) {
         const unsigned c =
-            trace_slab[(u64)column * trace_column_stride_words + row_index];
+            trace_slab[column * trace_column_stride_words + row_index];
         const unsigned expected = stwo_m31_add(
             stwo_m31_mul(a, a),
             stwo_m31_mul(b, b));
@@ -136,7 +135,7 @@ stwo_native_constraint_wide_fibonacci_slab_v1_6f60dbf6e15716eb(
             stwo_qm31_mul_base(
                 stwo_load_qm31(
                     random_coeff_powers,
-                    (u64)rc_base + sequence_len - 1u - column),
+                    rc_base + sequence_len - 1u - column),
                 constraint));
         a = b;
         b = c;
@@ -149,8 +148,8 @@ stwo_native_constraint_wide_fibonacci_slab_v1_6f60dbf6e15716eb(
         stwo_m31_add(coordinate_slab[row_index], result.a);
     coordinate_slab[coordinate_stride_words + row_index] = stwo_m31_add(
         coordinate_slab[coordinate_stride_words + row_index], result.b);
-    coordinate_slab[2ull * coordinate_stride_words + row_index] = stwo_m31_add(
-        coordinate_slab[2ull * coordinate_stride_words + row_index], result.c);
-    coordinate_slab[3ull * coordinate_stride_words + row_index] = stwo_m31_add(
-        coordinate_slab[3ull * coordinate_stride_words + row_index], result.d);
+    coordinate_slab[2u * coordinate_stride_words + row_index] = stwo_m31_add(
+        coordinate_slab[2u * coordinate_stride_words + row_index], result.c);
+    coordinate_slab[3u * coordinate_stride_words + row_index] = stwo_m31_add(
+        coordinate_slab[3u * coordinate_stride_words + row_index], result.d);
 }

--- a/src/backends/cuda/runtime/constraints/wide_fibonacci.zig
+++ b/src/backends/cuda/runtime/constraints/wide_fibonacci.zig
@@ -12,7 +12,7 @@ pub const max_sequence_len: u32 = 512;
 pub const secure_extension_degree: u32 =
     @sizeOf(field.SecureField) / @sizeOf(u32);
 pub const argument_count: u32 = 14;
-pub const cache_key: u64 = 0x7a6ba68d80b91b07;
+pub const cache_key: u64 = 0x77dc1ee9436bd636;
 pub const kernel_name =
     "stwo_native_constraint_wide_fibonacci_slab_v1_6f60dbf6e15716eb";
 
@@ -34,17 +34,19 @@ pub const PreparedLaunch = struct {
 };
 
 const Arguments = struct {
+    // The authenticated AOT ABI keeps geometry in u32. prepare() rejects any
+    // arena shape that cannot be represented without truncation.
     trace_slab: [*]u32,
-    trace_slab_words: u64,
-    trace_column_stride_words: u64,
+    trace_slab_words: u32,
+    trace_column_stride_words: u32,
     sequence_len: u32,
     random_coefficient_powers: [*]u32,
-    random_coefficient_words: u64,
+    random_coefficient_words: u32,
     denominator_inverses: [*]u32,
-    denominator_words: u64,
+    denominator_words: u32,
     coordinate_slab: [*]u32,
-    coordinate_slab_words: u64,
-    coordinate_stride_words: u64,
+    coordinate_slab_words: u32,
+    coordinate_stride_words: u32,
     row_count: u32,
     trace_log_size: u32,
     random_coefficient_base: u32,
@@ -127,13 +129,13 @@ pub fn prepare(
         .kernel = try descriptor(trace_log_size),
         .arguments = .{
             .trace_slab = trace.pointer,
-            .trace_slab_words = try u64Count(
+            .trace_slab_words = try u32Count(
                 buffers.trace_evaluations.storage.len,
             ),
-            .trace_column_stride_words = try u64Count(trace.stride_words),
+            .trace_column_stride_words = try u32Count(trace.stride_words),
             .sequence_len = sequence_len,
             .random_coefficient_powers = @ptrCast(powers.pointer),
-            .random_coefficient_words = try u64Count(
+            .random_coefficient_words = try u32Count(
                 std.math.mul(
                     usize,
                     buffers.random_coefficient_powers.len,
@@ -141,14 +143,14 @@ pub fn prepare(
                 ) catch return error.SizeOverflow,
             ),
             .denominator_inverses = denominators.pointer,
-            .denominator_words = try u64Count(
+            .denominator_words = try u32Count(
                 buffers.denominator_inverses.len,
             ),
             .coordinate_slab = coordinates.pointer,
-            .coordinate_slab_words = try u64Count(
+            .coordinate_slab_words = try u32Count(
                 buffers.composition_coordinates.storage.len,
             ),
-            .coordinate_stride_words = try u64Count(
+            .coordinate_stride_words = try u32Count(
                 coordinates.stride_words,
             ),
             .row_count = row_count,
@@ -199,8 +201,8 @@ fn evaluationRows(trace_log_size: u32) runtime_error.Error!u32 {
     return @as(u32, 1) << shift;
 }
 
-fn u64Count(value: usize) runtime_error.Error!u64 {
-    return std.math.cast(u64, value) orelse error.SizeOverflow;
+fn u32Count(value: usize) runtime_error.Error!u32 {
+    return std.math.cast(u32, value) orelse error.SizeOverflow;
 }
 
 test "wide-Fibonacci AOT descriptor covers each quotient-domain row once" {
@@ -214,6 +216,19 @@ test "wide-Fibonacci AOT descriptor covers each quotient-domain row once" {
 
 test "wide-Fibonacci AOT descriptor rejects unrepresentable domains" {
     try std.testing.expectError(error.SizeOverflow, descriptor(31));
+}
+
+test "wide-Fibonacci AOT geometry conversion fails closed above u32" {
+    try std.testing.expectEqual(
+        std.math.maxInt(u32),
+        try u32Count(std.math.maxInt(u32)),
+    );
+    if (@sizeOf(usize) > @sizeOf(u32)) {
+        try std.testing.expectError(
+            error.SizeOverflow,
+            u32Count(@as(usize, std.math.maxInt(u32)) + 1),
+        );
+    }
 }
 
 test "wide-Fibonacci slab binding validates arena ownership range and aliases" {

--- a/src/integrations/cairo_cuda/executor/terminal_controller.zig
+++ b/src/integrations/cairo_cuda/executor/terminal_controller.zig
@@ -66,7 +66,10 @@ fn measuredRead(
 }
 
 test "terminal measurement maps only observed residency counters" {
-    var verdict = std.mem.zeroes(runtime_session.Verdict);
+    var verdict = std.mem.zeroInit(
+        runtime_session.Verdict,
+        .{ .provider = .nvidia_cuda },
+    );
     verdict.counters.d2h_proof_operations = 1;
     verdict.counters.d2h_proof_bytes = 4096;
     verdict.counters.cpu_fallback_attempts = 2;


### PR DESCRIPTION
## Outcome

- replaces the Native wide-Fibonacci AOT 64-bit geometry ABI with host-admitted 32-bit size and stride arguments, avoiding CuMetal translation corruption without truncation
- preserves fail-closed arena ownership, range, alias, shape, and capacity checks
- authenticates the new source identity and documents the portability boundary
- repairs the post-merge CUDA tool source closure and Cairo terminal-controller fixture
- keeps Cairo and RISC-V CuMetal execution explicitly fail-closed as TODOs

## Local validation

- Native CuMetal proof plus independent Zig verification: PASS
- exact built Native test executable, fixed seed: 30/30 PASS
- `python3 -m unittest discover -s scripts/tests -p test_cuda_*.py`: 97 PASS
- CUDA source closure, CuMetal ledger, build plan, build-plan tests, and runtime contract: PASS
- product policy: 29 PASS
- product identity: 8 PASS
- `zig fmt --check build.zig build_support src tools`: PASS

NVIDIA admission remains pending real NVIDIA hardware evidence; this PR qualifies the Native Apple-Silicon CuMetal development path only.